### PR TITLE
Fix quickplay from causing video player error on list of episodes in TV season

### DIFF
--- a/components/tvshows/TVEpisodes.bs
+++ b/components/tvshows/TVEpisodes.bs
@@ -2,6 +2,7 @@ import "pkg:/source/api/baserequest.bs"
 import "pkg:/source/api/Image.bs"
 import "pkg:/source/api/sdk.bs"
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/enums/KeyCode.bs"
 import "pkg:/source/enums/TaskControl.bs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/misc.bs"
@@ -161,12 +162,14 @@ function onKeyEvent(key as string, press as boolean) as boolean
         end if
     end if
 
-    if key = "play"
-        focusedItem = getFocusedItem()
-        if isValid(focusedItem)
-            m.top.quickPlayNode = focusedItem
+    if press
+        if isStringEqual(key, KeyCode.PLAY)
+            focusedItem = getFocusedItem()
+            if isValid(focusedItem)
+                m.top.quickPlayNode = focusedItem
+            end if
+            return true
         end if
-        return true
     end if
 
     return false

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -12,16 +12,9 @@ sub onQuickPlayEvent(msg)
     itemNode = invalid
 
     ' Prevent double fire bug
-    if isValid(reportingNode)
-        itemNode = reportingNode.quickPlayNode
-        if isValid(itemNode)
-            reportingNodeType = reportingNode.subtype()
-            if isValid(reportingNodeType)
-                if inArray(["home", "TVEpisodes", "VisualLibraryScene"], reportingNodeType)
-                    reportingNode.quickPlayNode = invalid
-                end if
-            end if
-        end if
+    if isChainValid(reportingNode, "quickPlayNode")
+        itemNode = reportingNode.quickPlayNode.clone(false)
+        reportingNode.quickPlayNode = invalid
     end if
 
     if not isValid(itemNode) then return

--- a/source/static/whatsNew/3.0.2.json
+++ b/source/static/whatsNew/3.0.2.json
@@ -28,7 +28,7 @@
     "author": "jimdogx"
   },
   {
-    "description": "Fix quickplay from causing video player error on list of episodes in TV season",
-    "author": "jimdogx"
+    "description": "Fix possible video player error when using quickplay on list of episodes in TV season screen",
+    "author": "1hitsong"
   }
 ]

--- a/source/static/whatsNew/3.0.2.json
+++ b/source/static/whatsNew/3.0.2.json
@@ -26,5 +26,9 @@
   {
     "description": "Fix default audio track not always selected correctly",
     "author": "jimdogx"
+  },
+  {
+    "description": "Fix quickplay from causing video player error on list of episodes in TV season",
+    "author": "jimdogx"
   }
 ]

--- a/source/utils/quickplay.bs
+++ b/source/utils/quickplay.bs
@@ -21,7 +21,7 @@ namespace quickplay
         if not isValid(itemNode) or not isValid(itemNode.id) or not isValid(itemNode.json) then return
 
         ' attempt to play video file. resume if possible
-        if isValid(itemNode.selectedVideoStreamId)
+        if isValidAndNotEmpty(itemNode.selectedVideoStreamId)
             itemNode.id = itemNode.selectedVideoStreamId
         end if
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Checks video id is not "" before using it in content load task
- Prevents quickplay double fire in TV episode list

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
