### PR TITLE
Make channel background image setting public

### DIFF
--- a/settings/settings.json
+++ b/settings/settings.json
@@ -12,31 +12,6 @@
         "default": "false"
       },
       {
-        "title": "Channel Background Image",
-        "description": "Overlay a background image over your chosen background color",
-        "settingName": "imageBackground",
-        "type": "radio",
-        "default": "",
-        "options": [
-          {
-            "title": "None",
-            "id": ""
-          },
-          {
-            "title": "Circles",
-            "id": "pkg:/images/background/bg1.jpg"
-          },
-          {
-            "title": "Swoosh",
-            "id": "pkg:/images/background/bg2.jpg"
-          },
-          {
-            "title": "Splashscreen Image",
-            "id": "splash"
-          }
-        ]
-      },
-      {
         "title": "Color Settings",
         "description": "Change the colors of elements in the channel",
         "children": [
@@ -459,6 +434,31 @@
         "title": "General",
         "description": "Settings relating to the appearance of the Home screen and the program in general.",
         "children": [
+          {
+            "title": "Channel Background Image",
+            "description": "Overlay a background image over the channel's background color",
+            "settingName": "imageBackground",
+            "type": "radio",
+            "default": "",
+            "options": [
+              {
+                "title": "None",
+                "id": ""
+              },
+              {
+                "title": "Circles",
+                "id": "pkg:/images/background/bg1.jpg"
+              },
+              {
+                "title": "Swoosh",
+                "id": "pkg:/images/background/bg2.jpg"
+              },
+              {
+                "title": "Splashscreen Image",
+                "id": "splash"
+              }
+            ]
+          },
           {
             "title": "Episode Images Next Up",
             "description": "What type of images to use for Episodes shown in the 'Next Up' and 'Continue Watching' sections.",

--- a/source/static/whatsNew/3.0.4.json
+++ b/source/static/whatsNew/3.0.4.json
@@ -4,7 +4,11 @@
     "author": "1hitsong"
   },
   {
-    "description": "Show Live TV channel number and logo on OSD",
+    "description": "Show live TV channel number and logo in OSD",
     "author": "michaelcresswell"
+  },
+  {
+    "description": "Create channel background image setting",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Moves channel backgound image setting from the secret menu to the public menu

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
