### PR TITLE
Fix type mismatch in user policy

### DIFF
--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -38,8 +38,14 @@ sub init()
 
     m.loadStatus = ViewLoadStatus.INIT
 
-    ' Only allow Admins to see Edit Subtitles button
-    if not m.global.session.user.policy.EnableSubtitleManagement
+    hasSubtitleManagementPermissions = false
+
+    if isChainValid(m.global.session, "user.policy.EnableSubtitleManagement")
+        hasSubtitleManagementPermissions = m.global.session.user.policy.EnableSubtitleManagement
+    end if
+
+    ' Only allow those with EnableSubtitleManagement permissions to see Edit Subtitles button
+    if not hasSubtitleManagementPermissions
         editSubtitleButton = m.top.findNode("editSubtitlesButton")
         if isValid(editSubtitleButton)
             m.buttonGrp.content.removeChild(editSubtitleButton)

--- a/source/static/whatsNew/3.0.1.json
+++ b/source/static/whatsNew/3.0.1.json
@@ -14,5 +14,9 @@
   {
     "description": "Fix typo in Community and Critical Ratings settings description",
     "author": "michaelcresswell"
+  },
+  {
+    "description": "Fix type mismatch error on movie detail screen",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Fixes type mismatch error on the movie detail screen. Reported by Roku logs.
<img width="169" alt="Screenshot 2025-03-30 at 2 45 49 PM" src="https://github.com/user-attachments/assets/e2429199-879b-4956-a6bc-6566bc7567a5" />


## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
