### PR TITLE
Create setting to use fallback font for CJK support in labels

### DIFF
--- a/components/AudioMiniPlayer.xml
+++ b/components/AudioMiniPlayer.xml
@@ -10,7 +10,7 @@
 
       <Poster id="albumCover" width="100" height="100" translation="[100, 20]" />
 
-      <ScrollingLabel id="song" translation="[240, 20]" horizAlign="left" font="font:MediumSystemFont" maxWidth="1600" height="50" />
+      <ScrollingText id="song" translation="[240, 20]" horizAlign="left" font="font:MediumSystemFont" maxWidth="1600" height="50" />
 
       <LayoutGroup id="buttons" translation="[240, 80]" layoutDirection="horiz" horizAlignment="left" itemSpacings="[25]">
         <Poster id="previous" width="32" height="32" uri="pkg:/images/icons/itemPrevious.png" opacity=".85" />

--- a/components/JFOverhang.xml
+++ b/components/JFOverhang.xml
@@ -2,7 +2,7 @@
 <component name="JFOverhang" extends="Group">
   <children>
     <LayoutGroup id="overlayLeftGroup" layoutDirection="horiz" translation="[50, 54]" itemSpacings="60">
-      <ScrollingLabel id="overlayTitle" font="font:LargeSystemFont" vertAlign="center" height="64" maxWidth="1100" repeatCount="0" />
+      <ScrollingText id="overlayTitle" font="font:LargeSystemFont" vertAlign="center" height="64" maxWidth="1100" repeatCount="0" />
     </LayoutGroup>
 
     <LayoutGroup id="overlayRightGroup" layoutDirection="horiz" itemSpacings="15" translation="[1766, 53]" horizAlignment="right">

--- a/components/home/HomeItem.xml
+++ b/components/home/HomeItem.xml
@@ -6,11 +6,13 @@
     <Poster id="itemPoster" width="464" height="261" loadDisplayMode="scaleToZoom">
       <PlayedCheckmark id="playedIndicator" translation="[375, 0]" />
     </Poster>
+
     <Rectangle id="progressBackground" visible="false" color="0x00000098" width="464" height="8" translation="[0,253]">
       <Rectangle id="progress" width="0" height="8" />
     </Rectangle>
-    <ScrollingLabel id="itemText" horizAlign="center" vertAlign="center" font="font:SmallBoldSystemFont" height="64" maxWidth="456" translation="[8,267]" repeatCount="0" />
-    <Label id="itemTextExtra" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" height="32" width="456" translation="[8,300]" visible="false" color="#777777FF" />
+
+    <ScrollingText id="itemText" horizAlign="center" vertAlign="center" font="font:SmallBoldSystemFont" height="64" maxWidth="456" translation="[8,267]" repeatCount="0" />
+    <Text id="itemTextExtra" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" height="32" width="456" translation="[8,300]" visible="false" color="#777777FF" />
 
     <Animation id="showProgressBar" duration="0.5" repeat="false" easeFunction="linear">
       <FloatFieldInterpolator id="showProgressBarField" key="[0.0, 1.0]" fieldToInterp="progress.width" />

--- a/components/labels/ScrollingText.bs
+++ b/components/labels/ScrollingText.bs
@@ -9,6 +9,8 @@ end sub
 
 sub setFont()
     if m.global.fallbackFont = string.EMPTY then return
+    if not chainLookupReturn(m.global.session, "user.settings.cjkText", false) then return
+
     m.top.font.uri = m.global.fallbackFont
 end sub
 

--- a/components/labels/ScrollingText.bs
+++ b/components/labels/ScrollingText.bs
@@ -1,0 +1,17 @@
+import "pkg:/source/enums/String.bs"
+import "pkg:/source/utils/misc.bs"
+
+sub init()
+    setFont()
+
+    m.top.observeFieldScoped("font", "onFontChanged")
+end sub
+
+sub setFont()
+    if m.global.fallbackFont = string.EMPTY then return
+    m.top.font.uri = m.global.fallbackFont
+end sub
+
+sub onFontChanged()
+    setFont()
+end sub

--- a/components/labels/ScrollingText.xml
+++ b/components/labels/ScrollingText.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<component name="ScrollingText" extends="ScrollingLabel" />

--- a/components/labels/Text.bs
+++ b/components/labels/Text.bs
@@ -9,6 +9,8 @@ end sub
 
 sub setFont()
     if m.global.fallbackFont = string.EMPTY then return
+    if not chainLookupReturn(m.global.session, "user.settings.cjkText", false) then return
+
     m.top.font.uri = m.global.fallbackFont
 end sub
 

--- a/components/labels/Text.bs
+++ b/components/labels/Text.bs
@@ -1,0 +1,17 @@
+import "pkg:/source/enums/String.bs"
+import "pkg:/source/utils/misc.bs"
+
+sub init()
+    setFont()
+
+    m.top.observeFieldScoped("font", "onFontChanged")
+end sub
+
+sub setFont()
+    if m.global.fallbackFont = string.EMPTY then return
+    m.top.font.uri = m.global.fallbackFont
+end sub
+
+sub onFontChanged()
+    setFont()
+end sub

--- a/components/labels/Text.xml
+++ b/components/labels/Text.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<component name="Text" extends="Label">
+</component>

--- a/components/music/AudioPlayerView.xml
+++ b/components/music/AudioPlayerView.xml
@@ -30,8 +30,8 @@
     </LayoutGroup>
 
     <LayoutGroup translation="[100,100]" layoutDirection="vert" horizAlignment="left" itemSpacings="[15]">
-      <ScrollingLabel id="song" font="font:MediumBoldSystemFont" maxWidth="1800" height="50" />
-      <ScrollingLabel id="artist" maxWidth="1800" height="25" />
+      <ScrollingText id="song" font="font:MediumBoldSystemFont" maxWidth="1800" height="50" />
+      <ScrollingText id="artist" maxWidth="1800" height="25" />
       <Label id="numberofsongs" width="500" height="25" font="font:SmallestSystemFont" color="#999999" />
     </LayoutGroup>
 

--- a/components/music/PlaylistItem.xml
+++ b/components/music/PlaylistItem.xml
@@ -4,8 +4,8 @@
     <LayoutGroup layoutDirection="horiz" horizAlignment="left" itemSpacings="[25, 0]" translation="[0, 15]">
       <Poster id="mediaTypeIcon" width="32" height="32" />
       <LayoutGroup layoutDirection="vert" horizAlignment="left" itemSpacings="[0, 10]">
-        <ScrollingLabel id="title" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" maxWidth="960" />
-        <ScrollingLabel id="subtitle" horizAlign="left" vertAlign="center" font="font:SmallSystemFont" maxWidth="960" />
+        <ScrollingText id="title" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" maxWidth="960" />
+        <ScrollingText id="subtitle" horizAlign="left" vertAlign="center" font="font:SmallSystemFont" maxWidth="960" />
       </LayoutGroup>
       <Label id="tracklength" horizAlign="right" vertAlign="center" font="font:SmallBoldSystemFont" width="150" />
     </LayoutGroup>

--- a/components/music/SongItem.xml
+++ b/components/music/SongItem.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="SongItem" extends="Group">
   <children>
-    <LayoutGroup layoutDirection="horiz" horizAlignment="left" vertAlign="center" itemSpacings="[5, 0]" translation="[0, 15]">
+    <LayoutGroup layoutDirection="horiz" horizAlignment="left" itemSpacings="[5, 0]" translation="[0, 15]">
       <Text id="trackNumber" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" width="80" />
       <Text id="itemText" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" width="930" />
       <Text id="tracklength" horizAlign="right" vertAlign="center" font="font:SmallBoldSystemFont" width="150" />

--- a/components/music/SongItem.xml
+++ b/components/music/SongItem.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="SongItem" extends="Group">
   <children>
-    <LayoutGroup layoutDirection="horiz" horizAlignment="left" itemSpacings="[5, 0]" translation="[0, 15]">
-      <Label id="trackNumber" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" width="80" />
-      <Label id="itemText" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" width="930" />
-      <Label id="tracklength" horizAlign="right" vertAlign="center" font="font:SmallBoldSystemFont" width="150" />
+    <LayoutGroup layoutDirection="horiz" horizAlignment="left" vertAlign="center" itemSpacings="[5, 0]" translation="[0, 15]">
+      <Text id="trackNumber" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" width="80" />
+      <Text id="itemText" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" width="930" />
+      <Text id="tracklength" horizAlign="right" vertAlign="center" font="font:SmallBoldSystemFont" width="150" />
     </LayoutGroup>
   </children>
   <interface>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1,36 +1,50 @@
 [
     {
         "title": "Secret",
-        "description": "Settings that are not for public consumption. There's nothing to see here at the moment.",
+        "description": "Settings that are not for public consumption.",
         "visible": false,
         "children": [
             {
-                "title": "Background",
-                "description": "The base background color for all screens in Jellyfin.",
-                "settingName": "colorBackground",
-                "type": "colorgrid",
-                "default": "#000033"
+                "title": "CJK Text",
+                "description": "Use CJK fallback font for text elements across the channel",
+                "settingName": "cjkText",
+                "type": "bool",
+                "default": "false"
             },
             {
-                "title": "Watched Check Mark & Unplayed Count Background",
-                "description": "The background color of the check mark & unplayed count shown in the top right corner of items.",
-                "settingName": "colorPlayedCheckmarkBackground",
-                "type": "colorgrid",
-                "default": "#6666FF"
-            },
-            {
-                "title": "Watched Check Mark",
-                "description": "The color of the watched check mark.",
-                "settingName": "colorPlayedCheckmarkIcon",
-                "type": "colorgrid",
-                "default": "#FFFFFF"
-            },
-            {
-                "title": "Unplayed Count",
-                "description": "The text color of the unplayed count number.",
-                "settingName": "colorUnplayedCountTextColor",
-                "type": "colorgrid",
-                "default": "#FFFFFF"
+                "title": "Color Settings",
+                "description": "Change the colors of elements in the channel",
+                "visible": false,
+                "children": [
+                    {
+                        "title": "Background",
+                        "description": "The base background color for all screens in Jellyfin.",
+                        "settingName": "colorBackground",
+                        "type": "colorgrid",
+                        "default": "#000033"
+                    },
+                    {
+                        "title": "Watched Check Mark & Unplayed Count Background",
+                        "description": "The background color of the check mark & unplayed count shown in the top right corner of items.",
+                        "settingName": "colorPlayedCheckmarkBackground",
+                        "type": "colorgrid",
+                        "default": "#6666FF"
+                    },
+                    {
+                        "title": "Watched Check Mark",
+                        "description": "The color of the watched check mark.",
+                        "settingName": "colorPlayedCheckmarkIcon",
+                        "type": "colorgrid",
+                        "default": "#FFFFFF"
+                    },
+                    {
+                        "title": "Unplayed Count",
+                        "description": "The text color of the unplayed count number.",
+                        "settingName": "colorUnplayedCountTextColor",
+                        "type": "colorgrid",
+                        "default": "#FFFFFF"
+                    }
+                ]
             }
         ]
     },

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -67,6 +67,14 @@ sub Main (args as dynamic) as void
     ' This font may be used for CJK subtitles
     downloadFallbackFont()
 
+    ' Refresh overhang title font so it can change to fallback if desired
+    if isValid(overhang)
+        titleLabel = overhang.findNode("overlayTitle")
+        if isValid(titleLabel)
+            titleLabel.font = "font:LargeSystemFont"
+        end if
+    end if
+
     ' Delete any old library filters
     clearOldLibraryFilters()
 

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -37,6 +37,7 @@ sub Main (args as dynamic) as void
     m.global.addFields({ queueManager: CreateObject("roSGNode", "QueueManager") })
     m.global.addFields({ audioPlayer: CreateObject("roSGNode", "AudioPlayer") })
     m.global.addFields({ jumpTo: {} })
+    m.global.addFields({ fallbackFont: string.EMPTY })
 
     m.global.observeField("jumpTo", m.port)
 
@@ -224,6 +225,7 @@ sub downloadFallbackFont()
                 if isValidAndNotEmpty(filename)
                     filename = filename[1]
                     APIRequest("FallbackFont/Fonts/" + filename).gettofile("tmp:/font")
+                    m.global.fallbackFont = "tmp:/font"
                 end if
             end if
         end if

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -75,6 +75,13 @@ sub Main (args as dynamic) as void
         end if
     end if
 
+    if isValid(audioMiniPlayer)
+        songLabel = audioMiniPlayer.findNode("song")
+        if isValid(songLabel)
+            songLabel.font = "font:MediumSystemFont"
+        end if
+    end if
+
     ' Delete any old library filters
     clearOldLibraryFilters()
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Adds secret setting to enable using fallback font for labels for CJK support.

This PR creates the setting, new text and scrolling text elements, and implements them on the following components:

- Audio mini player
- Audio player (Title text only - not lyrics yet)
- Playlist items
- Music album list of songs
- Home items
- Overhang title

I wanted to stop here before the PR gets too large and difficult to test.

Secret setting used so we can continue adding across the channel without blocking releases.

Hat tip to @9123086 for original work done in legacy client: https://github.com/jellyfin-archive/jellyfin-roku-legacy/pull/2091

Demo video showing it in use:
https://github.com/user-attachments/assets/68fc103b-8472-410d-8c24-fd2f0bae20fc