### PR TITLE
If seeking to end of video, use itemNext action to skip to next in queue

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -944,8 +944,13 @@ end function
 sub skipCurrentSegment()
     seekPosition = m.currentSegmentEndTicks / 10000000#
 
-    if seekPosition > m.top.duration
-        seekPosition = m.top.duration
+    if seekPosition > (m.top.duration - 2)
+        if m.global.queueManager.callFunc("getPosition") < m.global.queueManager.callFunc("getCount") - 1
+            handleItemSkipAction("itemnext")
+            return
+        else
+            seekPosition = m.top.duration - 1
+        end if
     end if
 
     m.top.seek = seekPosition

--- a/source/static/whatsNew/3.0.3.json
+++ b/source/static/whatsNew/3.0.3.json
@@ -18,5 +18,9 @@
   {
     "description": "Fix bug that caused video playback failure if audio was paused first",
     "author": "1hitsong"
+  },
+  {
+    "description": "Improve fix for skip outro can result in video stuck in buffering state",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
If user selects to skip a media segment that takes them within 1 second of the end of the video, call the itemNext action instead of seeking. If no items are in the queue, seek to 1 second before the end of the video.

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
