### PR TITLE
Use default background color before user is logged in

### DIFF
--- a/components/settings/ColorGrid.xml
+++ b/components/settings/ColorGrid.xml
@@ -3,6 +3,7 @@
   <children>
     <ContentNode role="content">
       <ColorOptionData colorcode="#000000" />
+      <ColorOptionData colorcode="#000018" />
       <ColorOptionData colorcode="#222222" />
       <ColorOptionData colorcode="#333333" />
       <ColorOptionData colorcode="#444444" />

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -21,7 +21,7 @@
                         "description": "The base background color for all screens in Jellyfin.",
                         "settingName": "colorBackground",
                         "type": "colorgrid",
-                        "default": "#000033"
+                        "default": "#000018"
                     },
                     {
                         "title": "Watched Check Mark & Unplayed Count Background",

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -19,6 +19,10 @@ sub Main (args as dynamic) as void
     session.Init()
 
     m.scene = m.screen.CreateScene("BaseScene")
+
+    ' Set default background color
+    m.scene.backgroundColor = chainLookupReturn(m.global.session, "user.settings.colorBackground", ColorPalette.VIEWBACKGROUND)
+
     m.screen.show() ' vscode_rale_tracker_entry
     'vscode_rdb_on_device_component_entry
 
@@ -50,6 +54,7 @@ sub Main (args as dynamic) as void
     ' First thing to do is validate the ability to use the API
     if not LoginFlow() then return
 
+    ' Set user's chosen background color
     m.scene.backgroundColor = chainLookupReturn(m.global.session, "user.settings.colorBackground", ColorPalette.VIEWBACKGROUND)
 
     ' remove login scenes from the stack


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
If you log out, exit the channel, and reopen the channel so it opens to the user selection screen, it doesn't set the background color - because that code exists post-user login.

This change sets the channel background color to the default value before the user logs in and we use their background color.
