### PR TITLE
Create setting allowing users to remember applied library filters

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -445,6 +445,13 @@
                         "description": "Settings relating to the appearance of pages in all Libraries.",
                         "children": [
                             {
+                                "title": "Forget Filters",
+                                "description": "Forget applied library filters when Jellyfin is closed.",
+                                "settingName": "itemgrid.forgetFilters",
+                                "type": "bool",
+                                "default": "true"
+                            },
+                            {
                                 "title": "Grid View Settings",
                                 "description": "Settings that apply when Grid views are enabled.",
                                 "children": [

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -229,6 +229,9 @@ sub downloadFallbackFont()
 end sub
 
 sub clearOldLibraryFilters()
+    forgetFilters = m.global.session.user.settings["itemgrid.forgetFilters"] ?? true
+    if not forgetFilters then return
+
     for each settingKeys in m.global.session.user.settings.keys()
         if isStringEqual(left(settingKeys, 8), "display.")
             if isStringEqual(right(settingKeys, 7), ".filter") or isStringEqual(right(settingKeys, 14), ".filterOptions")

--- a/source/static/whatsNew/3.0.1.json
+++ b/source/static/whatsNew/3.0.1.json
@@ -17,6 +17,10 @@
   },
   {
     "description": "Fix crash if album is missing an artist",
-    "author": "jimdogx"    
+    "author": "jimdogx"
+  },
+  {
+    "description": "Create setting allowing users to remember applied library filters on channel close",
+    "author": "jimdogx"
   }
 ]

--- a/source/static/whatsNew/3.0.1.json
+++ b/source/static/whatsNew/3.0.1.json
@@ -30,7 +30,7 @@
   {
     "description": "Fix type mismatch error on movie detail screen",
     "author": "1hitsong"
-  }
+  },
   {
     "description": "Create setting allowing users to remember applied library filters on channel close",
     "author": "1hitsong"


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
By default, applied library filters are forgotten between sessions. This new setting allows users to disable this functionality.

## Issues
Closes #217
