### PR TITLE
On error, do not advance to next queue item

### DIFF
--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -263,6 +263,12 @@ end sub
 
 ' Playback state change event handlers
 sub onStateChange()
+    ' If the state changed due to an error, we don't want to continue the queue
+    if m.view.errorCode <> 0
+        m.global.queueManager.callFunc("clear")
+        return
+    end if
+
     if LCase(m.view.state) = "finished"
         if isValid(m.view.returnOnStop)
             if m.view.returnOnStop then return


### PR DESCRIPTION
If an error occurs, stop playback and prevent the system from continuing to the next item.

This way users can read the error message popup.

Fixes #170