### PR TITLE
Create a solid background so user's selected bg image doesn't bleed over

### DIFF
--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -192,6 +192,19 @@ sub setBackdropImage(itemData as object)
         imageTag = itemData.ImageTags.Primary
     end if
 
+    ' Create a blank background so the user's background image doesn't bleed over
+    movieBackground = m.top.findNode("movieBackground")
+    if not isValid(movieBackground)
+        movieBackground = createObject("roSGNode", "Rectangle")
+    end if
+    movieBackground.id = "movieBackground"
+    movieBackground.width = "1920"
+    movieBackground.height = "1080"
+    movieBackground.color = "#000000"
+    if not isValid(m.top.findNode("movieBackdrop"))
+        m.top.insertChild(movieBackground, 0)
+    end if
+
     movieBackdrop = m.top.findNode("movieBackdrop")
     if not isValid(movieBackdrop)
         movieBackdrop = createObject("roSGNode", "Poster")
@@ -208,7 +221,7 @@ sub setBackdropImage(itemData as object)
     })
 
     if not isValid(m.top.findNode("movieBackdrop"))
-        m.top.insertChild(movieBackdrop, 0)
+        m.top.insertChild(movieBackdrop, 1)
     end if
 end sub
 

--- a/components/music/AudioPlayerView.bs
+++ b/components/music/AudioPlayerView.bs
@@ -176,6 +176,7 @@ end sub
 sub setupInfoNodes()
     m.albumCover = m.top.findNode("albumCover")
     m.backDrop = m.top.findNode("backdrop")
+    m.background = m.top.findNode("background")
     m.playPosition = m.top.findNode("playPosition")
     m.bufferPosition = m.top.findNode("bufferPosition")
     m.seekBar = m.top.findNode("seekBar")
@@ -511,6 +512,8 @@ sub onAudioDataChanged()
     else
         if isValid(currentItem.ParentBackdropItemId)
             setBackdropImage(ImageURL(currentItem.ParentBackdropItemId, ImageType.BACKDROP, { "maxHeight": "720", "maxWidth": "1280" }))
+        else
+            m.background.visible = false
         end if
 
         setPosterImage(ImageURL(currentItem.id, ImageType.PRIMARY, { "maxHeight": 500, "maxWidth": 500 }))
@@ -585,9 +588,7 @@ end sub
 sub onBackdropImageLoaded()
     data = m.LoadBackdropImageTask.content[0]
     m.LoadBackdropImageTask.unobserveField("content")
-    if isValid(data) and data <> ""
-        setBackdropImage(data)
-    end if
+    setBackdropImage(data)
 end sub
 
 sub onMetaDataLoaded()
@@ -642,10 +643,19 @@ end sub
 
 ' Add backdrop image to screen
 sub setBackdropImage(data)
-    if isValid(data)
-        if m.backDrop.uri <> data
-            m.backDrop.uri = data
-        end if
+    if not isValid(data)
+        m.background.visible = false
+        return
+    end if
+
+    if isStringEqual(data, string.EMPTY)
+        m.background.visible = false
+        return
+    end if
+
+    if m.backDrop.uri <> data
+        m.backDrop.uri = data
+        m.background.visible = true
     end if
 end sub
 

--- a/components/music/AudioPlayerView.xml
+++ b/components/music/AudioPlayerView.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="AudioPlayerView" extends="JFScreen">
   <children>
-    <Poster id="backdrop" opacity=".5" loadDisplayMode="scaleToZoom" width="1920" height="1200" blendColor="#3f3f3f" />
+    <Rectangle id="background" width="1920" height="1080" color="#000000" visible="false" />
+    <Poster id="backdrop" opacity=".3" loadDisplayMode="scaleToZoom" width="1920" height="1200" />
 
     <LayoutGroup translation="[100, 780]" layoutDirection="horiz" horizAlignment="left" itemSpacings="[10]">
       <Poster id="shuffleIndicator" width="50" height="50" uri="pkg:/images/icons/shuffleIndicator-off.png" opacity="0" />

--- a/source/static/whatsNew/3.0.4.json
+++ b/source/static/whatsNew/3.0.4.json
@@ -12,7 +12,7 @@
     "author": "michaelcresswell"
   },
   {
-    "description": "Create channel background image setting",
+    "description": "Create app background image setting",
     "author": "1hitsong"
   },
   {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
On screens where we set a full screen background image, the user's selected background image setting was bleeding over and looked terrible.

This PR adds a solid black background rectangle to the two screens we use full screen background images to cover the app's background so it doesn't bleed through.

1. Media detail screen (ref screenshots)
2. Audio player

## Screenshots
With this change
![WIN_20250524_09_34_59_Pro](https://github.com/user-attachments/assets/3a20e5c9-11f8-4f0c-844e-405d5133f6a6)

Without this change
![WIN_20250524_09_37_23_Pro](https://github.com/user-attachments/assets/da8f3da3-2659-4cac-ab63-88699b5157c3)

