### PR TITLE
Fix Profile data

### DIFF
--- a/components/data/UserData.bs
+++ b/components/data/UserData.bs
@@ -22,10 +22,12 @@ end sub
 sub saveToRegistry()
     users = parseJson(get_setting("available_users", "[]"))
     this_user = invalid
+
     for each user in users
         if user.id = m.top.id then this_user = user
     end for
-    if this_user = invalid
+
+    if not isValid(this_user)
         users.push({
             id: m.top.id,
             username: m.top.username,

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -188,6 +188,10 @@ namespace session
                 set_setting("active_user", tmpSession.user.id)
             end if
 
+            user = CreateObject("roSGNode", "UserData")
+            user.json = tmpSession
+            user.callFunc("saveToRegistry")
+
             ' Save device id so we don't calculate it every time we need it
             session.user.SetServerDeviceName()
             ' Load user preferences from server


### PR DESCRIPTION
Auto-login & remembered tokens caused the profile section of the user menu to inconsistently display the Profile data.

This PR registers the active user when they are remembered.

![Untitled](https://github.com/user-attachments/assets/b924abfd-12db-4c4f-8843-430d06386d97)
