### PR TITLE
Honor item title showing setting in "other" library views

### DIFF
--- a/components/ItemGrid/ItemGrid.bs
+++ b/components/ItemGrid/ItemGrid.bs
@@ -120,6 +120,8 @@ sub loadInitialItems()
     m.itemGrid.numColumns = "7"
     m.itemGrid.numRows = "3"
 
+    m.top.showItemTitles = m.global.session.user.settings["itemgrid.gridTitles"]
+
     if isStringEqual(m.top.showItemTitles, "hidealways")
         m.itemGrid.itemSize = "[230, 345]"
         m.itemGrid.rowHeights = "[345]"
@@ -213,8 +215,6 @@ sub loadInitialItems()
     else if isStringEqual(getCollectionType(), "tvshows")
         m.loadItemsTask.itemType = "Series"
         m.loadItemsTask.itemId = m.top.parentItem.Id
-
-        m.top.showItemTitles = m.global.session.user.settings["itemgrid.gridTitles"]
     else if isStringEqual(getCollectionType(), "music")
         ' Default Settings
         m.loadItemsTask.recursive = true
@@ -234,17 +234,6 @@ sub loadInitialItems()
         else
             ' non recursive for collections (folders, boxsets, photo albums, etc)
             m.loadItemsTask.recursive = false
-        end if
-
-        if isStringEqual(getCollectionType(), "boxsets")
-            m.top.showItemTitles = m.global.session.user.settings["itemgrid.gridTitles"]
-            if isStringEqual(m.top.showItemTitles, "hidealways")
-                m.itemGrid.itemSize = "[230, 345]"
-                m.itemGrid.rowHeights = "[345]"
-            else
-                m.itemGrid.itemSize = "[230, 390]"
-                m.itemGrid.rowHeights = "[390]"
-            end if
         end if
 
         if isStringEqual(getCollectionType(), "nextup")

--- a/source/static/whatsNew/3.0.3.json
+++ b/source/static/whatsNew/3.0.3.json
@@ -6,5 +6,9 @@
   {
     "description": "Fix transparent backgrounds when using SVG logos",
     "author": "1hitsong"
+  },
+  {
+    "description": "Honor item title showing setting in \"other\" library views",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Applies item title showing setting to libraries not covered by audiobook, music, and visual library scenes.

## Issues
Fixes #262
