### PR TITLE
Display color's hex code when choosing a color

### DIFF
--- a/components/settings/ColorGrid.bs
+++ b/components/settings/ColorGrid.bs
@@ -1,5 +1,21 @@
 import "pkg:/source/utils/misc.bs"
 
+sub init()
+    m.selectedColor = m.top.findNode("selectedColor")
+    m.selectedColor.font.size = 20
+
+    m.top.observeField("itemFocused", "onItemFocused")
+end sub
+
+sub onItemFocused()
+    if not isValid(m.top.itemFocused) then return
+    focusedColor = m.top.content.getChild(m.top.itemFocused)
+
+    if not isChainValid(focusedColor, "colorCode") then return
+
+    m.selectedColor.text = `${tr("Highlighted Color")}: ${focusedColor.colorCode}`
+end sub
+
 sub onSettingChange()
     selectedColor = chainLookupReturn(m.global.session, `user.settings.${m.top.setting.settingName}`, m.top.setting.default)
 

--- a/components/settings/ColorGrid.xml
+++ b/components/settings/ColorGrid.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="ColorGrid" extends="MarkupGrid">
   <children>
+    <Text id="selectedColor" horizAlign="left" vertAlign="center" text="Highlighted Color:" translation="[800, -25]" />
+
     <ContentNode role="content">
       <ColorOptionData colorcode="#000000" />
       <ColorOptionData colorcode="#000018" />

--- a/components/settings/settings.xml
+++ b/components/settings/settings.xml
@@ -29,7 +29,7 @@
 
     <ColorGrid
       id="colorgrid"
-      translation="[740, 350]"
+      translation="[740, 390]"
       itemComponentName="ColorOption"
       numColumns="15"
       numRows="9"

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1327,5 +1327,9 @@
             <translation>Use Show Image</translation>
             <extracomment>User Setting - Setting option title</extracomment>
         </message>
+        <message>
+            <source>Highlighted Color</source>
+            <translation>Highlighted Color</translation>
+        </message>
     </context>
 </TS>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Displays the focused color's hexcode as the user chooses a color from the colorgrid component.

## Screenshot
![WIN_20250503_16_49_21_Pro](https://github.com/user-attachments/assets/d582f93e-ecd1-44a1-ae73-89c418d29b5f)

