### PR TITLE
Fix error with long movies when transcoding (but not Force Transcoding)

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -756,6 +756,9 @@ sub onState(msg)
         m.bufferCheckTimer.control = "start"
         m.bufferCheckTimer.ObserveField("fire", "bufferCheck")
     else if m.top.state = "error"
+        print "Error: " m.top.errorCode, m.top.errorMsg, " ErrorStr: " m.top.errorStr
+        print m.top.errorInfo
+
         if not m.playReported and m.top.transcodeAvailable
             m.top.retryWithTranscoding = true ' If playback was not reported, retry with transcoding
         else

--- a/source/static/whatsNew/1.1.5.json
+++ b/source/static/whatsNew/1.1.5.json
@@ -40,6 +40,10 @@
     "author": "1hitsong"
   },
   {
+    "description": "Fix playback when transcoding long movies",
+    "author": "jimdogx"
+  },
+  {
     "description": "Fix access to empty playlist",
     "author": "1hitsong"
   },

--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -375,6 +375,7 @@ function getTranscodingProfiles() as object
         "VideoCodec": tsVideoCodecs,
         "MaxAudioChannels": maxAudioChannels,
         "MinSegments": 1,
+        "SegmentLength": 6,
         "BreakOnNonKeyFrames": false
     }
     mp4Array = {
@@ -386,6 +387,7 @@ function getTranscodingProfiles() as object
         "VideoCodec": mp4VideoCodecs,
         "MaxAudioChannels": maxAudioChannels,
         "MinSegments": 1,
+        "SegmentLength": 6,
         "BreakOnNonKeyFrames": false
     }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
Fix error with long (> 4 hours) movies when transcoding
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
* Increase segment length to 6 seconds.
* Add debug logging for playback errors.
## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
See: https://github.com/jellyfin/jellyfin-roku/issues/2060

Note: This does not fix long movies when using Viv's built in "Force Transcoding", that is a different error:

"reader pick stream error:bad:invalid or corrupt playlist:extra:content_id:1:etype:buffer:program_id:"