### PR TITLE
Prevent users from getting stuck on actor detail screen

### DIFF
--- a/components/extras/ExtrasRowList.bs
+++ b/components/extras/ExtrasRowList.bs
@@ -281,6 +281,7 @@ end sub
 
 sub onRowItemSelected()
     m.top.selectedItem = m.top.content.getChild(m.top.rowItemSelected[0]).getChild(m.top.rowItemSelected[1])
+    m.top.selectedItem = invalid
 end sub
 
 sub onRowItemFocused()

--- a/source/static/whatsNew/3.0.3.json
+++ b/source/static/whatsNew/3.0.3.json
@@ -10,5 +10,9 @@
   {
     "description": "Honor item title showing setting in \"other\" library views",
     "author": "1hitsong"
+  },
+  {
+    "description": "Fix bug that caused users to get stuck on actor detail screen",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION


<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Invalidates selectedItem in ExtrasRowList to prevent double firing of onRowItemSelected event.

## Issues
Fixes #309