### PR TITLE
Hide dropdown menus once you scroll down past the first row of items

### DIFF
--- a/components/Libraries/MusicLibraryView.bs
+++ b/components/Libraries/MusicLibraryView.bs
@@ -1,5 +1,7 @@
 import "pkg:/source/api/baserequest.bs"
 import "pkg:/source/api/Image.bs"
+import "pkg:/source/enums/AnimationControl.bs"
+import "pkg:/source/enums/AnimationState.bs"
 import "pkg:/source/enums/ColorPalette.bs"
 import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/enums/KeyCode.bs"
@@ -11,6 +13,11 @@ import "pkg:/source/utils/deviceCapabilities.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub setupNodes()
+    m.toggleDropdownOptionsAnimation = m.top.findNode("toggleDropdownOptionsAnimation")
+    m.dropdownOptionsMove = m.top.findNode("dropdownOptionsMove")
+    m.itemGridMove = m.top.findNode("itemGridMove")
+    m.genreListMove = m.top.findNode("genreListMove")
+    m.dropdownOptionsFade = m.top.findNode("dropdownOptionsFade")
     m.options = m.top.findNode("options")
     m.itemGrid = m.top.findNode("itemGrid")
     m.voiceBox = m.top.findNode("voiceBox")
@@ -279,6 +286,10 @@ sub loadInitialItems()
         SetBackground("")
     end if
 
+    if m.dropdownOptions.opacity < 1
+        toggleDropdownOptions(true)
+    end if
+
     m.sortField = m.global.session.user.settings["display." + m.top.parentItem.Id + ".sortField"]
     m.sortAscending = m.global.session.user.settings["display." + m.top.parentItem.Id + ".sortAscending"]
     m.filter = m.global.session.user.settings["display." + m.top.parentItem.Id + ".filter"]
@@ -319,8 +330,16 @@ sub loadInitialItems()
     m.loadItemsTask.view = "Artists"
     m.loadItemsTask.genreIds = ""
     m.itemGrid.translation = "[100, 210]"
-    m.itemGrid.numRows = "3"
+    m.itemGrid.numRows = "4"
     m.dropdownOptions.translation = "[100, 60]"
+    if m.dropdownOptions.opacity < 1
+        m.itemGrid.translation = "[100, 60]"
+    else
+        m.itemGrid.translation = "[100, 210]"
+    end if
+
+    m.dropdownOptionsMove.keyValue = "[[100, 60], [100, 0]]"
+    m.itemGridMove.keyValue = "[[100, 210], [100, 60]]"
     m.emptyText.translation = "[0, 540]"
 
     ' We're inside a genre
@@ -342,11 +361,25 @@ sub loadInitialItems()
         m.itemGrid.translation = "[100, 670]"
         m.itemGrid.numRows = "2"
         m.dropdownOptions.translation = "[100, 540]"
+        if m.dropdownOptions.opacity < 1
+            m.itemGrid.translation = "[100, 520]"
+        else
+            m.itemGrid.translation = "[100, 670]"
+        end if
+        m.dropdownOptionsMove.keyValue = "[[100, 540], [100, 480]]"
+        m.itemGridMove.keyValue = "[[100, 670], [100, 520]]"
     else if isStringEqual(m.view, "ArtistsPresentation")
         m.emptyText.translation = "[0, 750]"
         m.itemGrid.translation = "[100, 670]"
         m.itemGrid.numRows = "2"
         m.dropdownOptions.translation = "[100, 540]"
+        if m.dropdownOptions.opacity < 1
+            m.itemGrid.translation = "[100, 520]"
+        else
+            m.itemGrid.translation = "[100, 670]"
+        end if
+        m.dropdownOptionsMove.keyValue = "[[100, 540], [100, 480]]"
+        m.itemGridMove.keyValue = "[[100, 670], [100, 520]]"
     else if isStringEqual(m.view, "genres")
         m.loadItemsTask.itemType = ""
         m.loadItemsTask.recursive = true
@@ -742,6 +775,18 @@ end sub
 sub onItemFocused()
     focusedRow = m.itemGrid.currFocusRow
 
+    if m.itemGrid.isinFocusChain() or m.dropdownOptions.isinFocusChain()
+        if focusedRow = 0
+            if m.dropdownOptions.opacity < 1
+                toggleDropdownOptions(true)
+            end if
+        else if focusedRow > 0
+            if m.dropdownOptions.opacity > 0
+                toggleDropdownOptions(false)
+            end if
+        end if
+    end if
+
     itemInt = m.itemGrid.itemFocused
 
     ' If no selected item, set background to parent backdrop
@@ -903,9 +948,32 @@ end sub
 sub onGenreItemFocused()
     focusedRow = m.genreList.currFocusRow
 
+    if m.genreList.isinFocusChain()
+        if focusedRow = 0
+            if m.dropdownOptions.opacity < 1
+                toggleDropdownOptions(true)
+            end if
+        else if focusedRow > 0
+            if m.dropdownOptions.opacity > 0
+                toggleDropdownOptions(false)
+            end if
+        end if
+    end if
+
     ' Load more data if focus is within last 5 rows, and there are more items to load
     if focusedRow >= m.loadedRows - 5 and m.loadeditems < m.loadItemsTask.totalRecordCount
         loadMoreData()
+    end if
+end sub
+
+sub toggleDropdownOptions(runInReverse = false as boolean)
+    m.dropdownOptionsFade.reverse = runInReverse
+    m.dropdownOptionsMove.reverse = runInReverse
+    m.itemGridMove.reverse = runInReverse
+    m.genreListMove.reverse = runInReverse
+
+    if not isStringEqual(m.toggleDropdownOptionsAnimation.state, AnimationState.RUNNING)
+        m.toggleDropdownOptionsAnimation.control = AnimationControl.START
     end if
 end sub
 
@@ -1088,6 +1156,12 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     if isStringEqual(key, KeyCode.UP)
         if m.itemGrid.isinFocusChain() or m.genreList.isinFocusChain()
+
+            ' In case user quickly moves out of grid without focused row getting updated
+            if m.dropdownOptions.opacity < 1
+                toggleDropdownOptions(true)
+            end if
+
             overhangButton = getOverhangingButton()
             if overhangButton.isSubType("VoiceTextEditBox")
                 setSearchBackground(SearchButtonState.ACTIVE)

--- a/components/Libraries/MusicLibraryView.xml
+++ b/components/Libraries/MusicLibraryView.xml
@@ -19,7 +19,7 @@
       id="genrelist"
       itemComponentName="MusicArtistGridItem"
       numColumns="6"
-      numRows="3"
+      numRows="4"
       vertFocusAnimationStyle="fixed"
       translation="[100, 210]"
       itemSize="[270, 270]"
@@ -97,6 +97,12 @@
           width="335" />
       </LayoutGroup>
     </LayoutGroup>
+    <Animation id="toggleDropdownOptionsAnimation" duration="1" repeat="false" easeFunction="linear">
+      <FloatFieldInterpolator id="dropdownOptionsFade" key="[0.0, 1.0]" keyValue="[1.00, 0.00]" fieldToInterp="dropdownOptions.opacity" />
+      <Vector2DFieldInterpolator id="dropdownOptionsMove" key="[0.1, .9]" keyValue="[[100, 60], [100, 0]]" fieldToInterp="dropdownOptions.translation" />
+      <Vector2DFieldInterpolator id="itemGridMove" key="[0.1, .9]" keyValue="[[100, 210], [100, 60]]" fieldToInterp="itemGrid.translation" />
+      <Vector2DFieldInterpolator id="genreListMove" key="[0.1, .9]" keyValue="[[100, 210], [100, 60]]" fieldToInterp="genrelist.translation" />
+    </Animation>
 
     <Text id="selectedArtistName" visible="false" translation="[120, 40]" wrap="true" font="font:LargeBoldSystemFont" width="850" height="196" horizAlign="left" vertAlign="center" />
     <Poster id="artistLogo" visible="false" translation="[120, 40]" loadDisplayMode="scaleToFit" width="384" height="196" />

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -1,5 +1,7 @@
 import "pkg:/source/api/baserequest.bs"
 import "pkg:/source/api/Image.bs"
+import "pkg:/source/enums/AnimationControl.bs"
+import "pkg:/source/enums/AnimationState.bs"
 import "pkg:/source/enums/CollectionType.bs"
 import "pkg:/source/enums/ColorPalette.bs"
 import "pkg:/source/enums/ItemType.bs"
@@ -12,6 +14,11 @@ import "pkg:/source/utils/deviceCapabilities.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub setupNodes()
+    m.toggleDropdownOptionsAnimation = m.top.findNode("toggleDropdownOptionsAnimation")
+    m.dropdownOptionsMove = m.top.findNode("dropdownOptionsMove")
+    m.itemGridMove = m.top.findNode("itemGridMove")
+    m.genreListMove = m.top.findNode("genreListMove")
+    m.dropdownOptionsFade = m.top.findNode("dropdownOptionsFade")
     m.options = m.top.findNode("options")
     m.itemGrid = m.top.findNode("itemGrid")
     m.voiceBox = m.top.findNode("voiceBox")
@@ -90,6 +97,7 @@ sub init()
     m.itemGrid.content = m.data
 
     m.genreData = CreateObject("roSGNode", "ContentNode")
+    m.genreList.observeFieldScoped("itemFocused", "onGenreItemFocused")
     m.genreList.observeFieldScoped("itemSelected", "onGenreItemSelected")
     m.genreList.content = m.genreData
 
@@ -225,6 +233,10 @@ sub loadInitialItems()
         SetBackground(string.EMPTY)
     end if
 
+    if m.dropdownOptions.opacity < 1
+        toggleDropdownOptions(true)
+    end if
+
     m.sortField = m.global.session.user.settings["display." + m.top.parentItem.Id + ".sortField"]
     m.filter = m.global.session.user.settings["display." + m.top.parentItem.Id + ".filter"]
     m.filterOptions = m.global.session.user.settings["display." + m.top.parentItem.Id + ".filterOptions"]
@@ -343,7 +355,14 @@ sub loadInitialItems()
     end if
 
     m.dropdownOptions.translation = "[100, 540]"
-    m.itemGrid.translation = "[100, 670]"
+    if m.dropdownOptions.opacity < 1
+        m.itemGrid.translation = "[100, 520]"
+    else
+        m.itemGrid.translation = "[100, 670]"
+    end if
+    m.dropdownOptionsMove.keyValue = "[[100, 540], [100, 480]]"
+    m.itemGridMove.keyValue = "[[100, 670], [100, 520]]"
+
     m.emptyText.translation = "[0, 750]"
     m.itemGrid.itemSpacing = "[20, 20]"
 
@@ -362,7 +381,15 @@ sub loadInitialItems()
         m.backdrop.opacity = 0
         m.newBackdrop.opacity = 0
         m.itemLogo.visible = false
-        m.itemGrid.translation = "[100, 210]"
+
+        if m.dropdownOptions.opacity < 1
+            m.itemGrid.translation = "[100, 60]"
+        else
+            m.itemGrid.translation = "[100, 210]"
+        end if
+
+        m.dropdownOptionsMove.keyValue = "[[100, 60], [100, 0]]"
+        m.itemGridMove.keyValue = "[[100, 210], [100, 60]]"
         m.emptyText.translation = "[0, 540]"
         m.dropdownOptions.translation = "[100, 60]"
         m.itemGrid.numRows = "3"
@@ -375,7 +402,15 @@ sub loadInitialItems()
         m.backdrop.opacity = 0
         m.newBackdrop.opacity = 0
         m.itemLogo.visible = false
-        m.itemGrid.translation = "[100, 210]"
+
+        if m.dropdownOptions.opacity < 1
+            m.itemGrid.translation = "[100, 60]"
+        else
+            m.itemGrid.translation = "[100, 210]"
+        end if
+
+        m.dropdownOptionsMove.keyValue = "[[100, 60], [100, 0]]"
+        m.itemGridMove.keyValue = "[[100, 210], [100, 60]]"
         m.emptyText.translation = "[0, 540]"
         m.dropdownOptions.translation = "[100, 60]"
         m.itemGrid.numRows = "3"
@@ -447,13 +482,13 @@ sub setColumnSizes()
 
     m.itemGrid.itemSize = defaultSize
     m.itemGrid.rowHeights = [defaultSize[1]]
-    m.itemGrid.numRows = abs(1180 / (defaultSize[1] + m.itemGrid.itemSpacing[1]))
+    m.itemGrid.numRows = abs(1230 / (defaultSize[1] + m.itemGrid.itemSpacing[1]))
     m.itemGrid.numColumns = numberOfColumns
 
     m.genreList.itemSize = [1900, defaultSize[1] + 30]
     m.genreList.rowItemSize = [defaultSize]
     m.genreList.rowHeights = [defaultSize[1] + 30]
-    m.genreList.numRows = abs(1180 / (defaultSize[1] + m.genreList.itemSpacing[1]))
+    m.genreList.numRows = abs(1230 / (defaultSize[1] + m.genreList.itemSpacing[1]))
 end sub
 
 function setOptions() as object
@@ -960,10 +995,33 @@ sub SetBackground(backgroundUri as string)
     m.newBackdrop.uri = backgroundUri
 end sub
 
+sub toggleDropdownOptions(runInReverse = false as boolean)
+    m.dropdownOptionsFade.reverse = runInReverse
+    m.dropdownOptionsMove.reverse = runInReverse
+    m.itemGridMove.reverse = runInReverse
+    m.genreListMove.reverse = runInReverse
+
+    if not isStringEqual(m.toggleDropdownOptionsAnimation.state, AnimationState.RUNNING)
+        m.toggleDropdownOptionsAnimation.control = AnimationControl.START
+    end if
+end sub
+
 '
 'Handle new item being focused
 sub onItemFocused()
     focusedRow = m.itemGrid.currFocusRow
+
+    if m.itemGrid.isinFocusChain() or m.dropdownOptions.isinFocusChain()
+        if focusedRow = 0
+            if m.dropdownOptions.opacity < 1
+                toggleDropdownOptions(true)
+            end if
+        else if focusedRow > 0
+            if m.dropdownOptions.opacity > 0
+                toggleDropdownOptions(false)
+            end if
+        end if
+    end if
 
     itemInt = m.itemGrid.itemFocused
 
@@ -1179,6 +1237,24 @@ end function
 'Genre Item Selected
 sub onGenreItemSelected()
     m.top.selectedItem = m.genreList.content.getChild(m.genreList.rowItemSelected[0]).getChild(m.genreList.rowItemSelected[1])
+end sub
+
+'
+'Genre Item Focused
+sub onGenreItemFocused()
+    focusedRow = m.genreList.currFocusRow
+
+    if m.genreList.isinFocusChain()
+        if focusedRow = 0
+            if m.dropdownOptions.opacity < 1
+                toggleDropdownOptions(true)
+            end if
+        else if focusedRow > 0
+            if m.dropdownOptions.opacity > 0
+                toggleDropdownOptions(false)
+            end if
+        end if
+    end if
 end sub
 
 sub processDropdownState(searchTerm as string)
@@ -1506,6 +1582,12 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     if isStringEqual(key, KeyCode.UP)
         if m.itemGrid.isinFocusChain() or m.genreList.isinFocusChain()
+
+            ' In case user quickly moves out of grid without focused row getting updated
+            if m.dropdownOptions.opacity < 1
+                toggleDropdownOptions(true)
+            end if
+
             overhangButton = getOverhangingButton()
             if overhangButton.isSubType("VoiceTextEditBox")
                 setSearchBackground(SearchButtonState.ACTIVE)

--- a/components/Libraries/VisualLibraryScene.xml
+++ b/components/Libraries/VisualLibraryScene.xml
@@ -94,6 +94,12 @@
           width="335" />
       </LayoutGroup>
     </LayoutGroup>
+    <Animation id="toggleDropdownOptionsAnimation" duration="1" repeat="false" easeFunction="linear">
+      <FloatFieldInterpolator id="dropdownOptionsFade" key="[0.0, 1.0]" keyValue="[1.00, 0.00]" fieldToInterp="dropdownOptions.opacity" />
+      <Vector2DFieldInterpolator id="dropdownOptionsMove" key="[0.1, .9]" keyValue="[[100, 60], [100, 0]]" fieldToInterp="dropdownOptions.translation" />
+      <Vector2DFieldInterpolator id="itemGridMove" key="[0.1, .9]" keyValue="[[100, 210], [100, 60]]" fieldToInterp="itemGrid.translation" />
+      <Vector2DFieldInterpolator id="genreListMove" key="[0.1, .9]" keyValue="[[100, 210], [100, 60]]" fieldToInterp="genrelist.translation" />
+    </Animation>
 
     <Text id="selectedItemName" visible="false" translation="[120, 40]" wrap="true" font="font:LargeBoldSystemFont" width="850" height="196" horizAlign="left" vertAlign="center" />
     <Poster id="itemLogo" visible="false" translation="[120, 40]" loadDisplayMode="scaleToFit" width="384" height="196" />

--- a/source/enums/AnimationState.bs
+++ b/source/enums/AnimationState.bs
@@ -1,3 +1,5 @@
 enum AnimationState
+    PAUSED = "paused"
+    RUNNING = "running"
     STOPPED = "stopped"
 end enum

--- a/source/static/whatsNew/3.0.5.json
+++ b/source/static/whatsNew/3.0.5.json
@@ -2,5 +2,9 @@
   {
     "description": "Fix OSD auto hide",
     "author": "1hitsong"
+  },
+  {
+    "description": "Hide dropdown menus once you scroll down past the first row of items in a library",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Hides the library dropdown menus when you scroll down past the first row of items.

Shows the menus again if you scroll back up to the 1st row.

Changes applied to all libraries that show the dropdown menus.


## Demo Video
https://social.linux.pizza/@tgpo/114610184252128465
