### PR TITLE
Fix bug that caused video playback failure if audio was paused first

### DIFF
--- a/components/music/AudioPlayerView.bs
+++ b/components/music/AudioPlayerView.bs
@@ -3,6 +3,7 @@ import "pkg:/source/api/Image.bs"
 import "pkg:/source/enums/ColorPalette.bs"
 import "pkg:/source/enums/ImageType.bs"
 import "pkg:/source/enums/KeyCode.bs"
+import "pkg:/source/enums/MediaPlaybackState.bs"
 import "pkg:/source/enums/String.bs"
 import "pkg:/source/enums/TaskControl.bs"
 import "pkg:/source/enums/ViewLoadStatus.bs"
@@ -299,7 +300,12 @@ sub endScreenSaver()
 end sub
 
 sub displayMiniPlayer()
-    if not m.global.audioPlayer.state = "playing" then return
+    if not isStringEqual(m.global.audioPlayer.state, MediaPlaybackState.PLAYING)
+        m.global.queueManager.callFunc("clear")
+        m.global.audioPlayer.control = "stop"
+        return
+    end if
+
     if m.playlistTypeCount > 1 then return
 
     scene = m.top.getScene()

--- a/source/static/whatsNew/3.0.3.json
+++ b/source/static/whatsNew/3.0.3.json
@@ -14,5 +14,9 @@
   {
     "description": "Fix bug that caused users to get stuck on actor detail screen",
     "author": "1hitsong"
+  },
+  {
+    "description": "Fix bug that caused video playback failure if audio was paused first",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
When calling `displayMiniPlayer()`, if audio is not playing, send stop command to audioPlayer.

## Issues
Fixes #311