### PR TITLE
Fallback to available images when posters fail to load on home items

### DIFF
--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -426,6 +426,22 @@ sub onPosterLoadStatusChanged()
             return
         end if
 
+        ' If loading the episode poster image failed, try loading the series image
+        if isStringEqual(thisItemType, ItemType.EPISODE)
+            params = {
+                tag: m.top.itemContent.json.parentbackdropimagetags,
+                maxHeight: 261,
+                maxWidth: 261
+            }
+            seriesPrimaryImageURL = ImageURL(m.top.itemContent.json.parentbackdropitemid, "Primary", params)
+
+            ' Check if we've already tried to fall back to the series image
+            if isStringEqual(m.itemPoster.uri, seriesPrimaryImageURL) then return
+
+            m.itemPoster.uri = seriesPrimaryImageURL
+            return
+        end if
+
         ' Wide Poster failed to load, try poster url
         if isStringEqual(m.itemPoster.uri, m.top.itemContent.widePosterURL)
             m.itemPoster.uri = m.top.itemContent.posterURL

--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -5,6 +5,7 @@ import "pkg:/source/enums/ColorPalette.bs"
 import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/enums/PosterLoadStatus.bs"
 import "pkg:/source/enums/SeriesStatus.bs"
+import "pkg:/source/enums/String.bs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/misc.bs"
 
@@ -406,7 +407,45 @@ end sub
 
 'Hide backdrop and icon when poster loaded
 sub onPosterLoadStatusChanged()
-    if m.itemPoster.loadStatus = PosterLoadStatus.READY and m.itemPoster.uri <> ""
+    if m.itemPoster.loadStatus = PosterLoadStatus.FAILED
+        thisItemType = chainLookupReturn(m.top.itemContent, "json.type", string.EMPTY)
+
+        ' If loading the album poster image failed, try loading the artist image
+        if isStringEqual(thisItemType, ItemType.MUSICALBUM)
+            params = {
+                tag: m.top.itemContent.json.parentbackdropimagetags,
+                maxHeight: 261,
+                maxWidth: 261
+            }
+            artistPrimaryImageURL = ImageURL(m.top.itemContent.json.parentbackdropitemid, "Primary", params)
+
+            ' Check if we've already tried to fall back to the artist image
+            if isStringEqual(m.itemPoster.uri, artistPrimaryImageURL) then return
+
+            m.itemPoster.uri = artistPrimaryImageURL
+            return
+        end if
+
+        ' Wide Poster failed to load, try poster url
+        if isStringEqual(m.itemPoster.uri, m.top.itemContent.widePosterURL)
+            m.itemPoster.uri = m.top.itemContent.posterURL
+            return
+        end if
+
+        ' Thumbnail failed to load, try poster url
+        if isStringEqual(m.itemPoster.uri, m.top.itemContent.thumbnailURL)
+            m.itemPoster.uri = m.top.itemContent.posterURL
+            return
+        end if
+
+        ' Poster url has failed. Show blank backdrop
+        m.backdrop.visible = true
+        m.itemIcon.visible = true
+
+        return
+    end if
+
+    if m.itemPoster.loadStatus = PosterLoadStatus.READY and m.itemPoster.uri <> string.EMPTY
         m.backdrop.visible = false
         m.itemIcon.visible = false
     else

--- a/source/static/whatsNew/3.0.4.json
+++ b/source/static/whatsNew/3.0.4.json
@@ -16,6 +16,10 @@
     "author": "1hitsong"
   },
   {
+    "description": "Fallback to available images if home screen item's image fails to load",
+    "author": "1hitsong"
+  },
+  {
     "description": "Fix several crashes across app",
     "author": "1hitsong"
   }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
On the home screen, if an item's poster image fails to load, try falling back to other available images.

If a music album poster image fails to load, try falling back to the artist primary image.

If an episode poster image fails to load, try falling back to the series primary image.

## Issues
Fixes #334
