### PR TITLE
Fix recently added image. Fix go to season/series

### DIFF
--- a/components/data/HomeData.bs
+++ b/components/data/HomeData.bs
@@ -62,6 +62,11 @@ sub setData()
             m.top.widePosterUrl = ImageURL(datum.LookupCI("Id"), "Primary", imgParams)
         end if
 
+        ' If no widePosterUrl has been determined, revent to thumbnailURL
+        if not isValidAndNotEmpty(m.top.widePosterUrl)
+            m.top.widePosterUrl = m.top.thumbnailURL
+        end if
+
     else if datum.type = "Series"
         m.top.isWatched = datum.UserData.Played
 

--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -365,7 +365,7 @@ sub displayEpisodeInfo(localGlobal as object, itemData as object)
         end if
     end if
 
-    episodeimagesnextupSetting = chainLookup(localGlobal, "session.user.settings.ui.general.episodeimagesnextup")
+    episodeimagesnextupSetting = chainLookup(localGlobal, "session.user.settings.ui-general-episodeimagesnextup")
 
     ' Default to wide poster image
     m.itemPoster.uri = itemData.LookupCI("widePosterURL")

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -83,6 +83,8 @@ function loadLatestMedia() as object
                 ProductionYear: item.LookupCI("ProductionYear"),
                 Album: item.LookupCI("Album"),
                 SeriesName: item.LookupCI("SeriesName"),
+                SeriesId: item.LookupCI("SeriesId"),
+                SeasonId: item.LookupCI("SeasonId"),
                 ParentIndexNumber: item.LookupCI("ParentIndexNumber"),
                 IndexNumber: item.LookupCI("IndexNumber"),
                 IndexNumberEnd: item.LookupCI("IndexNumberEnd"),

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -354,7 +354,7 @@
                     {
                         "title": "Episode Images Next Up",
                         "description": "What type of images to use for Episodes shown in the 'Next Up' and 'Continue Watching' sections.",
-                        "settingName": "ui.general.episodeimagesnextup",
+                        "settingName": "ui-general-episodeimagesnextup",
                         "type": "radio",
                         "default": "webclient",
                         "options": [

--- a/source/static/whatsNew/3.0.1.json
+++ b/source/static/whatsNew/3.0.1.json
@@ -14,5 +14,13 @@
   {
     "description": "Fix typo in Community and Critical Ratings settings description",
     "author": "michaelcresswell"
+  },
+  {
+    "description": "Fix broken image for episodes in recently added sections",
+    "author": "1hitsong"
+  },
+  {
+    "description": "Fix crash when selecting go to series / go to season from episodes in recently added sections",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Properly gets setting "ui-general-episodeimagesnextup" value.
Populates season and series ID for recently added shows so the Go to Series and Go to Season options work.

## Issues
Fixes #218

Previously:
![WIN_20250330_15_32_16_Pro](https://github.com/user-attachments/assets/ca890dea-4faa-48fa-af9c-1335bd500ea6)

With this fix:
![WIN_20250330_15_33_54_Pro](https://github.com/user-attachments/assets/848d17a9-b0af-4ed6-9c14-8ed07371afbc)


Note: This row should be unaffected by the Episode Images Next Up setting.
![WIN_20250330_15_35_13_Pro](https://github.com/user-attachments/assets/ebe5b593-1a77-44aa-b902-8639e0f06631)



