### PR TITLE
Fix clicking skip outro can result in video stuck in buffering state

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -939,7 +939,13 @@ function availSubtitleTrackIdx(tracknameToFind as string) as integer
 end function
 
 sub skipCurrentSegment()
-    m.top.seek = m.currentSegmentEndTicks / 10000000#
+    seekPosition = m.currentSegmentEndTicks / 10000000#
+
+    if seekPosition > m.top.duration
+        seekPosition = m.top.duration
+    end if
+
+    m.top.seek = seekPosition
 end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean

--- a/source/static/whatsNew/3.0.2.json
+++ b/source/static/whatsNew/3.0.2.json
@@ -2,5 +2,9 @@
   {
     "description": "Add unplayed episode count and refresh number in real time",
     "author": "1hitsong"
+  },
+  {
+    "description": "Fix clicking skip outro can result in video stuck in buffering state",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Ensures seek position is not past the video duration.

## Issues
Fixes #274
