### PR TITLE
Add Autoplay Episode Limit setting and behaviour

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -184,12 +184,11 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
         end for
     end if
 
-    if m.global.session.user.Configuration.EnableNextEpisodeAutoPlay
+    if m.global.session.user.Configuration.EnableNextEpisodeAutoPlay and isValid(video.showID)
         episodeQueueLimit = chainLookupReturn(m.global.session, "user.settings.episodeQueueLimit", "50")
         episodeQueueLimit = episodeQueueLimit.ToInt()
-        if isValid(video.showID)
-            addNextEpisodesToQueue(video.showID, additionalPartsCount, episodeQueueLimit)
-        end if
+
+        addNextEpisodesToQueue(video.showID, additionalPartsCount, episodeQueueLimit)
     end if
 
     playbackPosition = 0!

--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -574,7 +574,7 @@ sub addNextEpisodesToQueue(showID, additionalPartsCount as integer, queueLimit a
     url = Substitute("Shows/{0}/Episodes", showID)
     urlParams = { "UserId": m.global.session.user.id }
     urlParams.Append({ "StartItemId": videoID })
-    urlParams.Append({ "Limit": queueLimit })
+    urlParams.Append({ "Limit": queueLimit + 1 })
     resp = APIRequest(url, urlParams)
     data = getJson(resp)
 

--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -185,7 +185,8 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
     end if
 
     if m.global.session.user.Configuration.EnableNextEpisodeAutoPlay
-        episodeQueueLimit = m.global.session.user.settings.["playback.episodeQueueLimit"].ToInt()
+        episodeQueueLimit = chainLookupReturn(m.global.session, "user.settings.episodeQueueLimit", "50")
+        episodeQueueLimit = episodeQueueLimit.ToInt()
         if isValid(video.showID)
             addNextEpisodesToQueue(video.showID, additionalPartsCount, episodeQueueLimit)
         end if
@@ -570,17 +571,10 @@ sub addNextEpisodesToQueue(showID, additionalPartsCount as integer, queueLimit a
         end if
     end if
 
-    limitParam = queueLimit
-
-    ' If the queue limit is set to 0 / disabled, default to 50
-    if limitParam = 0
-        limitParam = 50
-    end if
-
     url = Substitute("Shows/{0}/Episodes", showID)
     urlParams = { "UserId": m.global.session.user.id }
     urlParams.Append({ "StartItemId": videoID })
-    urlParams.Append({ "Limit": limitParam })
+    urlParams.Append({ "Limit": queueLimit })
     resp = APIRequest(url, urlParams)
     data = getJson(resp)
 

--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -185,8 +185,9 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
     end if
 
     if m.global.session.user.Configuration.EnableNextEpisodeAutoPlay
+        episodeQueueLimit = m.global.session.user.settings.["playback.episodeQueueLimit"].ToInt()
         if isValid(video.showID)
-            addNextEpisodesToQueue(video.showID, additionalPartsCount)
+            addNextEpisodesToQueue(video.showID, additionalPartsCount, episodeQueueLimit)
         end if
     end if
 
@@ -542,7 +543,7 @@ function getContainerType(meta as object) as string
 end function
 
 ' Add next episodes to the playback queue
-sub addNextEpisodesToQueue(showID, additionalPartsCount as integer)
+sub addNextEpisodesToQueue(showID, additionalPartsCount as integer, queueLimit as integer)
     ' Don't queue next episodes if we already have a playback queue
     maxQueueCount = additionalPartsCount + 1
 
@@ -569,10 +570,17 @@ sub addNextEpisodesToQueue(showID, additionalPartsCount as integer)
         end if
     end if
 
+    limitParam = queueLimit
+
+    ' If the queue limit is set to 0 / disabled, default to 50
+    if limitParam = 0
+        limitParam = 50
+    end if
+
     url = Substitute("Shows/{0}/Episodes", showID)
     urlParams = { "UserId": m.global.session.user.id }
     urlParams.Append({ "StartItemId": videoID })
-    urlParams.Append({ "Limit": 50 })
+    urlParams.Append({ "Limit": limitParam })
     resp = APIRequest(url, urlParams)
     data = getJson(resp)
 

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1013,6 +1013,14 @@
             <translation>Albums</translation>
         </message>
         <message>
+            <source>Autoplay Episode Limit</source>
+            <translation>Autoplay Episode Limit</source>
+        </message>
+        <message>
+            <source>The number of episodes that will play automatically before stopping. Requires 'Play next episode automatically' server setting to be enabled. Set to 0 to disable.</source>
+            <translation>The number of episodes that will play automatically before stopping. Requires 'Play next episode automatically' server setting to be enabled. Set to 0 to disable.</translation>
+        </message>
+        <message>
             <source>View All</source>
             <translation>View All</translation>
         </message>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1017,8 +1017,8 @@
             <translation>Autoplay Episode Limit</source>
         </message>
         <message>
-            <source>The number of episodes that will play automatically before stopping. Requires 'Play next episode automatically' server setting to be enabled.</source>
-            <translation>The number of episodes that will play automatically before stopping. Requires 'Play next episode automatically' server setting to be enabled.</translation>
+            <source>The number of episodes that will play automatically after the selected episode. Requires 'Play next episode automatically' server setting to be enabled.</source>
+            <translation>The number of episodes that will play automatically after the selected episode. Requires 'Play next episode automatically' server setting to be enabled.</translation>
         </message>
         <message>
             <source>View All</source>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1017,8 +1017,8 @@
             <translation>Autoplay Episode Limit</source>
         </message>
         <message>
-            <source>The number of episodes that will play automatically before stopping. Requires 'Play next episode automatically' server setting to be enabled. Set to 0 to disable.</source>
-            <translation>The number of episodes that will play automatically before stopping. Requires 'Play next episode automatically' server setting to be enabled. Set to 0 to disable.</translation>
+            <source>The number of episodes that will play automatically before stopping. Requires 'Play next episode automatically' server setting to be enabled.</source>
+            <translation>The number of episodes that will play automatically before stopping. Requires 'Play next episode automatically' server setting to be enabled.</translation>
         </message>
         <message>
             <source>View All</source>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -125,10 +125,10 @@
     "children": [
       {
         "title": "Autoplay Episode Limit",
-        "description": "The number of episodes that will play automatically before stopping. Requires 'Play next episode automatically' server setting to be enabled. Set to 0 to disable.",
-        "settingName": "playback.episodeQueueLimit",
+        "description": "The number of episodes that will play automatically before stopping. Requires 'Play next episode automatically' server setting to be enabled.",
+        "settingName": "episodeQueueLimit",
         "type": "integer",
-        "default": "0"
+        "default": "50"
       },
       {
         "title": "Bitrate Limit",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1,615 +1,622 @@
 [
-    {
-        "title": "Secret",
-        "description": "Settings that are not for public consumption. Do not get mad if these things change without notice.",
-        "visible": false,
-        "children": [
-            {
-                "title": "CJK Text",
-                "description": "Use CJK fallback font for text elements across the channel",
-                "settingName": "cjkText",
-                "type": "bool",
-                "default": "false"
-            },
-            {
-                "title": "Channel Background Image",
-                "description": "Overlay a background image over your chosen background color",
-                "settingName": "imageBackground",
-                "type": "radio",
-                "default": "",
-                "options": [
-                    {
-                        "title": "None",
-                        "id": ""
-                    },
-                    {
-                        "title": "Circles",
-                        "id": "pkg:/images/background/bg1.jpg"
-                    },
-                    {
-                        "title": "Swoosh",
-                        "id": "pkg:/images/background/bg2.jpg"
-                    },
-                    {
-                        "title": "Splashscreen Image",
-                        "id": "splash"
-                    }
-                ]
-            },
-            {
-                "title": "Color Settings",
-                "description": "Change the colors of elements in the channel",
-                "children": [
-                    {
-                        "title": "Background",
-                        "description": "The base background color for all screens in Jellyfin.",
-                        "settingName": "colorBackground",
-                        "type": "colorgrid",
-                        "default": "#000018"
-                    },
-                    {
-                        "title": "Primary Text",
-                        "description": "The primary text color for all screens in Jellyfin.",
-                        "settingName": "colorText",
-                        "type": "colorgrid",
-                        "default": "#FFFFFF"
-                    },
-                    {
-                        "title": "Secondary Text",
-                        "description": "The secondary text color for all screens in Jellyfin.",
-                        "settingName": "colorSubText",
-                        "type": "colorgrid",
-                        "default": "#777777FF"
-                    },
-                    {
-                        "title": "Cursor",
-                        "description": "The highlight color for the cursor showing where the user's focus is.",
-                        "settingName": "colorCursor",
-                        "type": "colorgrid",
-                        "default": "#FF6666"
-                    },
-                    {
-                        "title": "What's New Author",
-                        "description": "The text color for the author in the What's New popup.",
-                        "settingName": "colorWhatsNewAuthor",
-                        "type": "colorgrid",
-                        "default": "#FF6666"
-                    },
-                    {
-                        "title": "Watched Check Mark & Unplayed Count",
-                        "description": "Watched Check Mark & Unplayed Count color settings",
-                        "children": [
-                            {
-                                "title": "Background",
-                                "description": "The background color of the check mark & unplayed count shown in the top right corner of items.",
-                                "settingName": "colorPlayedCheckmarkBackground",
-                                "type": "colorgrid",
-                                "default": "#6666FF"
-                            },
-                            {
-                                "title": "Watched Check Mark",
-                                "description": "The color of the watched check mark.",
-                                "settingName": "colorPlayedCheckmarkIcon",
-                                "type": "colorgrid",
-                                "default": "#FFFFFF"
-                            },
-                            {
-                                "title": "Unplayed Count",
-                                "description": "The text color of the unplayed count number.",
-                                "settingName": "colorUnplayedCountTextColor",
-                                "type": "colorgrid",
-                                "default": "#FFFFFF"
-                            }
-                        ]
-                    }
-                ]
-            }
+  {
+    "title": "Secret",
+    "description": "Settings that are not for public consumption. Do not get mad if these things change without notice.",
+    "visible": false,
+    "children": [
+      {
+        "title": "CJK Text",
+        "description": "Use CJK fallback font for text elements across the channel",
+        "settingName": "cjkText",
+        "type": "bool",
+        "default": "false"
+      },
+      {
+        "title": "Channel Background Image",
+        "description": "Overlay a background image over your chosen background color",
+        "settingName": "imageBackground",
+        "type": "radio",
+        "default": "",
+        "options": [
+          {
+            "title": "None",
+            "id": ""
+          },
+          {
+            "title": "Circles",
+            "id": "pkg:/images/background/bg1.jpg"
+          },
+          {
+            "title": "Swoosh",
+            "id": "pkg:/images/background/bg2.jpg"
+          },
+          {
+            "title": "Splashscreen Image",
+            "id": "splash"
+          }
         ]
-    },
-    {
-        "title": "Global",
-        "description": "Global settings that affect everyone that uses this Roku device.",
+      },
+      {
+        "title": "Color Settings",
+        "description": "Change the colors of elements in the channel",
         "children": [
-            {
-                "title": "Remember Me?",
-                "description": "Remember the currently logged in user and try to log them in again next time you start Jellyfin.",
-                "settingName": "global.rememberme",
+          {
+            "title": "Background",
+            "description": "The base background color for all screens in Jellyfin.",
+            "settingName": "colorBackground",
+            "type": "colorgrid",
+            "default": "#000018"
+          },
+          {
+            "title": "Primary Text",
+            "description": "The primary text color for all screens in Jellyfin.",
+            "settingName": "colorText",
+            "type": "colorgrid",
+            "default": "#FFFFFF"
+          },
+          {
+            "title": "Secondary Text",
+            "description": "The secondary text color for all screens in Jellyfin.",
+            "settingName": "colorSubText",
+            "type": "colorgrid",
+            "default": "#777777FF"
+          },
+          {
+            "title": "Cursor",
+            "description": "The highlight color for the cursor showing where the user's focus is.",
+            "settingName": "colorCursor",
+            "type": "colorgrid",
+            "default": "#FF6666"
+          },
+          {
+            "title": "What's New Author",
+            "description": "The text color for the author in the What's New popup.",
+            "settingName": "colorWhatsNewAuthor",
+            "type": "colorgrid",
+            "default": "#FF6666"
+          },
+          {
+            "title": "Watched Check Mark & Unplayed Count",
+            "description": "Watched Check Mark & Unplayed Count color settings",
+            "children": [
+              {
+                "title": "Background",
+                "description": "The background color of the check mark & unplayed count shown in the top right corner of items.",
+                "settingName": "colorPlayedCheckmarkBackground",
+                "type": "colorgrid",
+                "default": "#6666FF"
+              },
+              {
+                "title": "Watched Check Mark",
+                "description": "The color of the watched check mark.",
+                "settingName": "colorPlayedCheckmarkIcon",
+                "type": "colorgrid",
+                "default": "#FFFFFF"
+              },
+              {
+                "title": "Unplayed Count",
+                "description": "The text color of the unplayed count number.",
+                "settingName": "colorUnplayedCountTextColor",
+                "type": "colorgrid",
+                "default": "#FFFFFF"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "title": "Global",
+    "description": "Global settings that affect everyone that uses this Roku device.",
+    "children": [
+      {
+        "title": "Remember Me?",
+        "description": "Remember the currently logged in user and try to log them in again next time you start Jellyfin.",
+        "settingName": "global.rememberme",
+        "type": "bool",
+        "default": "true"
+      }
+    ]
+  },
+  {
+    "title": "Playback",
+    "description": "Settings relating to playback and supported codec and media types.",
+    "children": [
+      {
+        "title": "Autoplay Episode Limit",
+        "description": "The number of episodes that will play automatically before stopping. Requires 'Play next episode automatically' server setting to be enabled. Set to 0 to disable.",
+        "settingName": "playback.episodeQueueLimit",
+        "type": "integer",
+        "default": "0"
+      },
+      {
+        "title": "Bitrate Limit",
+        "description": "Configure the maximum playback bitrate.",
+        "children": [
+          {
+            "title": "Enable Limit",
+            "description": "Enable or disable the 'Maximum Bitrate' setting.",
+            "settingName": "playback.bitrate.maxlimited",
+            "type": "bool",
+            "default": "true"
+          },
+          {
+            "title": "Maximum Bitrate",
+            "description": "Set the maximum bitrate in Mbps. Set to 0 to use Roku's specifications. This setting must be enabled to take effect.",
+            "settingName": "playback.bitrate.limit",
+            "type": "integer",
+            "default": "0"
+          }
+        ]
+      },
+      {
+        "title": "Cinema Mode",
+        "description": "Bring the theater experience straight to your living room with the ability to play custom intros before the main feature.",
+        "settingName": "playback.cinemamode",
+        "type": "bool",
+        "default": "false"
+      },
+      {
+        "title": "Compatibility",
+        "description": "Attempt to prevent playback failures.",
+        "children": [
+          {
+            "title": "Disable HEVC",
+            "description": "Disable the HEVC codec on this device. This may improve playback for some devices (ultra).",
+            "settingName": "playback.compatibility.disablehevc",
+            "type": "bool",
+            "default": "false"
+          }
+        ]
+      },
+      {
+        "title": "Custom Subtitles",
+        "description": "Replace Roku's default subtitle functions with custom functions that support CJK fonts. Fallback fonts must be configured and enabled on the server for CJK rendering to work.",
+        "settingName": "playback.subs.custom",
+        "type": "bool",
+        "default": "false"
+      },
+      {
+        "title": "Custom Trickplay",
+        "description": "Display custom trickplay images even if this Roku says it's displaying its own. This may cause the two images to overlay on top of each other.",
+        "settingName": "playback.trickplay.forcecustom",
+        "type": "bool",
+        "default": "false"
+      },
+      {
+        "title": "Force Transcoding",
+        "description": "Force all playable media to be transcoded.",
+        "settingName": "playback.media.forceTranscode",
+        "type": "bool",
+        "default": "false"
+      },
+      {
+        "title": "Maximum Resolution",
+        "description": "Configure the maximum resolution when playing video files on this device.",
+        "children": [
+          {
+            "title": "Mode",
+            "description": "Apply max resolution to all files or only transcoded files.",
+            "settingName": "playback.resolution.mode",
+            "type": "radio",
+            "default": "transcoding",
+            "options": [
+              {
+                "title": "All files",
+                "id": "everything"
+              },
+              {
+                "title": "Only transcoded files",
+                "id": "transcoding"
+              }
+            ]
+          },
+          {
+            "title": "Value",
+            "description": "Set the maximum resolution when playing video files on this device.",
+            "settingName": "playback.resolution.max",
+            "type": "radio",
+            "default": "auto",
+            "options": [
+              {
+                "title": "Off - Attempt to play all resolutions",
+                "id": "off"
+              },
+              {
+                "title": "Auto - Use TV resolution",
+                "id": "auto"
+              },
+              {
+                "title": "360p",
+                "id": "360"
+              },
+              {
+                "title": "480p",
+                "id": "480"
+              },
+              {
+                "title": "720p",
+                "id": "720"
+              },
+              {
+                "title": "1080p",
+                "id": "1080"
+              },
+              {
+                "title": "4k",
+                "id": "2160"
+              },
+              {
+                "title": "8k",
+                "id": "4320"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Media Segment Actions",
+        "description": "Settings relating to how Jellyfin should handle media segments.",
+        "children": [
+          {
+            "title": "Commercial Segments",
+            "description": "What action should Jellyfin take for commercial segments? ",
+            "settingName": "playback.mediasegments.commercial",
+            "type": "radio",
+            "default": "none",
+            "options": [
+              {
+                "title": "Ask To Skip",
+                "id": "asktoskip"
+              },
+              {
+                "title": "Skip",
+                "id": "skip"
+              },
+              {
+                "title": "None",
+                "id": "none"
+              }
+            ]
+          },
+          {
+            "title": "Intro Segments",
+            "description": "What action should Jellyfin take for intro segments? ",
+            "settingName": "playback.mediasegments.intro",
+            "type": "radio",
+            "default": "asktoskip",
+            "options": [
+              {
+                "title": "Ask To Skip",
+                "id": "asktoskip"
+              },
+              {
+                "title": "Skip",
+                "id": "skip"
+              },
+              {
+                "title": "None",
+                "id": "None"
+              }
+            ]
+          },
+          {
+            "title": "Outro Segments",
+            "description": "What action should Jellyfin take for outro segments? ",
+            "settingName": "playback.mediasegments.outro",
+            "type": "radio",
+            "default": "asktoskip",
+            "options": [
+              {
+                "title": "Ask To Skip",
+                "id": "asktoskip"
+              },
+              {
+                "title": "Skip",
+                "id": "skip"
+              },
+              {
+                "title": "None",
+                "id": "none"
+              }
+            ]
+          },
+          {
+            "title": "Preview Segments",
+            "description": "What action should Jellyfin take for preview segments? ",
+            "settingName": "playback.mediasegments.preview",
+            "type": "radio",
+            "default": "none",
+            "options": [
+              {
+                "title": "Ask To Skip",
+                "id": "asktoskip"
+              },
+              {
+                "title": "Skip",
+                "id": "skip"
+              },
+              {
+                "title": "None",
+                "id": "none"
+              }
+            ]
+          },
+          {
+            "title": "Recap Segments",
+            "description": "What action should Jellyfin take for recap segments? ",
+            "settingName": "playback.mediasegments.recap",
+            "type": "radio",
+            "default": "none",
+            "options": [
+              {
+                "title": "Ask To Skip",
+                "id": "asktoskip"
+              },
+              {
+                "title": "Skip",
+                "id": "skip"
+              },
+              {
+                "title": "None",
+                "id": "none"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Next Episode Button Time",
+        "description": "If no Outro media segment exists, set how many seconds before the end of an episode the Skip Outro button should appear. Set to 0 to disable.",
+        "settingName": "playback.nextupbuttonseconds",
+        "type": "integer",
+        "default": "30"
+      },
+      {
+        "title": "Preferred Audio Codec",
+        "description": "Use the selected audio codec for transcodes. If the device or stream does not support it, a fallback codec will be used.",
+        "settingName": "playback.preferredAudioCodec",
+        "type": "radio",
+        "default": "auto",
+        "options": [
+          {
+            "title": "Use system settings",
+            "id": "auto"
+          },
+          {
+            "title": "AAC",
+            "id": "aac"
+          },
+          {
+            "title": "DD (AC3)",
+            "id": "ac3"
+          },
+          {
+            "title": "DD+ (EAC3)",
+            "id": "eac3"
+          },
+          {
+            "title": "DTS",
+            "id": "dts"
+          }
+        ]
+      },
+      {
+        "title": "Text Subtitles Only",
+        "description": "Only display text subtitles to minimize transcoding.",
+        "settingName": "playback.subs.onlytext",
+        "type": "bool",
+        "default": "false"
+      },
+      {
+        "title": "Video Codec Support",
+        "description": "Enable or disable Direct Play support for certain codecs.",
+        "children": [
+          {
+            "title": "MPEG-2",
+            "description": "Support Direct Play of MPEG-2 content (e.g., Live TV). This will prevent transcoding of MPEG-2 content, but uses significantly more bandwidth.",
+            "settingName": "playback.mpeg2",
+            "type": "bool",
+            "default": "false"
+          },
+          {
+            "title": "MPEG-4",
+            "description": "Support Direct Play of MPEG-4 content. This may need to be disabled for playback of DIVX encoded video files.",
+            "settingName": "playback.mpeg4",
+            "type": "bool",
+            "default": "true"
+          }
+        ]
+      },
+      {
+        "title": "Video Profile Level Support",
+        "description": "Attempt Direct Play of potentially unsupported profile levels",
+        "children": [
+          {
+            "title": "H.264",
+            "description": "Attempt Direct Play for H.264 media with unsupported profile levels before falling back to transcoding if it fails.",
+            "settingName": "playback.tryDirect.h264ProfileLevel",
+            "type": "bool",
+            "default": "false"
+          },
+          {
+            "title": "HEVC",
+            "description": "Attempt Direct Play for HEVC media with unsupported profile levels before falling back to transcoding if it fails.",
+            "settingName": "playback.tryDirect.hevcProfileLevel",
+            "type": "bool",
+            "default": "false"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "title": "User Interface",
+    "description": "Settings relating to how the application looks.",
+    "children": [
+      {
+        "title": "General",
+        "description": "Settings relating to the appearance of the Home screen and the program in general.",
+        "children": [
+          {
+            "title": "Episode Images Next Up",
+            "description": "What type of images to use for Episodes shown in the 'Next Up' and 'Continue Watching' sections.",
+            "settingName": "ui-general-episodeimagesnextup",
+            "type": "radio",
+            "default": "webclient",
+            "options": [
+              {
+                "title": "Use Web Client Setting",
+                "id": "webclient"
+              },
+              {
+                "title": "Use Episode Image",
+                "id": "episode"
+              },
+              {
+                "title": "Use Show Image",
+                "id": "show"
+              }
+            ]
+          },
+          {
+            "title": "Hide Clock",
+            "description": "Hide all clocks in Jellyfin. Jellyfin will need to be closed and reopened for changes to take effect.",
+            "settingName": "ui.design.hideclock",
+            "type": "bool",
+            "default": "false"
+          },
+          {
+            "title": "Max Days Next Up",
+            "description": "Set the maximum amount of days a show should stay in the 'Next Up' list without watching it.",
+            "settingName": "ui.details.maxdaysnextup",
+            "type": "integer",
+            "default": "365"
+          },
+          {
+            "title": "Rewatching Next Up",
+            "description": "Show already watched episodes in 'Next Up' sections.",
+            "settingName": "ui.details.enablerewatchingnextup",
+            "type": "bool",
+            "default": "false"
+          },
+          {
+            "title": "Show What's New Popup",
+            "description": "Show What's New popup when Jellyfin is updated to a new version.",
+            "settingName": "load.allowwhatsnew",
+            "type": "bool",
+            "default": "true"
+          },
+          {
+            "title": "Use Web Client's Home Section Arrangement",
+            "description": "Make the arrangement of the Roku home view sections match the web client's home screen. Jellyfin will need to be closed and reopened for change to take effect.",
+            "settingName": "ui.home.useWebSectionArrangement",
+            "type": "bool",
+            "default": "true"
+          }
+        ]
+      },
+      {
+        "title": "Item Detail Screen",
+        "description": "Settings relating to the appearance of the item detail screen.",
+        "children": [
+          {
+            "title": "Community and Critical Ratings",
+            "description": "Community and critic review ratings from Rotten Tomatoes.",
+            "settingName": "ui.itemdetail.showRatings",
+            "type": "bool",
+            "default": "true"
+          },
+          {
+            "title": "Overview Content",
+            "description": "A quick overview of the item selected - typically a short plot outline.",
+            "settingName": "ui.itemdetail.showoverviewcontent",
+            "type": "bool",
+            "default": "true"
+          }
+        ]
+      },
+      {
+        "title": "Libraries",
+        "description": "Settings relating to the appearance of Library pages.",
+        "children": [
+          {
+            "title": "General",
+            "description": "Settings relating to the appearance of pages in all Libraries.",
+            "children": [
+              {
+                "title": "Forget Filters",
+                "description": "Forget applied library filters when Jellyfin is closed.",
+                "settingName": "itemgrid.forgetFilters",
                 "type": "bool",
                 "default": "true"
-            }
+              },
+              {
+                "title": "Grid View Settings",
+                "description": "Settings that apply when Grid views are enabled.",
+                "children": [
+                  {
+                    "title": "Item Count",
+                    "description": "Show item count in the library and index of selected item.",
+                    "settingName": "itemgrid.showItemCount",
+                    "type": "bool",
+                    "default": "false"
+                  },
+                  {
+                    "title": "Item Titles",
+                    "description": "Select when to show titles.",
+                    "settingName": "itemgrid.gridTitles",
+                    "type": "radio",
+                    "default": "showonhover",
+                    "options": [
+                      {
+                        "title": "Show On Hover",
+                        "id": "showonhover"
+                      },
+                      {
+                        "title": "Always Show",
+                        "id": "showalways"
+                      },
+                      {
+                        "title": "Always Hide",
+                        "id": "hidealways"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "title": "TV Shows",
+            "description": "Settings relating to the appearance of pages in TV Libraries.",
+            "children": [
+              {
+                "title": "Disable Community Rating for Episodes",
+                "description": "Hide the star and community rating for episodes of a TV show. This is to prevent spoilers of an upcoming good/bad episode.",
+                "settingName": "ui.itemdetail.showRatings",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "Disable Unwatched Episode Count",
+                "description": "If enabled, the number of unwatched episodes in a series/season will be removed.",
+                "settingName": "ui.tvshows.disableUnwatchedEpisodeCount",
+                "type": "bool",
+                "default": "false"
+              },
+              {
+                "title": "Skip Details for Single Seasons",
+                "description": "If enabled, selecting a TV series with only one season will go straight to the episode list rather than the show details and season list.",
+                "settingName": "ui.tvshows.goStraightToEpisodeListing",
+                "type": "bool",
+                "default": "false"
+              }
+            ]
+          }
         ]
-    },
-    {
-        "title": "Playback",
-        "description": "Settings relating to playback and supported codec and media types.",
-        "children": [
-            {
-                "title": "Bitrate Limit",
-                "description": "Configure the maximum playback bitrate.",
-                "children": [
-                    {
-                        "title": "Enable Limit",
-                        "description": "Enable or disable the 'Maximum Bitrate' setting.",
-                        "settingName": "playback.bitrate.maxlimited",
-                        "type": "bool",
-                        "default": "true"
-                    },
-                    {
-                        "title": "Maximum Bitrate",
-                        "description": "Set the maximum bitrate in Mbps. Set to 0 to use Roku's specifications. This setting must be enabled to take effect.",
-                        "settingName": "playback.bitrate.limit",
-                        "type": "integer",
-                        "default": "0"
-                    }
-                ]
-            },
-            {
-                "title": "Cinema Mode",
-                "description": "Bring the theater experience straight to your living room with the ability to play custom intros before the main feature.",
-                "settingName": "playback.cinemamode",
-                "type": "bool",
-                "default": "false"
-            },
-            {
-                "title": "Compatibility",
-                "description": "Attempt to prevent playback failures.",
-                "children": [
-                    {
-                        "title": "Disable HEVC",
-                        "description": "Disable the HEVC codec on this device. This may improve playback for some devices (ultra).",
-                        "settingName": "playback.compatibility.disablehevc",
-                        "type": "bool",
-                        "default": "false"
-                    }
-                ]
-            },
-            {
-                "title": "Custom Subtitles",
-                "description": "Replace Roku's default subtitle functions with custom functions that support CJK fonts. Fallback fonts must be configured and enabled on the server for CJK rendering to work.",
-                "settingName": "playback.subs.custom",
-                "type": "bool",
-                "default": "false"
-            },
-            {
-                "title": "Custom Trickplay",
-                "description": "Display custom trickplay images even if this Roku says it's displaying its own. This may cause the two images to overlay on top of each other.",
-                "settingName": "playback.trickplay.forcecustom",
-                "type": "bool",
-                "default": "false"
-            },
-            {
-                "title": "Force Transcoding",
-                "description": "Force all playable media to be transcoded.",
-                "settingName": "playback.media.forceTranscode",
-                "type": "bool",
-                "default": "false"
-            },
-            {
-                "title": "Maximum Resolution",
-                "description": "Configure the maximum resolution when playing video files on this device.",
-                "children": [
-                    {
-                        "title": "Mode",
-                        "description": "Apply max resolution to all files or only transcoded files.",
-                        "settingName": "playback.resolution.mode",
-                        "type": "radio",
-                        "default": "transcoding",
-                        "options": [
-                            {
-                                "title": "All files",
-                                "id": "everything"
-                            },
-                            {
-                                "title": "Only transcoded files",
-                                "id": "transcoding"
-                            }
-                        ]
-                    },
-                    {
-                        "title": "Value",
-                        "description": "Set the maximum resolution when playing video files on this device.",
-                        "settingName": "playback.resolution.max",
-                        "type": "radio",
-                        "default": "auto",
-                        "options": [
-                            {
-                                "title": "Off - Attempt to play all resolutions",
-                                "id": "off"
-                            },
-                            {
-                                "title": "Auto - Use TV resolution",
-                                "id": "auto"
-                            },
-                            {
-                                "title": "360p",
-                                "id": "360"
-                            },
-                            {
-                                "title": "480p",
-                                "id": "480"
-                            },
-                            {
-                                "title": "720p",
-                                "id": "720"
-                            },
-                            {
-                                "title": "1080p",
-                                "id": "1080"
-                            },
-                            {
-                                "title": "4k",
-                                "id": "2160"
-                            },
-                            {
-                                "title": "8k",
-                                "id": "4320"
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "title": "Media Segment Actions",
-                "description": "Settings relating to how Jellyfin should handle media segments.",
-                "children": [
-                    {
-                        "title": "Commercial Segments",
-                        "description": "What action should Jellyfin take for commercial segments? ",
-                        "settingName": "playback.mediasegments.commercial",
-                        "type": "radio",
-                        "default": "none",
-                        "options": [
-                            {
-                                "title": "Ask To Skip",
-                                "id": "asktoskip"
-                            },
-                            {
-                                "title": "Skip",
-                                "id": "skip"
-                            },
-                            {
-                                "title": "None",
-                                "id": "none"
-                            }
-                        ]
-                    },
-                    {
-                        "title": "Intro Segments",
-                        "description": "What action should Jellyfin take for intro segments? ",
-                        "settingName": "playback.mediasegments.intro",
-                        "type": "radio",
-                        "default": "asktoskip",
-                        "options": [
-                            {
-                                "title": "Ask To Skip",
-                                "id": "asktoskip"
-                            },
-                            {
-                                "title": "Skip",
-                                "id": "skip"
-                            },
-                            {
-                                "title": "None",
-                                "id": "None"
-                            }
-                        ]
-                    },
-                    {
-                        "title": "Outro Segments",
-                        "description": "What action should Jellyfin take for outro segments? ",
-                        "settingName": "playback.mediasegments.outro",
-                        "type": "radio",
-                        "default": "asktoskip",
-                        "options": [
-                            {
-                                "title": "Ask To Skip",
-                                "id": "asktoskip"
-                            },
-                            {
-                                "title": "Skip",
-                                "id": "skip"
-                            },
-                            {
-                                "title": "None",
-                                "id": "none"
-                            }
-                        ]
-                    },
-                    {
-                        "title": "Preview Segments",
-                        "description": "What action should Jellyfin take for preview segments? ",
-                        "settingName": "playback.mediasegments.preview",
-                        "type": "radio",
-                        "default": "none",
-                        "options": [
-                            {
-                                "title": "Ask To Skip",
-                                "id": "asktoskip"
-                            },
-                            {
-                                "title": "Skip",
-                                "id": "skip"
-                            },
-                            {
-                                "title": "None",
-                                "id": "none"
-                            }
-                        ]
-                    },
-                    {
-                        "title": "Recap Segments",
-                        "description": "What action should Jellyfin take for recap segments? ",
-                        "settingName": "playback.mediasegments.recap",
-                        "type": "radio",
-                        "default": "none",
-                        "options": [
-                            {
-                                "title": "Ask To Skip",
-                                "id": "asktoskip"
-                            },
-                            {
-                                "title": "Skip",
-                                "id": "skip"
-                            },
-                            {
-                                "title": "None",
-                                "id": "none"
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "title": "Next Episode Button Time",
-                "description": "If no Outro media segment exists, set how many seconds before the end of an episode the Skip Outro button should appear. Set to 0 to disable.",
-                "settingName": "playback.nextupbuttonseconds",
-                "type": "integer",
-                "default": "30"
-            },
-            {
-                "title": "Preferred Audio Codec",
-                "description": "Use the selected audio codec for transcodes. If the device or stream does not support it, a fallback codec will be used.",
-                "settingName": "playback.preferredAudioCodec",
-                "type": "radio",
-                "default": "auto",
-                "options": [
-                    {
-                        "title": "Use system settings",
-                        "id": "auto"
-                    },
-                    {
-                        "title": "AAC",
-                        "id": "aac"
-                    },
-                    {
-                        "title": "DD (AC3)",
-                        "id": "ac3"
-                    },
-                    {
-                        "title": "DD+ (EAC3)",
-                        "id": "eac3"
-                    },
-                    {
-                        "title": "DTS",
-                        "id": "dts"
-                    }
-                ]
-            },
-            {
-                "title": "Text Subtitles Only",
-                "description": "Only display text subtitles to minimize transcoding.",
-                "settingName": "playback.subs.onlytext",
-                "type": "bool",
-                "default": "false"
-            },
-            {
-                "title": "Video Codec Support",
-                "description": "Enable or disable Direct Play support for certain codecs.",
-                "children": [
-                    {
-                        "title": "MPEG-2",
-                        "description": "Support Direct Play of MPEG-2 content (e.g., Live TV). This will prevent transcoding of MPEG-2 content, but uses significantly more bandwidth.",
-                        "settingName": "playback.mpeg2",
-                        "type": "bool",
-                        "default": "false"
-                    },
-                    {
-                        "title": "MPEG-4",
-                        "description": "Support Direct Play of MPEG-4 content. This may need to be disabled for playback of DIVX encoded video files.",
-                        "settingName": "playback.mpeg4",
-                        "type": "bool",
-                        "default": "true"
-                    }
-                ]
-            },
-            {
-                "title": "Video Profile Level Support",
-                "description": "Attempt Direct Play of potentially unsupported profile levels",
-                "children": [
-                    {
-                        "title": "H.264",
-                        "description": "Attempt Direct Play for H.264 media with unsupported profile levels before falling back to transcoding if it fails.",
-                        "settingName": "playback.tryDirect.h264ProfileLevel",
-                        "type": "bool",
-                        "default": "false"
-                    },
-                    {
-                        "title": "HEVC",
-                        "description": "Attempt Direct Play for HEVC media with unsupported profile levels before falling back to transcoding if it fails.",
-                        "settingName": "playback.tryDirect.hevcProfileLevel",
-                        "type": "bool",
-                        "default": "false"
-                    }
-                ]
-            }
-        ]
-    },
-    {
-        "title": "User Interface",
-        "description": "Settings relating to how the application looks.",
-        "children": [
-            {
-                "title": "General",
-                "description": "Settings relating to the appearance of the Home screen and the program in general.",
-                "children": [
-                    {
-                        "title": "Episode Images Next Up",
-                        "description": "What type of images to use for Episodes shown in the 'Next Up' and 'Continue Watching' sections.",
-                        "settingName": "ui-general-episodeimagesnextup",
-                        "type": "radio",
-                        "default": "webclient",
-                        "options": [
-                            {
-                                "title": "Use Web Client Setting",
-                                "id": "webclient"
-                            },
-                            {
-                                "title": "Use Episode Image",
-                                "id": "episode"
-                            },
-                            {
-                                "title": "Use Show Image",
-                                "id": "show"
-                            }
-                        ]
-                    },
-                    {
-                        "title": "Hide Clock",
-                        "description": "Hide all clocks in Jellyfin. Jellyfin will need to be closed and reopened for changes to take effect.",
-                        "settingName": "ui.design.hideclock",
-                        "type": "bool",
-                        "default": "false"
-                    },
-                    {
-                        "title": "Max Days Next Up",
-                        "description": "Set the maximum amount of days a show should stay in the 'Next Up' list without watching it.",
-                        "settingName": "ui.details.maxdaysnextup",
-                        "type": "integer",
-                        "default": "365"
-                    },
-                    {
-                        "title": "Rewatching Next Up",
-                        "description": "Show already watched episodes in 'Next Up' sections.",
-                        "settingName": "ui.details.enablerewatchingnextup",
-                        "type": "bool",
-                        "default": "false"
-                    },
-                    {
-                        "title": "Show What's New Popup",
-                        "description": "Show What's New popup when Jellyfin is updated to a new version.",
-                        "settingName": "load.allowwhatsnew",
-                        "type": "bool",
-                        "default": "true"
-                    },
-                    {
-                        "title": "Use Web Client's Home Section Arrangement",
-                        "description": "Make the arrangement of the Roku home view sections match the web client's home screen. Jellyfin will need to be closed and reopened for change to take effect.",
-                        "settingName": "ui.home.useWebSectionArrangement",
-                        "type": "bool",
-                        "default": "true"
-                    }
-                ]
-            },
-            {
-                "title": "Item Detail Screen",
-                "description": "Settings relating to the appearance of the item detail screen.",
-                "children": [
-                    {
-                        "title": "Community and Critical Ratings",
-                        "description": "Community and critic review ratings from Rotten Tomatoes.",
-                        "settingName": "ui.itemdetail.showRatings",
-                        "type": "bool",
-                        "default": "true"
-                    },
-                    {
-                        "title": "Overview Content",
-                        "description": "A quick overview of the item selected - typically a short plot outline.",
-                        "settingName": "ui.itemdetail.showoverviewcontent",
-                        "type": "bool",
-                        "default": "true"
-                    }
-                ]
-            },
-            {
-                "title": "Libraries",
-                "description": "Settings relating to the appearance of Library pages.",
-                "children": [
-                    {
-                        "title": "General",
-                        "description": "Settings relating to the appearance of pages in all Libraries.",
-                        "children": [
-                            {
-                                "title": "Forget Filters",
-                                "description": "Forget applied library filters when Jellyfin is closed.",
-                                "settingName": "itemgrid.forgetFilters",
-                                "type": "bool",
-                                "default": "true"
-                            },
-                            {
-                                "title": "Grid View Settings",
-                                "description": "Settings that apply when Grid views are enabled.",
-                                "children": [
-                                    {
-                                        "title": "Item Count",
-                                        "description": "Show item count in the library and index of selected item.",
-                                        "settingName": "itemgrid.showItemCount",
-                                        "type": "bool",
-                                        "default": "false"
-                                    },
-                                    {
-                                        "title": "Item Titles",
-                                        "description": "Select when to show titles.",
-                                        "settingName": "itemgrid.gridTitles",
-                                        "type": "radio",
-                                        "default": "showonhover",
-                                        "options": [
-                                            {
-                                                "title": "Show On Hover",
-                                                "id": "showonhover"
-                                            },
-                                            {
-                                                "title": "Always Show",
-                                                "id": "showalways"
-                                            },
-                                            {
-                                                "title": "Always Hide",
-                                                "id": "hidealways"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "title": "TV Shows",
-                        "description": "Settings relating to the appearance of pages in TV Libraries.",
-                        "children": [
-                            {
-                                "title": "Disable Community Rating for Episodes",
-                                "description": "Hide the star and community rating for episodes of a TV show. This is to prevent spoilers of an upcoming good/bad episode.",
-                                "settingName": "ui.itemdetail.showRatings",
-                                "type": "bool",
-                                "default": "false"
-                            },
-                            {
-                                "title": "Disable Unwatched Episode Count",
-                                "description": "If enabled, the number of unwatched episodes in a series/season will be removed.",
-                                "settingName": "ui.tvshows.disableUnwatchedEpisodeCount",
-                                "type": "bool",
-                                "default": "false"
-                            },
-                            {
-                                "title": "Skip Details for Single Seasons",
-                                "description": "If enabled, selecting a TV series with only one season will go straight to the episode list rather than the show details and season list.",
-                                "settingName": "ui.tvshows.goStraightToEpisodeListing",
-                                "type": "bool",
-                                "default": "false"
-                            }
-                        ]
-                    }
-                ]
-            }
-        ]
-    }
+      }
+    ]
+  }
 ]

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -125,7 +125,7 @@
     "children": [
       {
         "title": "Autoplay Episode Limit",
-        "description": "The number of episodes that will play automatically before stopping. Requires 'Play next episode automatically' server setting to be enabled.",
+        "description": "The number of episodes that will play automatically after the selected episode. Requires 'Play next episode automatically' server setting to be enabled.",
         "settingName": "episodeQueueLimit",
         "type": "integer",
         "default": "50"

--- a/source/static/whatsNew/3.0.3.json
+++ b/source/static/whatsNew/3.0.3.json
@@ -1,5 +1,9 @@
 [
   {
+    "description": "Add playback \"Autoplay Episode Limit\" setting and behavior",
+    "author": "rookly"
+  },
+  {
     "description": "Fix crash when watching a recording in progress",
     "author": "1hitsong"
   },


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Add "Autoplay Episode Limit" setting to "Playback"
- Use this setting to control the number of episodes added to the queue when hitting play on an episode
<!-- Describe your changes here in 1-5 sentences. -->

## Issues
- Addresses the need for more granular control over the autoplay episodes feature, so that if used after falling asleep the number of episodes missed is minimized / user controlled
- Alleviates the need for an "Are you still watching" screen as requested [here](https://features.jellyfin.org/posts/814/are-you-still-watching-prompt), and could be enhanced to show that screen after the queue limit in the future
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

In a subsequent PR I would also like to add a "Next Episode" button to the episode details screen, so that when an episode stops playing you can use that instead of having to scroll down to the episode list, moving to the next episode, and hitting select.