### PR TITLE
Fix displaying all episodes if tv series is in collection

### DIFF
--- a/components/ItemGrid/GridItemSmall.bs
+++ b/components/ItemGrid/GridItemSmall.bs
@@ -45,8 +45,13 @@ sub itemContentChanged()
     end if
 
     m.itemPoster.uri = itemData.PosterUrl
-    m.posterText.text = itemData.title
-    m.title.text = itemData.title
+    if isValidAndNotEmpty(itemData.LookupCI("fullNameWithShowTitle"))
+        m.posterText.text = itemData.LookupCI("fullNameWithShowTitle")
+    else
+        m.posterText.text = itemData.title
+    end if
+
+    m.title.text = m.posterText.text
 
     'If Poster not loaded, ensure "blue box" is shown until loaded
     if m.itemPoster.loadStatus <> "ready"

--- a/components/ItemGrid/LoadItemsTask2.bs
+++ b/components/ItemGrid/LoadItemsTask2.bs
@@ -263,8 +263,17 @@ sub loadItems()
                     tmp.image = PosterImage(item.id, { "maxHeight": 450, "maxWidth": 450, "quality": "90" })
                 else if item.type = "Episode"
                     tmp = CreateObject("roSGNode", "TVEpisode")
+                    tmp.title = item.name
+
+                    seasonName = ` - ${item.LookupCI("SeasonName")}`
+
+                    if isValid(item.LookupCI("IndexNumber"))
+                        seasonName += ` Episode ${item.LookupCI("IndexNumber")}`
+                    end if
+
+                    tmp.fullNameWithShowTitle = `${item.LookupCI("seriesname")}${seasonName} - ${item.LookupCI("name")}`
+
                     if LCase(m.top.ItemType) = "nextup"
-                        tmp.title = item.name
                         tmp.type = "Episode"
                     end if
                 else if LCase(item.Type) = "recording"

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -220,12 +220,10 @@ sub loadInitialItems()
     m.loadItemsTask.studioIds = string.EMPTY
     m.loadItemsTask.view = string.EMPTY
 
-    if not inArray([ItemType.BOXSET, ItemType.PHOTO, ItemType.PHOTOALBUM], m.top.mediaType)
-        m.loadItemsTask.itemType = m.top.mediaType
-    end if
-
-    if inArray([ItemType.PHOTO, ItemType.PHOTOALBUM], m.top.mediaType)
+    if inArray([ItemType.BOXSET, ItemType.PHOTO, ItemType.PHOTOALBUM], m.top.mediaType)
         m.loadItemsTask.recursive = false
+    else
+        m.loadItemsTask.itemType = m.top.mediaType
     end if
 
     if isStringEqual(m.view, "Genres")

--- a/components/data/TVEpisode.bs
+++ b/components/data/TVEpisode.bs
@@ -6,7 +6,6 @@ sub setFields()
     json = m.top.json
 
     m.top.id = json.id
-    m.top.Title = json.name
     m.top.Description = json.overview
     m.top.favorite = json.UserData.isFavorite
     m.top.watched = chainLookup(json, "UserData.played")

--- a/components/data/TVEpisode.xml
+++ b/components/data/TVEpisode.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="TVEpisode" extends="JFContentItem">
-
+    <interface>
+        <field id="fullNameWithShowTitle" type="string" />
+    </interface>
 </component>

--- a/source/static/whatsNew/3.0.1.json
+++ b/source/static/whatsNew/3.0.1.json
@@ -2,5 +2,9 @@
   {
     "description": "Fix playlist playback starting from specific item",
     "author": "1hitsong"
+  },
+  {
+    "description": "Fix collection display when a series is added",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Disables resursive lookup for boxsets
Uses single line title for episodes in collections

## Issues
Fixes #202
