### PR TITLE
Fix forced subs

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -22,6 +22,7 @@ sub init()
 
     preferredSubtitle = m.global.queueManager.callFunc("getPreferredSubtitleTrack")
     m.top.SelectedSubtitle = isChainValid(preferredSubtitle, "StreamIndex") ? preferredSubtitle.StreamIndex : -1
+    m.originalClosedCaptionState = invalid
 
     ' Load meta data
     m.LoadMetaDataTask = CreateObject("roSGNode", "LoadVideoContentTask")
@@ -510,7 +511,7 @@ sub onVideoContentLoaded()
     ' Set subtitleTrack property if subs are natively supported by Roku
     selectedSubtitle = invalid
     for each subtitle in m.top.fullSubtitleData
-        if subtitle.Index = videoContent[0].selectedSubtitle
+        if subtitle.Index = videoContent[0].selectedSubtitle or subtitle.IsForced
             selectedSubtitle = subtitle
             exit for
         end if
@@ -520,6 +521,10 @@ sub onVideoContentLoaded()
         availableSubtitleTrackIndex = availSubtitleTrackIdx(selectedSubtitle.Track.TrackName)
         if availableSubtitleTrackIndex <> -1
             if not selectedSubtitle.IsEncoded
+                if selectedSubtitle.IsForced
+                    ' If IsForced, make sure to remember the Roku global setting so we can set it back when the video is done playing.
+                    m.originalClosedCaptionState = m.top.globalCaptionMode
+                end if
                 m.top.globalCaptionMode = "On"
                 m.top.subtitleTrack = m.top.availableSubtitleTracks[availableSubtitleTrackIndex].TrackName
             end if
@@ -860,6 +865,11 @@ sub ReportPlayback(state = "update" as string)
             "LiveStreamId": m.top.transcodeParams.LiveStreamId
         })
         m.bufferCheckTimer.duration = 30
+    end if
+
+    if (state = "stop" or state = "finished") and m.originalClosedCaptionState <> invalid
+        m.top.globalCaptionMode = m.originalClosedCaptionState
+        m.originalClosedCaptionState = invalid
     end if
 
     ' Report playstate via worker task

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -865,7 +865,7 @@ sub ReportPlayback(state = "update" as string)
         m.bufferCheckTimer.duration = 30
     end if
 
-    if (state = "stop" or state = "finished") and m.originalClosedCaptionState <> invalid
+    if inArray(["stop", "finished"], state) and isValid(m.originalClosedCaptionState)
         m.top.globalCaptionMode = m.originalClosedCaptionState
         m.originalClosedCaptionState = invalid
     end if

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -21,7 +21,7 @@ sub init()
     }
 
     preferredSubtitle = m.global.queueManager.callFunc("getPreferredSubtitleTrack")
-    m.top.SelectedSubtitle = isChainValid(preferredSubtitle, "StreamIndex") ? preferredSubtitle.StreamIndex : -1
+    m.top.SelectedSubtitle = isChainValid(preferredSubtitle, "StreamIndex") ? preferredSubtitle.StreamIndex : -2
     m.originalClosedCaptionState = invalid
 
     ' Load meta data
@@ -509,7 +509,7 @@ sub onVideoContentLoaded()
     ' Set subtitleTrack property if subs are natively supported by Roku
     selectedSubtitle = invalid
     for each subtitle in m.top.fullSubtitleData
-        if subtitle.Index = videoContent[0].selectedSubtitle or subtitle.IsForced
+        if subtitle.Index = videoContent[0].selectedSubtitle
             selectedSubtitle = subtitle
             exit for
         end if


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
Fix forced subs not showing up automatically.
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
Forces subtitles on if the subtitles are "Forced". Remembers global Roku subtitle settings so they can be returned when the video is done playing.
## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Subtitles will not be returned to their original settings if the user hits "Home" from the playing video.
