### PR TITLE
Make all instances of Highlight color be user selectable

### DIFF
--- a/components/AudioMiniPlayer.bs
+++ b/components/AudioMiniPlayer.bs
@@ -58,7 +58,7 @@ sub onButtonSelectedChange()
     ' Change selected button image to selected image
     selectedButton = m.buttons.getChild(m.selectedButtonIndex)
     if isValid(selectedButton)
-        selectedButton.blendColor = ColorPalette.HIGHLIGHT
+        selectedButton.blendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
         selectedButton.opacity = 1
     end if
 end sub

--- a/components/Buttons/JFButtons.bs
+++ b/components/Buttons/JFButtons.bs
@@ -18,7 +18,7 @@ sub init()
     m.focusAnimHeight = m.top.findNode("focusHeight")
 
     ' Set button color to global
-    m.focusRing.color = ColorPalette.HIGHLIGHT
+    m.focusRing.color = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 
     m.buttonCount = 0
     m.selectedFocusedIndex = 0
@@ -98,7 +98,7 @@ end sub
 ' Change opacity of the highlighted menu item based on focus
 sub focusChanged()
     if m.top.isInFocusChain()
-        m.focusRing.color = ColorPalette.HIGHLIGHT
+        m.focusRing.color = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
         setButtonColor(m.selectedFocusedIndex, ColorPalette.WHITE)
     else
         m.focusRing.color = ColorPalette.LIGHTBLUE

--- a/components/ItemGrid/Alpha.bs
+++ b/components/ItemGrid/Alpha.bs
@@ -1,5 +1,6 @@
 import "pkg:/source/enums/ColorPalette.bs"
 import "pkg:/source/enums/KeyCode.bs"
+import "pkg:/source/utils/misc.bs"
 
 sub init()
     m.top.setFocus(false)
@@ -7,7 +8,7 @@ sub init()
     m.alphaText = m.top.findNode("alphaText")
     m.alphaMenu = m.top.findNode("alphaMenu")
 
-    m.alphaMenu.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.alphaMenu.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.alphaMenu.focusFootprintBlendColor = ColorPalette.TRANSPARENT
 
     m.alphaMenu.setFocus(false)

--- a/components/ItemGrid/ItemGrid.bs
+++ b/components/ItemGrid/ItemGrid.bs
@@ -98,7 +98,7 @@ sub createItemGrid()
     m.itemGrid.itemSize = "[230, 345]"
     m.itemGrid.itemSpacing = "[20, 20]"
     m.itemGrid.drawFocusFeedback = "true"
-    m.itemGrid.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.itemGrid.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.top.appendChild(m.itemGrid)
     m.itemGrid.observeField("itemFocused", "onItemFocused")
     m.itemGrid.observeField("itemSelected", "onItemSelected")

--- a/components/ItemGrid/ItemGridOptions.bs
+++ b/components/ItemGrid/ItemGridOptions.bs
@@ -24,17 +24,17 @@ sub init()
     m.selectedItem = MenuType.SORT
 
     viewMenu = m.top.findNode("viewMenu")
-    viewMenu.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    viewMenu.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     viewMenu.focusFootprintBlendColor = ColorPalette.LIGHTHIGHLIGHT
     viewMenu.focusedColor = ColorPalette.WHITE
 
     sortMenu = m.top.findNode("sortMenu")
-    sortMenu.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    sortMenu.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     sortMenu.focusFootprintBlendColor = ColorPalette.LIGHTHIGHLIGHT
     sortMenu.focusedColor = ColorPalette.WHITE
 
     m.filterMenu = m.top.findNode("filterMenu")
-    m.filterMenu.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.filterMenu.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.filterMenu.focusFootprintBlendColor = ColorPalette.LIGHTHIGHLIGHT
     m.filterMenu.focusedColor = ColorPalette.WHITE
 
@@ -47,7 +47,7 @@ sub init()
     m.menus.push(m.filterMenu)
 
     m.filterOptions = m.top.findNode("filterOptions")
-    m.filterOptions.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.filterOptions.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.filterOptions.focusFootprintBlendColor = ColorPalette.LIGHTHIGHLIGHT
     m.filterOptions.focusedColor = ColorPalette.WHITE
 

--- a/components/ItemGrid/LibraryFilterDialog.bs
+++ b/components/ItemGrid/LibraryFilterDialog.bs
@@ -11,7 +11,7 @@ sub init()
     m.submitButton = m.top.findNode("submitButton")
     m.submitButton.background = ColorPalette.LIGHTBLUE
     m.submitButton.color = ColorPalette.DARKGREY
-    m.submitButton.focusBackground = ColorPalette.HIGHLIGHT
+    m.submitButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.submitButton.focusColor = ColorPalette.WHITE
 
     overlay = m.top.findNode("overlay")
@@ -27,7 +27,7 @@ sub init()
     headerBorder.color = ColorPalette.LIGHTBLUE
 
     m.filterMenu = m.top.findNode("filterMenu")
-    m.filterMenu.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.filterMenu.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.filterMenu.focusFootprintBlendColor = ColorPalette.LIGHTHIGHLIGHT
     m.filterMenu.focusedColor = ColorPalette.WHITE
 
@@ -35,7 +35,7 @@ sub init()
     filterOptionsBackdrop.color = ColorPalette.LIGHTGREY
 
     m.filterOptionsMenu = m.top.findNode("filterOptionsMenu")
-    m.filterOptionsMenu.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.filterOptionsMenu.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.filterOptionsMenu.focusFootprintBlendColor = ColorPalette.LIGHTHIGHLIGHT
     m.filterOptionsMenu.focusedColor = ColorPalette.WHITE
 

--- a/components/JFMessageDialog.bs
+++ b/components/JFMessageDialog.bs
@@ -1,8 +1,9 @@
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/utils/misc.bs"
 
 sub init()
     options = m.top.findNode("optionList")
-    options.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    options.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     options.color = "0xffffff"
     options.focusedColor = "0xffffff"
     options.setFocus(true)

--- a/components/JFOverhang.bs
+++ b/components/JFOverhang.bs
@@ -20,7 +20,7 @@ sub init()
 
     m.overlayCurrentUserSelection = m.top.findNode("overlayCurrentUserSelection")
     if isValid(m.overlayCurrentUserSelection)
-        m.overlayCurrentUserSelection.blendColor = ColorPalette.HIGHLIGHT
+        m.overlayCurrentUserSelection.blendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     end if
 
 end sub

--- a/components/Libraries/AudioBookLibraryView.bs
+++ b/components/Libraries/AudioBookLibraryView.bs
@@ -19,7 +19,7 @@ sub init()
     m.newBackdrop = m.top.findNode("backdropTransition")
     m.emptyText = m.top.findNode("emptyText")
 
-    m.itemGrid.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.itemGrid.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 
     m.genreList = m.top.findNode("genrelist")
     m.genreList.observeField("itemSelected", "onGenreItemSelected")

--- a/components/Libraries/MusicLibraryView.bs
+++ b/components/Libraries/MusicLibraryView.bs
@@ -32,39 +32,39 @@ sub setupNodes()
     m.searchButton.textColor = ColorPalette.DARKGREY
     m.searchButton.focusTextColor = ColorPalette.WHITE
     m.searchButton.background = ColorPalette.WHITE
-    m.searchButton.focusBackground = ColorPalette.HIGHLIGHT
+    m.searchButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 
     m.sortButton = m.top.findNode("sortButton")
     m.sortButton.textColor = ColorPalette.DARKGREY
     m.sortButton.focusTextColor = ColorPalette.WHITE
     m.sortButton.background = ColorPalette.WHITE
-    m.sortButton.focusBackground = ColorPalette.HIGHLIGHT
+    m.sortButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 
     m.sortOrderButton = m.top.findNode("sortOrderButton")
     m.sortOrderButton.textColor = ColorPalette.DARKGREY
     m.sortOrderButton.focusTextColor = ColorPalette.WHITE
     m.sortOrderButton.background = ColorPalette.WHITE
-    m.sortOrderButton.focusBackground = ColorPalette.HIGHLIGHT
+    m.sortOrderButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 
     m.filterButton = m.top.findNode("filterButton")
     m.filterButton.textColor = ColorPalette.DARKGREY
     m.filterButton.focusTextColor = ColorPalette.WHITE
     m.filterButton.background = ColorPalette.WHITE
-    m.filterButton.focusBackground = ColorPalette.HIGHLIGHT
+    m.filterButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 
     m.viewButton = m.top.findNode("viewButton")
     m.viewButton.textColor = ColorPalette.DARKGREY
     m.viewButton.focusTextColor = ColorPalette.WHITE
     m.viewButton.background = ColorPalette.WHITE
-    m.viewButton.focusBackground = ColorPalette.HIGHLIGHT
+    m.viewButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 end sub
 
 sub init()
     setupNodes()
     m.bypassSearchEvent = false
 
-    m.itemGrid.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
-    m.genrelist.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.itemGrid.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+    m.genrelist.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.top.findNode("VoiceBoxCover").color = chainLookupReturn(m.global.session, "user.settings.colorBackground", ColorPalette.VIEWBACKGROUND)
 
     m.overhang.isVisible = false

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -39,31 +39,31 @@ sub setupNodes()
     m.searchButton.textColor = ColorPalette.DARKGREY
     m.searchButton.focusTextColor = ColorPalette.WHITE
     m.searchButton.background = ColorPalette.WHITE
-    m.searchButton.focusBackground = ColorPalette.HIGHLIGHT
+    m.searchButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 
     m.sortButton = m.top.findNode("sortButton")
     m.sortButton.textColor = ColorPalette.DARKGREY
     m.sortButton.focusTextColor = ColorPalette.WHITE
     m.sortButton.background = ColorPalette.WHITE
-    m.sortButton.focusBackground = ColorPalette.HIGHLIGHT
+    m.sortButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 
     m.sortOrderButton = m.top.findNode("sortOrderButton")
     m.sortOrderButton.textColor = ColorPalette.DARKGREY
     m.sortOrderButton.focusTextColor = ColorPalette.WHITE
     m.sortOrderButton.background = ColorPalette.WHITE
-    m.sortOrderButton.focusBackground = ColorPalette.HIGHLIGHT
+    m.sortOrderButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 
     m.filterButton = m.top.findNode("filterButton")
     m.filterButton.textColor = ColorPalette.DARKGREY
     m.filterButton.focusTextColor = ColorPalette.WHITE
     m.filterButton.background = ColorPalette.WHITE
-    m.filterButton.focusBackground = ColorPalette.HIGHLIGHT
+    m.filterButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 
     m.viewButton = m.top.findNode("viewButton")
     m.viewButton.textColor = ColorPalette.DARKGREY
     m.viewButton.focusTextColor = ColorPalette.WHITE
     m.viewButton.background = ColorPalette.WHITE
-    m.viewButton.focusBackground = ColorPalette.HIGHLIGHT
+    m.viewButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 end sub
 
 sub init()
@@ -71,8 +71,8 @@ sub init()
     setupNodes()
     m.bypassSearchEvent = false
 
-    m.itemGrid.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
-    m.genreList.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.itemGrid.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+    m.genreList.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.top.findNode("VoiceBoxCover").color = chainLookupReturn(m.global.session, "user.settings.colorBackground", ColorPalette.VIEWBACKGROUND)
 
     m.overhang.isVisible = false

--- a/components/MovieDetailButton.bs
+++ b/components/MovieDetailButton.bs
@@ -1,4 +1,5 @@
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/utils/misc.bs"
 
 sub init()
     m.buttonBackground = m.top.findNode("buttonBackground")
@@ -20,7 +21,7 @@ sub itemContentChanged()
 
     m.focusTextColor = ColorPalette.WHITE
     m.textColor = ColorPalette.WHITE
-    m.focusBackground = ColorPalette.HIGHLIGHT
+    m.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.focusIcon = itemData.focusIcon
     m.icon = itemData.icon
     m.background = ColorPalette.TRANSPARENT

--- a/components/WhatsNewDialog.bs
+++ b/components/WhatsNewDialog.bs
@@ -25,7 +25,7 @@ sub init()
         "author": {
             "fontSize": 27,
             "fontUri": "font:SystemFontFile",
-            "color": chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+            "color": chainLookupReturn(m.global.session, "user.settings.colorWhatsNewAuthor", ColorPalette.HIGHLIGHT)
         }
     }
 

--- a/components/WhatsNewDialog.bs
+++ b/components/WhatsNewDialog.bs
@@ -1,4 +1,5 @@
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/utils/misc.bs"
 
 sub init()
     m.content = m.top.findNode("content")
@@ -24,7 +25,7 @@ sub init()
         "author": {
             "fontSize": 27,
             "fontUri": "font:SystemFontFile",
-            "color": ColorPalette.HIGHLIGHT
+            "color": chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
         }
     }
 
@@ -44,7 +45,7 @@ sub setPalette()
         DialogFocusColor: "0xcececeFF",
         DialogFocusItemColor: "0x202020FF",
         DialogSecondaryTextColor: "0xf8f8f8ff",
-        DialogSecondaryItemColor: ColorPalette.HIGHLIGHT,
+        DialogSecondaryItemColor: chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT),
         DialogTextColor: "0xeeeeeeFF"
     }
 

--- a/components/data/SceneManager.bs
+++ b/components/data/SceneManager.bs
@@ -283,7 +283,7 @@ sub standardDialog(title, message)
     dlgPalette = createObject("roSGNode", "RSGPalette")
     dlgPalette.colors = {
         DialogBackgroundColor: ColorPalette.ELEMENTBACKGROUND,
-        DialogFocusColor: ColorPalette.HIGHLIGHT,
+        DialogFocusColor: chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT),
         DialogFocusItemColor: ColorPalette.WHITE,
         DialogSecondaryTextColor: ColorPalette.WHITE,
         DialogSecondaryItemColor: ColorPalette.LIGHTBLUE,
@@ -316,7 +316,7 @@ sub radioDialog(title, message)
     dlgPalette = createObject("roSGNode", "RSGPalette")
     dlgPalette.colors = {
         DialogBackgroundColor: ColorPalette.ELEMENTBACKGROUND,
-        DialogFocusColor: ColorPalette.HIGHLIGHT,
+        DialogFocusColor: chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT),
         DialogFocusItemColor: ColorPalette.WHITE,
         DialogSecondaryTextColor: ColorPalette.WHITE,
         DialogSecondaryItemColor: ColorPalette.LIGHTBLUE,
@@ -344,7 +344,7 @@ sub remoteSubtitleDialog(title, message)
     dlgPalette = createObject("roSGNode", "RSGPalette")
     dlgPalette.colors = {
         DialogBackgroundColor: ColorPalette.ELEMENTBACKGROUND,
-        DialogFocusColor: ColorPalette.HIGHLIGHT,
+        DialogFocusColor: chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT),
         DialogFocusItemColor: ColorPalette.WHITE,
         DialogSecondaryTextColor: ColorPalette.WHITE,
         DialogSecondaryItemColor: ColorPalette.LIGHTBLUE,
@@ -371,7 +371,7 @@ sub keyboardDialog(id, title, message, buttons, hintText, itemID)
     dlgPalette = createObject("roSGNode", "RSGPalette")
     dlgPalette.colors = {
         DialogBackgroundColor: ColorPalette.ELEMENTBACKGROUND,
-        DialogFocusColor: ColorPalette.HIGHLIGHT,
+        DialogFocusColor: chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT),
         DialogFocusItemColor: ColorPalette.WHITE,
         DialogSecondaryTextColor: ColorPalette.WHITE,
         DialogSecondaryItemColor: ColorPalette.LIGHTBLUE,
@@ -411,7 +411,7 @@ sub optionDialog(id, title, message, buttons, params)
     dlgPalette = createObject("roSGNode", "RSGPalette")
     dlgPalette.colors = {
         DialogBackgroundColor: ColorPalette.ELEMENTBACKGROUND,
-        DialogFocusColor: ColorPalette.HIGHLIGHT,
+        DialogFocusColor: chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT),
         DialogFocusItemColor: ColorPalette.WHITE,
         DialogSecondaryTextColor: ColorPalette.WHITE,
         DialogSecondaryItemColor: ColorPalette.LIGHTBLUE,

--- a/components/extras/ExtrasRowList.bs
+++ b/components/extras/ExtrasRowList.bs
@@ -8,7 +8,7 @@ import "pkg:/source/utils/misc.bs"
 sub init()
     m.top.visible = true
 
-    m.top.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.top.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 
     updateSize()
     m.top.observeField("rowItemSelected", "onRowItemSelected")

--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -19,21 +19,16 @@ sub init()
     m.loadItemsTask1.itemsToLoad = "isInMyList"
 
     m.homeRows = m.top.findNode("homeRows")
-    animationInterpolator = m.top.findNode("fadeInFocusBitmapInterpolator")
-    animationInterpolator.keyValue = `[${ColorPalette.TRANSPARENT}, ${ColorPalette.HIGHLIGHT}]`
-
-    m.fadeInFocusBitmap = m.top.findNode("fadeInFocusBitmap")
+    m.homeRows.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 end sub
 
 sub refresh()
-    m.homeRows.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.homeRows.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.homeRows.callFunc("updateHomeRows")
 end sub
 
 sub loadLibraries()
-    m.homeRows.focusBitmapBlendColor = ColorPalette.TRANSPARENT
     m.homeRows.callFunc("loadLibraries")
-    m.fadeInFocusBitmap.control = "start"
 end sub
 
 ' JFScreen hook called when the screen is displayed by the screen manager

--- a/components/home/Home.xml
+++ b/components/home/Home.xml
@@ -11,10 +11,6 @@
       numRows="2"
       rowLabelOffset="[[0,20]]" />
     <OptionsSlider id="options" />
-
-    <Animation id="fadeInFocusBitmap" delay="1" duration=".2" repeat="false" easeFunction="inQuad">
-      <ColorFieldInterpolator id="fadeInFocusBitmapInterpolator" key="[0.0, 1.0]" fieldToInterp="homeRows.focusBitmapBlendColor" />
-    </Animation>
   </children>
   <interface>
     <field id="playlistData" type="array" />

--- a/components/liveTv/LiveTVLibraryView.bs
+++ b/components/liveTv/LiveTVLibraryView.bs
@@ -30,7 +30,7 @@ sub init()
     m.data = CreateObject("roSGNode", "ContentNode")
 
     m.itemGrid = m.top.findNode("itemGrid")
-    m.itemGrid.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.itemGrid.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.itemGrid.observeField("itemFocused", "onItemFocused")
     m.itemGrid.observeField("itemSelected", "onItemSelected")
     m.itemGrid.content = m.data

--- a/components/liveTv/ProgramDetails.bs
+++ b/components/liveTv/ProgramDetails.bs
@@ -299,7 +299,7 @@ sub focusChanged()
         m.viewChannelOutline.visible = true
         m.recordOutline.visible = false
         m.recordSeriesOutline.visible = false
-        m.viewChannelButtonBackground.blendColor = ColorPalette.HIGHLIGHT
+        m.viewChannelButtonBackground.blendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
         m.recordButtonBackground.blendColor = "#000000"
         m.recordSeriesButtonBackground.blendColor = "#000000"
     else
@@ -343,7 +343,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             m.viewChannelOutline.visible = false
             m.recordOutline.visible = true
             m.viewChannelButtonBackground.blendColor = "#000000"
-            m.recordButtonBackground.blendColor = ColorPalette.HIGHLIGHT
+            m.recordButtonBackground.blendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
             m.recordSeriesButtonBackground.blendColor = "#000000"
             return true
         else if key = "right" and m.recordButton.hasFocus()
@@ -354,7 +354,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             m.recordSeriesOutline.visible = true
             m.viewChannelButtonBackground.blendColor = "#000000"
             m.recordButtonBackground.blendColor = "#000000"
-            m.recordSeriesButtonBackground.blendColor = ColorPalette.HIGHLIGHT
+            m.recordSeriesButtonBackground.blendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
             return true
         else if key = "left" and m.recordSeriesButton.hasFocus()
             m.recordButton.setFocus(true)
@@ -363,7 +363,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             m.recordOutline.visible = true
             m.recordSeriesOutline.visible = false
             m.viewChannelButtonBackground.blendColor = "#000000"
-            m.recordButtonBackground.blendColor = ColorPalette.HIGHLIGHT
+            m.recordButtonBackground.blendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
             m.recordSeriesButtonBackground.blendColor = "#000000"
             return true
         else if key = "left" and m.recordButton.hasFocus()
@@ -372,7 +372,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             group.lastFocus = m.viewChannelButton
             m.viewChannelOutline.visible = true
             m.recordOutline.visible = false
-            m.viewChannelButtonBackground.blendColor = ColorPalette.HIGHLIGHT
+            m.viewChannelButtonBackground.blendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
             m.recordButtonBackground.blendColor = "#000000"
             m.recordSeriesButtonBackground.blendColor = "#000000"
             return true

--- a/components/liveTv/schedule.bs
+++ b/components/liveTv/schedule.bs
@@ -29,7 +29,7 @@ sub init()
     m.scheduleGrid.observeField("leftEdgeTargetTime", "onGridScrolled")
     m.scheduleGrid.channelInfoWidth = 350
 
-    m.scheduleGrid.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.scheduleGrid.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.scheduleGrid.programTitleFocusedColor = ColorPalette.WHITE
     m.scheduleGrid.timeLabelColor = ColorPalette.LIGHTGREY
     m.scheduleGrid.timeLabelFont.size = 30

--- a/components/login/UserRow.bs
+++ b/components/login/UserRow.bs
@@ -1,7 +1,8 @@
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/utils/misc.bs"
 
 sub init()
-    m.top.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.top.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.top.itemComponentName = "UserItem"
     m.top.content = SetData()
     m.top.observeField("itemSelected", "SetUser")

--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -100,7 +100,7 @@ end sub
 
 sub setButtonColors()
     m.buttonGrp.focusBitmapUri = "pkg:/images/white.9.png"
-    m.buttonGrp.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.buttonGrp.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 end sub
 
 ' OnScreenShown: Callback function when view is presented on screen

--- a/components/movies/MovieOptions.bs
+++ b/components/movies/MovieOptions.bs
@@ -17,7 +17,7 @@ sub init()
     m.selectedSubtitleIndex = -1
 
     m.optionMenu = m.top.findNode("optionMenu")
-    m.optionMenu.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.optionMenu.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.optionMenu.focusedColor = ColorPalette.WHITE
 
     m.menus = [m.top.findNode("subtitleMenu"), m.top.findNode("audioMenu"), m.top.findNode("videoMenu"), m.optionMenu]
@@ -25,13 +25,13 @@ sub init()
     m.videoNames = []
     m.audioNames = []
 
-    m.top.findNode("videoMenu").focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.top.findNode("videoMenu").focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.top.findNode("videoMenu").focusedColor = ColorPalette.WHITE
 
-    m.top.findNode("audioMenu").focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.top.findNode("audioMenu").focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.top.findNode("audioMenu").focusedColor = ColorPalette.WHITE
 
-    m.top.findNode("subtitleMenu").focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.top.findNode("subtitleMenu").focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.top.findNode("subtitleMenu").focusedColor = ColorPalette.WHITE
 
     ' Animation

--- a/components/music/AlbumView.bs
+++ b/components/music/AlbumView.bs
@@ -11,7 +11,7 @@ sub init()
     m.instantMix = m.top.findNode("instantMix")
     m.instantMix.background = ColorPalette.LIGHTBLUE
     m.instantMix.color = ColorPalette.DARKGREY
-    m.instantMix.focusBackground = ColorPalette.HIGHLIGHT
+    m.instantMix.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.instantMix.focusColor = ColorPalette.WHITE
 
     m.albumCover = m.top.findNode("albumCover")
@@ -21,7 +21,7 @@ sub init()
     m.top.lastFocus = m.songList
 
     m.songList.focusFootprintBitmapUri = string.EMPTY
-    m.songList.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.songList.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.songList.focusFootprintBlendColor = ColorPalette.LIGHTHIGHLIGHT
 
     m.songListRect.color = ColorPalette.ELEMENTBACKGROUND
@@ -152,7 +152,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
         if m.songList.hasFocus()
             if m.dscr.isTextEllipsized
                 m.dscr.setFocus(true)
-                m.dscr.color = ColorPalette.HIGHLIGHT
+                m.dscr.color = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
                 return true
             end if
         end if

--- a/components/music/ArtistView.bs
+++ b/components/music/ArtistView.bs
@@ -17,7 +17,7 @@ sub init()
     m.appearsOnHeader.text = tr("AppearsOn")
 
     m.similarArtist = m.top.findNode("similarArtist")
-    m.similarArtist.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.similarArtist.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.similarArtist.observeField("escape", "onSimilarArtistEscape")
 
     m.LoadSimilarArtistTask = CreateObject("roSGNode", "LoadItemsTask")
@@ -25,12 +25,12 @@ sub init()
     m.LoadSimilarArtistTask.observeField("content", "onSimilarArtistLoaded")
 
     m.appearsOn = m.top.findNode("appearsOn")
-    m.appearsOn.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.appearsOn.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.appearsOn.observeField("escape", "onAppearsOnEscape")
     m.appearsOn.observeField("MusicArtistAlbumData", "onAppearsOnData")
 
     m.albums = m.top.findNode("albums")
-    m.albums.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.albums.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.albums.observeField("escape", "onAlbumsEscape")
     m.albums.observeField("MusicArtistAlbumData", "onAlbumsData")
 
@@ -161,7 +161,7 @@ sub setupButtons()
     m.buttonCount = m.buttonGrp.getChildCount()
 
     m.playButton = m.top.findNode("play")
-    m.playButton.focusBackground = ColorPalette.HIGHLIGHT
+    m.playButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.previouslySelectedButtonIndex = -1
 
     buttons = ["instantMix", "albumsLink", "appearsOnLink", "similarArtistLink", "detailsLink"]
@@ -169,7 +169,7 @@ sub setupButtons()
     for each button in buttons
         thisButton = m.top.findNode(button)
         if isValid(thisButton)
-            thisButton.focusBackground = ColorPalette.HIGHLIGHT
+            thisButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
         end if
     end for
 

--- a/components/music/AudioPlayerView.bs
+++ b/components/music/AudioPlayerView.bs
@@ -169,7 +169,7 @@ sub onButtonSelectedChange()
 
     ' Change selected button image to selected image
     selectedButton = m.buttons.getChild(m.top.selectedButtonIndex)
-    selectedButton.blendColor = ColorPalette.HIGHLIGHT
+    selectedButton.blendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 end sub
 
 sub setupInfoNodes()
@@ -648,7 +648,7 @@ end sub
 ' @param {string} newState - state to replace {oldState} with in icon url
 sub setSelectedButtonState(newState as string)
     selectedButton = m.buttons.getChild(m.top.selectedButtonIndex)
-    selectedButton.blendColor = newState = ButtonState.SELECTED ? ColorPalette.HIGHLIGHT : ColorPalette.WHITE
+    selectedButton.blendColor = newState = ButtonState.SELECTED ? chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT) : ColorPalette.WHITE
 end sub
 
 ' processScrubAction: Handles +/- seeking for the audio trickplay bar
@@ -819,7 +819,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 m.song.color = ColorPalette.WHITE
 
                 m.artist.setFocus(true)
-                m.artist.color = ColorPalette.HIGHLIGHT
+                m.artist.color = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
                 return true
             end if
 
@@ -880,7 +880,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 m.artist.color = ColorPalette.WHITE
 
                 m.song.setFocus(true)
-                m.song.color = ColorPalette.HIGHLIGHT
+                m.song.color = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
                 return true
             end if
 
@@ -938,7 +938,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             end if
 
             if key = KeyCode.UP
-                m.artist.color = ColorPalette.HIGHLIGHT
+                m.artist.color = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
                 if m.thumb.visible
                     exitScrubMode(m.artist)
                 end if

--- a/components/music/PlaylistView.bs
+++ b/components/music/PlaylistView.bs
@@ -13,7 +13,7 @@ sub init()
     m.songListRect = m.top.FindNode("songListRect")
     m.songListRect.color = ColorPalette.ELEMENTBACKGROUND
 
-    m.playlist.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.playlist.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 
     m.playlist.observeField("doneLoading", "onDoneLoading")
 

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -92,9 +92,26 @@ sub onColorSelected()
     selectedSetting = m.userLocation.peek().children[m.settingsMenu.itemFocused]
     set_user_setting(selectedSetting.settingName, selectedColor ?? ColorPalette.VIEWBACKGROUND)
 
+    ' Apply settings to items already loaded so user doesn't need to close the channel to see the changes
+
+    ' Apply global background color
     if isStringEqual(selectedSetting.settingName, "colorBackground")
         scene = m.top.getScene()
         scene.backgroundColor = selectedColor ?? ColorPalette.VIEWBACKGROUND
+    end if
+
+    ' Apply cursor color
+    if isStringEqual(selectedSetting.settingName, "colorCursor")
+        ' Update cursor around user avatar
+        scene = m.top.getScene()
+        overhang = scene.findNode("overhang")
+        if isValid(overhang)
+            overlayCurrentUserSelection = overhang.findNode("overlayCurrentUserSelection")
+            overlayCurrentUserSelection.blendColor = selectedColor ?? ColorPalette.HIGHLIGHT
+        end if
+
+        ' Update setting menu colors
+        m.settingsMenu.focusBitmapBlendColor = selectedColor ?? ColorPalette.HIGHLIGHT
     end if
 end sub
 

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -15,7 +15,7 @@ sub init()
     m.userLocation = []
 
     m.settingsMenu = m.top.findNode("settingsMenu")
-    m.settingsMenu.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.settingsMenu.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.settingsMenu.focusFootprintBlendColor = ColorPalette.TRANSPARENT
     m.settingsMenu.focusedColor = ColorPalette.WHITE
 
@@ -35,7 +35,7 @@ sub init()
         "b": {
             "fontSize": 27,
             "fontUri": "font:SystemFontFile",
-            "color": ColorPalette.HIGHLIGHT
+            "color": chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
         }
     }
 
@@ -49,7 +49,7 @@ sub init()
     m.colorgrid = m.top.findNode("colorgrid")
 
     m.radioSetting = m.top.findNode("radioSetting")
-    m.radioSetting.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.radioSetting.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.radioSetting.focusFootprintBlendColor = ColorPalette.TRANSPARENT
     m.radioSetting.focusedColor = ColorPalette.WHITE
 

--- a/components/subtitle/SubtitleSearchView.bs
+++ b/components/subtitle/SubtitleSearchView.bs
@@ -15,14 +15,14 @@ sub init()
     m.languageButton.textColor = ColorPalette.DARKGREY
     m.languageButton.focusTextColor = ColorPalette.WHITE
     m.languageButton.background = ColorPalette.WHITE
-    m.languageButton.focusBackground = ColorPalette.HIGHLIGHT
+    m.languageButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 
     m.searchButton.background = ColorPalette.LIGHTBLUE
     m.searchButton.color = ColorPalette.DARKGREY
-    m.searchButton.focusBackground = ColorPalette.HIGHLIGHT
+    m.searchButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.searchButton.focusColor = ColorPalette.WHITE
 
-    m.mySubtitleList.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.mySubtitleList.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.mySubtitleList.focusFootprintBlendColor = ColorPalette.WHITE
 
     headerText = m.top.findNode("headerText")

--- a/components/tvshows/TVEpisodes.bs
+++ b/components/tvshows/TVEpisodes.bs
@@ -14,7 +14,7 @@ sub init()
     m.poster = m.top.findNode("seasonPoster")
     m.shuffle = m.top.findNode("shuffle")
     m.extras = m.top.findNode("extras")
-    m.rows.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.rows.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 
     m.playedIndicator = m.top.findNode("playedIndicator")
 

--- a/components/tvshows/TVListOptions.bs
+++ b/components/tvshows/TVListOptions.bs
@@ -19,10 +19,10 @@ sub init()
     m.videoNames = []
     m.audioNames = []
 
-    m.top.findNode("videoMenu").focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.top.findNode("videoMenu").focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.top.findNode("videoMenu").focusedColor = ColorPalette.WHITE
 
-    m.top.findNode("audioMenu").focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.top.findNode("audioMenu").focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.top.findNode("audioMenu").focusedColor = ColorPalette.WHITE
 
     ' Animation

--- a/components/tvshows/TVSeasonRow.bs
+++ b/components/tvshows/TVSeasonRow.bs
@@ -1,11 +1,12 @@
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/utils/misc.bs"
 
 sub init()
     m.top.itemComponentName = "ListPoster"
     m.top.content = getData()
 
     m.top.rowFocusAnimationStyle = "fixedFocusWrap"
-    m.top.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.top.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 
     m.top.showRowLabel = [false]
     m.top.showRowCounter = [true]

--- a/components/video/OSD.bs
+++ b/components/video/OSD.bs
@@ -1,5 +1,5 @@
-import "pkg:/source/utils/misc.bs"
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/utils/misc.bs"
 
 const LOGO_RIGHT_PADDING = 30
 const OPTIONCONTROLS_TOP_PADDING = 50
@@ -51,13 +51,13 @@ sub init()
     optionButtons = m.optionControls.getChildren(-1, 0)
     for each button in optionButtons
         button.background = ColorPalette.DARKGREY
-        button.focusBackground = ColorPalette.HIGHLIGHT
+        button.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     end for
 
     videoButtons = m.videoControls.getChildren(-1, 0)
     for each button in videoButtons
         button.background = ColorPalette.DARKGREY
-        button.focusBackground = ColorPalette.HIGHLIGHT
+        button.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     end for
 end sub
 

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -45,7 +45,7 @@ sub init()
 
     m.chapterList = m.top.findNode("chapterList")
     m.chapterMenu = m.top.findNode("chapterMenu")
-    m.chapterMenu.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
+    m.chapterMenu.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.chapterMenu.color = ColorPalette.WHITE
     m.chapterMenu.focusedColor = ColorPalette.WHITE
     m.chapterContent = m.top.findNode("chapterContent")
@@ -78,7 +78,7 @@ sub init()
     m.skipSegmentButton = m.top.findNode("skipSegment")
     m.skipSegmentButton.background = ColorPalette.LIGHTBLUE
     m.skipSegmentButton.color = ColorPalette.DARKGREY
-    m.skipSegmentButton.focusBackground = ColorPalette.HIGHLIGHT
+    m.skipSegmentButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.skipSegmentButton.focusColor = ColorPalette.WHITE
 
     'Play Next Episode button

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -62,6 +62,13 @@
                         "default": "#777777FF"
                     },
                     {
+                        "title": "Cursor Color",
+                        "description": "The highlight color for the cursor showing where the user's focus is.",
+                        "settingName": "colorCursor",
+                        "type": "colorgrid",
+                        "default": "#FF6666"
+                    },
+                    {
                         "title": "Watched Check Mark & Unplayed Count",
                         "description": "Watched Check Mark & Unplayed Count color settings",
                         "children": [

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -48,23 +48,30 @@
                         "default": "#000018"
                     },
                     {
-                        "title": "Primary Text Color",
+                        "title": "Primary Text",
                         "description": "The primary text color for all screens in Jellyfin.",
                         "settingName": "colorText",
                         "type": "colorgrid",
                         "default": "#FFFFFF"
                     },
                     {
-                        "title": "Secondary Text Color",
+                        "title": "Secondary Text",
                         "description": "The secondary text color for all screens in Jellyfin.",
                         "settingName": "colorSubText",
                         "type": "colorgrid",
                         "default": "#777777FF"
                     },
                     {
-                        "title": "Cursor Color",
+                        "title": "Cursor",
                         "description": "The highlight color for the cursor showing where the user's focus is.",
                         "settingName": "colorCursor",
+                        "type": "colorgrid",
+                        "default": "#FF6666"
+                    },
+                    {
+                        "title": "What's New Author",
+                        "description": "The text color for the author in the What's New popup.",
+                        "settingName": "colorWhatsNewAuthor",
                         "type": "colorgrid",
                         "default": "#FF6666"
                     },

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -51,8 +51,8 @@ sub Main (args as dynamic) as void
     ' First thing to do is validate the ability to use the API
     if not LoginFlow() then return
 
-    ' Set user's chosen background color
-    setUserBackground()
+    ' Set user's chosen colors
+    setUserColors()
 
     ' remove login scenes from the stack
     sceneManager.callFunc("clearScenes")
@@ -185,18 +185,18 @@ sub Main (args as dynamic) as void
                 unset_setting("server")
                 session.server.Delete()
                 SignOut(false)
-                setUserBackground()
+                setUserColors()
                 sceneManager.callFunc("clearScenes")
                 goto app_start
             else if isStringEqual(button.id, "change_user")
                 SignOut(false)
                 ' Reset colors to defaults
-                setUserBackground()
+                setUserColors()
                 sceneManager.callFunc("clearScenes")
                 goto app_start
             else if isStringEqual(button.id, "sign_out")
                 SignOut()
-                setUserBackground()
+                setUserColors()
                 sceneManager.callFunc("clearScenes")
                 goto app_start
             else if isStringEqual(button.id, "settings")
@@ -285,8 +285,17 @@ sub displayWhatsNewPopup(args)
     end if
 end sub
 
-sub setUserBackground()
+sub setUserColors()
+    setBackgroundColor()
+    setBackgroundImage()
+    setCursorColor()
+end sub
+
+sub setBackgroundColor()
     m.scene.backgroundColor = chainLookupReturn(m.global.session, "user.settings.colorBackground", ColorPalette.VIEWBACKGROUND)
+end sub
+
+sub setBackgroundImage()
     selectedBackgroundImage = chainLookupReturn(m.global.session, "user.settings.imageBackground", string.EMPTY)
 
     if isStringEqual(selectedBackgroundImage, "splash")
@@ -302,4 +311,12 @@ sub setUserBackground()
     end if
 
     m.scene.callFunc("setBackgroundImage", selectedBackgroundImage)
+end sub
+
+sub setCursorColor()
+    overhang = m.scene.findNode("overhang")
+    if isValid(overhang)
+        overlayCurrentUserSelection = overhang.findNode("overlayCurrentUserSelection")
+        overlayCurrentUserSelection.blendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+    end if
 end sub

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -541,7 +541,7 @@ function CreateSigninGroup(user = "", profileImageUri = "")
                     dlgPalette = createObject("roSGNode", "RSGPalette")
                     dlgPalette.colors = {
                         DialogBackgroundColor: ColorPalette.ELEMENTBACKGROUND,
-                        DialogFocusColor: ColorPalette.HIGHLIGHT,
+                        DialogFocusColor: chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT),
                         DialogFocusItemColor: ColorPalette.WHITE,
                         DialogSecondaryTextColor: ColorPalette.WHITE,
                         DialogSecondaryItemColor: ColorPalette.LIGHTBLUE,


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
There are 2 use cases for Highlight color:
1. The user's cursor
2. The author name in the What's New content

This change creates 2 color settings for these items, allowing users to select their own colors.

![WIN_20250426_09_31_06_Pro](https://github.com/user-attachments/assets/eb5add35-6f2f-4839-a297-ceaa17b5192e)
![WIN_20250426_09_34_31_Pro](https://github.com/user-attachments/assets/9d22e594-503c-4c6c-a0fa-1a5403cf114d)

Demo Video:
https://social.linux.pizza/@tgpo/114404560224878321