### PR TITLE
Display video ending time above seekbar

### DIFF
--- a/components/Clock.bs
+++ b/components/Clock.bs
@@ -43,25 +43,35 @@ sub onCurrentTimeTimerFire()
     m.dateTimeObject.ToLocalTime()
 
     ' Format time for display - based on 12h/24h setting
-    formattedTime = formatTimeAsString()
+    formattedTime = formatTimeAsString(m.dateTimeObject)
 
     ' Display time
     m.clockTime.text = formattedTime
 end sub
 
+function getCurrentTime()
+    return m.dateTimeObject.AsSecondsLong()
+end function
+
+function getFormattedTime(timestamp as object)
+    dateTimeObject = CreateObject("roDateTime")
+    dateTimeObject.FromSecondsLong(timestamp)
+    return formatTimeAsString(dateTimeObject)
+end function
+
 ' formatTimeAsString: Returns a string with the current time formatted for either a 12 or 24 hour clock
 '
 ' @return {string} current time formatted for either a 12 hour or 24 hour clock
-function formatTimeAsString() as string
-    return m.format = ClockFormat.h12 ? format12HourTime() : format24HourTime()
+function formatTimeAsString(dateTimeObject as object) as string
+    return m.format = ClockFormat.h12 ? format12HourTime(dateTimeObject) : format24HourTime(dateTimeObject)
 end function
 
 ' format12HourTime: Returns a string with the current time formatted for a 12 hour clock
 '
 ' @return {string} current time formatted for a 12 hour clock
-function format12HourTime() as string
-    currentHour = m.dateTimeObject.GetHours()
-    currentMinute = m.dateTimeObject.GetMinutes()
+function format12HourTime(dateTimeObject as object) as string
+    currentHour = dateTimeObject.GetHours()
+    currentMinute = dateTimeObject.GetMinutes()
 
     displayedHour = StrI(currentHour).trim()
     displayedMinute = StrI(currentMinute).trim()
@@ -86,9 +96,9 @@ end function
 ' format24HourTime: Returns a string with the current time formatted for a 24 hour clock
 '
 ' @return {string} current time formatted for a 24 hour clock
-function format24HourTime() as string
-    currentHour = m.dateTimeObject.GetHours()
-    currentMinute = m.dateTimeObject.GetMinutes()
+function format24HourTime(dateTimeObject as object) as string
+    currentHour = dateTimeObject.GetHours()
+    currentMinute = dateTimeObject.GetMinutes()
 
     displayedHour = StrI(currentHour).trim()
     displayedMinute = StrI(currentMinute).trim()

--- a/components/Clock.bs
+++ b/components/Clock.bs
@@ -1,3 +1,4 @@
+import "pkg:/source/enums/String.bs"
 import "pkg:/source/utils/misc.bs"
 
 ' @fileoverview Clock component to display current time formatted based on user's chosen 12 or 24 hour setting
@@ -53,9 +54,15 @@ function getCurrentTime()
     return m.dateTimeObject.AsSecondsLong()
 end function
 
-function getFormattedTime(timestamp as object)
+function getFormattedTime(timestamp as object, allowPastTime = true as boolean)
     dateTimeObject = CreateObject("roDateTime")
     dateTimeObject.FromSecondsLong(timestamp)
+
+    ' If passed timestamp is before current time, return empty string
+    if not allowPastTime
+        if dateTimeObject.AsSeconds() <= m.dateTimeObject.AsSeconds() then return string.EMPTY
+    end if
+
     return formatTimeAsString(dateTimeObject)
 end function
 

--- a/components/Clock.xml
+++ b/components/Clock.xml
@@ -5,5 +5,7 @@
     <Timer id="currentTimeTimer" repeat="true" duration="1" />
   </children>
   <interface>
+    <function name="getCurrentTime" />
+    <function name="getFormattedTime" />
   </interface>
 </component>

--- a/components/video/OSD.bs
+++ b/components/video/OSD.bs
@@ -14,6 +14,7 @@ sub init()
     m.videoPlayPause = m.top.findNode("videoPlayPause")
     m.videoPositionTime = m.top.findNode("videoPositionTime")
     m.videoRemainingTime = m.top.findNode("videoRemainingTime")
+    m.videoEndingTime = m.top.findNode("videoEndingTime")
     m.progressBar = m.top.findNode("progressBar")
     m.progressBarBackground = m.top.findNode("progressBarBackground")
     m.nextItem = m.top.FindNode("nextItem")
@@ -23,6 +24,7 @@ sub init()
     m.top.observeField("hasFocus", "onFocusChanged")
     m.top.observeField("progressPercentage", "onProgressPercentageChanged")
     m.top.observeField("playbackState", "onPlaybackStateChanged")
+    m.top.observeField("videoEndingTime", "setVideoEndingTime")
 
     m.top.observeField("itemTitleText", "onItemTitleTextChanged")
     m.top.observeField("seasonNumber", "onSeasonNumberChanged")
@@ -68,6 +70,11 @@ sub onProgressPercentageChanged()
     m.videoRemainingTime.text = secondsToHuman(m.top.remainingPositionTime, true)
     m.progressBar.width = m.progressBarBackground.width * m.top.progressPercentage
 end sub
+
+sub setVideoEndingTime()
+    m.videoEndingTime.text = m.top.videoEndingTime
+end sub
+
 
 ' onPlaybackStateChanged: Handler for changes to m.top.playbackState param
 '
@@ -257,6 +264,8 @@ sub inactiveCheck()
     if m.global.sceneManager.callFunc("isDialogOpen")
         return
     end if
+
+    return
 
     if m.deviceInfo.timeSinceLastKeypress() >= m.top.inactiveTimeout
         checkDisplaySiblingItem("")

--- a/components/video/OSD.xml
+++ b/components/video/OSD.xml
@@ -69,6 +69,7 @@
 
     <Text id="videoPositionTime" font="font:MediumSystemFont" color="0xffffffFF" translation="[103,985]" />
     <Text id="videoRemainingTime" font="font:MediumSystemFont" color="0xffffffFF" horizAlign="right" width="200" translation="[1617,985]" />
+    <Text id="videoEndingTime" font="font:SmallSystemFont" color="0xffffffFF" horizAlign="right" width="200" translation="[1617,915]" />
 
     <Timer id="inactivityTimer" duration="1" repeat="true" />
   </children>
@@ -85,6 +86,7 @@
     <field id="inactiveTimeout" type="integer" />
     <field id="progressPercentage" type="float" />
     <field id="positionTime" type="float" />
+    <field id="videoEndingTime" type="string" />
     <field id="remainingPositionTime" type="float" />
     <field id="playbackState" type="string" alwaysNotify="true" />
     <field id="action" type="string" alwaysNotify="true" />

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -51,6 +51,9 @@ sub init()
     m.chapterContent = m.top.findNode("chapterContent")
     m.osd = m.top.findNode("osd")
     m.osd.observeField("action", "onOSDAction")
+    m.clock = m.osd.findNode("clock")
+    currentTimeTimer = m.clock.findNode("currentTimeTimer")
+    currentTimeTimer.observeField("fire", "setVideoEndingTime")
 
     m.playbackTimer = m.top.findNode("playbackTimer")
     m.bufferCheckTimer = m.top.findNode("bufferCheckTimer")
@@ -74,6 +77,8 @@ sub init()
         clockNode = findNodeBySubtype(m.top, "clock")
         if clockNode[0] <> invalid then clockNode[0].parent.removeChild(clockNode[0].node)
     end if
+
+    m.videoEndingTime = m.top.findNode("videoEndingTime")
 
     m.skipSegmentButton = m.top.findNode("skipSegment")
     m.skipSegmentButton.background = ColorPalette.LIGHTBLUE
@@ -806,6 +811,10 @@ sub onTrickPlayBarVisibleChange()
         trickplayImage.visible = m.top.trickPlayBar.visible
     end if
 
+    if isValid(m.videoEndingTime)
+        m.videoEndingTime.visible = m.top.trickPlayBar.visible
+    end if
+
     ' Don't show both the trickplay bar and the skip segment button at the same time
     if m.top.trickPlayBar.visible
         if m.skipSegmentButton.visible
@@ -814,8 +823,51 @@ sub onTrickPlayBarVisibleChange()
     end if
 end sub
 
+sub setVideoEndingTime()
+    m.clock = m.osd.findNode("clock")
+    if not isValid(m.clock) then return
+
+    currentTime = m.clock.callFunc("getCurrentTime")
+    remainingTime = getremainingTime()
+
+    videoEndingTime = m.clock.callFunc("getFormattedTime", (currentTime + remainingTime))
+
+    m.videoEndingTime.text = videoEndingTime
+    m.osd.videoEndingTime = videoEndingTime
+end sub
+
+function getRemainingTime()
+    if not isChainValid(m.positionText, "text")
+        return m.top.duration - m.top.position
+    end if
+
+    seekTime = 0#
+    seekPosition = m.positionText.text.split(":")
+
+    if seekPosition.count() = 3
+        ' hours -> seconds
+        seekTime += seekPosition[0].toint() * 3600
+        ' minutes -> seconds
+        seekTime += seekPosition[1].toint() * 60
+    end if
+
+    ' minutes -> seconds
+    if seekPosition.count() = 2
+        seekTime += seekPosition[0].toint() * 60
+    end if
+
+    ' add seconds
+    seekTime += seekPosition[seekPosition.count() - 1].toint()
+
+    seekTime = seekTime = 0 ? m.top.position : seekTime
+
+    return m.top.duration - seekTime
+end function
+
 sub onTrickPlayBarTextChange()
     if not m.top.trickPlayBar.visible then return
+
+    setVideoEndingTime()
 
     ' If Roku has pulled thumbnailtiles from the video stream, use them instead
     if not m.global.session.user.settings["playback.trickplay.forcecustom"]

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -811,8 +811,10 @@ sub onTrickPlayBarVisibleChange()
         trickplayImage.visible = m.top.trickPlayBar.visible
     end if
 
-    if isValid(m.videoEndingTime)
-        m.videoEndingTime.visible = m.top.trickPlayBar.visible
+    if not m.top.content.live
+        if isValid(m.videoEndingTime)
+            m.videoEndingTime.visible = m.top.trickPlayBar.visible
+        end if
     end if
 
     ' Don't show both the trickplay bar and the skip segment button at the same time
@@ -826,6 +828,9 @@ end sub
 sub setVideoEndingTime()
     m.clock = m.osd.findNode("clock")
     if not isValid(m.clock) then return
+    if not isValid(m.top.content) then return
+
+    if m.top.content.live then return
 
     currentTime = m.clock.callFunc("getCurrentTime")
     remainingTime = getremainingTime()

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -835,7 +835,7 @@ sub setVideoEndingTime()
     currentTime = m.clock.callFunc("getCurrentTime")
     remainingTime = getremainingTime()
 
-    videoEndingTime = m.clock.callFunc("getFormattedTime", (currentTime + remainingTime))
+    videoEndingTime = m.clock.callFunc("getFormattedTime", (currentTime + remainingTime), false)
 
     m.videoEndingTime.text = videoEndingTime
     m.osd.videoEndingTime = videoEndingTime

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -41,6 +41,8 @@
       </LabelList>
     </Rectangle>
 
+    <Text id="videoEndingTime" font="font:SmallSystemFont" color="0xffffffFF" horizAlign="right" width="200" translation="[1617,900]" visible="false" />
+
     <StandardButton id="skipSegment" visible="false" height="85" width="250" translation="[1500, 900]" />
   </children>
 </component>

--- a/source/static/whatsNew/3.0.4.json
+++ b/source/static/whatsNew/3.0.4.json
@@ -20,6 +20,10 @@
     "author": "1hitsong"
   },
   {
+    "description": "Display video ending time above seekbar",
+    "author": "1hitsong"
+  },
+  {
     "description": "Fix several crashes across app",
     "author": "1hitsong"
   }


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Adds a timestamp above the seekbar in both the OSD and Roku's seek screen indicating the time when the current video will end. This time is dynamic and updates based on seek position and current time.

This means if the user moves the seek bar to a new position, the end timestamp changes as needed.

It also means if the user pauses the video and the time on the clock changes, the end timestamp will change as needed.

Reminder, the video positions are based on seconds, but the clock only displays down to minutes. So just because a minute rolls over, doesn't mean the displayed timestamp will change.

## Issues
Fixes #335

## Screenshot
![WIN_20250518_15_34_25_Pro](https://github.com/user-attachments/assets/036b0cf3-08cf-4d61-9371-9fc0ec8da7b1)
