### PR TITLE
Create landscape image column count setting

### DIFF
--- a/components/ItemGrid/GridItemMedium.bs
+++ b/components/ItemGrid/GridItemMedium.bs
@@ -27,6 +27,10 @@ sub init()
     'Parent is MarkupGrid and it's parent is the ItemGrid
     m.topParent = m.top.GetParent().GetParent()
 
+    if not isValid(m.topParent.showItemTitles)
+        m.topParent = m.topParent.GetParent().GetParent()
+    end if
+
     'Get the imageDisplayMode for these grid items
     if m.topParent.imageDisplayMode <> invalid
         m.itemPoster.loadDisplayMode = m.topParent.imageDisplayMode
@@ -62,6 +66,16 @@ end sub
 
 sub itemContentChanged()
     m.backdrop.blendColor = ColorPalette.ELEMENTBACKGROUND
+
+    m.title.visible = false
+    m.itemTextExtra.visible = false
+
+    if isValid(m.topParent.showItemTitles)
+        if LCase(m.topParent.showItemTitles) = "showalways"
+            m.title.visible = true
+            m.itemTextExtra.visible = true
+        end if
+    end if
 
     itemData = m.top.itemContent
 
@@ -157,6 +171,13 @@ sub focusChanged()
     else
         m.title.repeatCount = 0
         m.itemTextExtra.repeatCount = 0
+    end if
+
+    if isValid(m.topParent.showItemTitles)
+        if LCase(m.topParent.showItemTitles) = "showonhover"
+            m.title.visible = m.top.itemHasFocus
+            m.itemTextExtra.visible = m.top.itemHasFocus
+        end if
     end if
 end sub
 

--- a/components/ItemGrid/GridItemMedium.bs
+++ b/components/ItemGrid/GridItemMedium.bs
@@ -33,6 +33,33 @@ sub init()
     end if
 end sub
 
+sub onHeightChanged()
+    calculatedHeight = m.top.height
+
+    showItemTitles = chainLookupReturn(m.topParent, "showItemTitles", "showonhover")
+    if not isStringEqual(showItemTitles, "hidealways")
+        calculatedHeight -= 60
+    end if
+
+    m.backdrop.height = calculatedHeight
+    m.itemPoster.height = calculatedHeight
+    m.posterText.height = calculatedHeight
+    m.title.translation = [0, calculatedHeight + 30]
+    m.itemTextExtra.translation = [0, calculatedHeight + 60]
+
+    m.itemIconBackground.translation = [m.itemIconBackground.translation[0], calculatedHeight - 37]
+end sub
+
+sub onWidthChanged()
+    m.backdrop.width = m.top.width
+    m.itemPoster.width = m.top.width
+    m.posterText.width = m.top.width
+    m.title.maxWidth = m.top.width
+    m.itemTextExtra.maxWidth = m.top.width
+    m.playedIndicator.translation = [m.top.width - m.playedIndicator.width, 22]
+    m.itemIconBackground.translation = [m.top.width - m.itemIconBackground.width, m.itemIconBackground.translation[1]]
+end sub
+
 sub itemContentChanged()
     m.backdrop.blendColor = ColorPalette.ELEMENTBACKGROUND
 
@@ -89,21 +116,23 @@ sub itemContentChanged()
 
     m.itemIconBackground.visible = m.itemIcon.uri <> string.EMPTY
 
-    imageDimensions = chainLookup(itemData, "imageDimensions") ?? [400, 260]
-    m.itemPoster.width = imageDimensions[0]
-    m.backdrop.width = imageDimensions[0]
-    m.posterText.width = imageDimensions[0]
+    if isChainValid(itemData, "imageDimensions")
+        imageDimensions = itemData.imageDimensions
+        m.itemPoster.width = imageDimensions[0]
+        m.backdrop.width = imageDimensions[0]
+        m.posterText.width = imageDimensions[0]
 
-    m.title.maxWidth = imageDimensions[0] - 16
-    m.itemTextExtra.maxWidth = imageDimensions[0] - 16
+        m.title.maxWidth = imageDimensions[0] - 16
+        m.itemTextExtra.maxWidth = imageDimensions[0] - 16
 
-    m.itemPoster.height = imageDimensions[1]
-    m.backdrop.height = imageDimensions[1]
-    m.posterText.height = imageDimensions[1] + 40
+        m.itemPoster.height = imageDimensions[1]
+        m.backdrop.height = imageDimensions[1]
+        m.posterText.height = imageDimensions[1] + 40
 
-    m.playedIndicator.translation = [imageDimensions[0] - 60, m.playedIndicator.translation[1]]
-    m.title.translation = [m.title.translation[0], imageDimensions[1] + 30]
-    m.itemTextExtra.translation = [m.itemTextExtra.translation[0], imageDimensions[1] + 65]
+        m.playedIndicator.translation = [imageDimensions[0] - 60, m.playedIndicator.translation[1]]
+        m.title.translation = [m.title.translation[0], imageDimensions[1] + 30]
+        m.itemTextExtra.translation = [m.itemTextExtra.translation[0], imageDimensions[1] + 65]
+    end if
 
     m.itemPoster.uri = itemData.PosterUrl
     m.posterText.text = itemData.title

--- a/components/ItemGrid/GridItemMedium.xml
+++ b/components/ItemGrid/GridItemMedium.xml
@@ -14,6 +14,8 @@
     <PlayedCheckmark id="playedIndicator" translation="[340, 22]" />
   </children>
   <interface>
+    <field id="height" type="float" onChange="onHeightChanged" />
+    <field id="width" type="float" onChange="onWidthChanged" />
     <field id="itemContent" type="node" onChange="itemContentChanged" />
     <field id="itemHasFocus" type="boolean" onChange="focusChanged" alwaysNotify="true" />
   </interface>

--- a/components/ItemGrid/LoadItemsTask2.bs
+++ b/components/ItemGrid/LoadItemsTask2.bs
@@ -275,8 +275,7 @@ sub loadItems()
                 else if LCase(item.Type) = "recording"
                     tmp = CreateObject("roSGNode", "RecordingData")
                 else if item.Type = "Genre"
-                    numberOfColumns = chainLookupReturn(m.global.session, "user.settings.numberOfColumns", "7")
-                    itemLimit = numberOfColumns.toInt()
+                    itemLimit = m.top.numberOfColumns ?? 7
 
                     tmp = CreateObject("roSGNode", "ContentNode")
                     tmp.title = item.name
@@ -290,7 +289,7 @@ sub loadItems()
                         Fields: "PrimaryImageAspectRatio,MediaSourceCount,BasicSyncInfo",
                         ImageTypeLimit: 1,
                         EnableImageTypes: "Primary",
-                        Limit: itemLimit - 1,
+                        Limit: itemLimit,
                         GenreIds: item.id,
                         EnableTotalRecordCount: false,
                         ParentId: m.top.itemId
@@ -319,6 +318,8 @@ sub loadItems()
                         row.FHDPOSTERURL = genreItemImage
                         row.HDPOSTERURL = genreItemImage
                         row.SDPOSTERURL = genreItemImage
+
+                        genreData.Items.Pop()
                     end if
 
                     for each genreItem in genreData.Items

--- a/components/ItemGrid/LoadItemsTask2.xml
+++ b/components/ItemGrid/LoadItemsTask2.xml
@@ -18,6 +18,7 @@
     <field id="studioIds" type="string" value="" />
     <field id="genreIds" type="string" value="" />
     <field id="view" type="string" value="" />
+    <field id="numberOfColumns" type="integer" value="7" />
     <!-- Total records available from server-->
     <field id="totalRecordCount" type="int" value="-1" />
     <field id="content" type="array" />

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -4,6 +4,7 @@ import "pkg:/source/enums/AnimationControl.bs"
 import "pkg:/source/enums/AnimationState.bs"
 import "pkg:/source/enums/CollectionType.bs"
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/enums/ImageLayout.bs"
 import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/enums/KeyCode.bs"
 import "pkg:/source/enums/SearchButtonState.bs"
@@ -12,6 +13,11 @@ import "pkg:/source/enums/TaskControl.bs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/deviceCapabilities.bs"
 import "pkg:/source/utils/misc.bs"
+
+const ASPECT_RATIO_PORTRAIT_NO_TITLE = 1.52173
+const ASPECT_RATIO_LANDSCAPE_NO_TITLE = .825
+const ASPECT_RATIO_PORTRAIT_WITH_TITLE = 1.69565
+const ASPECT_RATIO_LANDSCAPE_WITH_TITLE = .925
 
 sub setupNodes()
     m.librarySettings = m.top.findNode("librarySettings")
@@ -481,8 +487,10 @@ sub loadInitialItems()
         m.genreList.rowHeights = "[360]"
     end if
 
-    if not inArray([ItemType.PHOTO, ItemType.PHOTOALBUM, ItemType.MUSICVIDEO, ItemType.MYLIST], m.top.mediaType)
-        setColumnSizes()
+    if inArray([ItemType.PHOTO, ItemType.PHOTOALBUM, ItemType.MUSICVIDEO, ItemType.MYLIST], m.top.mediaType)
+        setColumnSizes(ImageLayout.LANDSCAPE)
+    else
+        setColumnSizes(ImageLayout.PORTRAIT)
     end if
 
     m.loadItemsTask.observeField("content", "ItemDataLoaded")
@@ -497,15 +505,23 @@ sub loadInitialItems()
     m.getFiltersTask.control = "RUN"
 end sub
 
-sub setColumnSizes()
-    numberOfColumns = chainLookupReturn(m.global.session, "user.settings.numberOfColumns", "7")
-    imageWidth = Val(chainLookupReturn(m.global.session, "user.settings.numberOfColumnsData", "230"))
+sub setColumnSizes(layout = ImageLayout.PORTRAIT as string)
+
+    if isStringEqual(layout, ImageLayout.PORTRAIT)
+        numberOfColumns = chainLookupReturn(m.global.session, "user.settings.numberOfColumnsPortrait", "7")
+        imageWidthData = val(chainLookupReturn(m.global.session, "user.settings.numberOfColumnsPortraitData", "230"))
+    else
+        numberOfColumns = chainLookupReturn(m.global.session, "user.settings.numberOfColumnsLandscape", "4")
+        imageWidthData = val(chainLookupReturn(m.global.session, "user.settings.numberOfColumnsLandscapeData", "400"))
+    end if
 
     if isStringEqual(m.top.showItemTitles, "hidealways")
-        defaultSize = [imageWidth, CInt(imageWidth * 1.52173)]
+        aspectRatio = isStringEqual(layout, ImageLayout.PORTRAIT) ? ASPECT_RATIO_PORTRAIT_NO_TITLE : ASPECT_RATIO_LANDSCAPE_NO_TITLE
     else
-        defaultSize = [imageWidth, CInt(imageWidth * 1.69565)]
+        aspectRatio = isStringEqual(layout, ImageLayout.PORTRAIT) ? ASPECT_RATIO_PORTRAIT_WITH_TITLE : ASPECT_RATIO_LANDSCAPE_WITH_TITLE
     end if
+
+    defaultSize = [imageWidthData, CInt(imageWidthData * aspectRatio)]
 
     m.itemGrid.itemSize = defaultSize
     m.itemGrid.rowHeights = [defaultSize[1]]
@@ -515,7 +531,9 @@ sub setColumnSizes()
     m.genreList.itemSize = [1900, defaultSize[1] + 30]
     m.genreList.rowItemSize = [defaultSize]
     m.genreList.rowHeights = [defaultSize[1] + 30]
-    m.genreList.numRows = abs(1230 / (defaultSize[1] + m.genreList.itemSpacing[1]))
+    m.genreList.numRows = abs(1180 / (defaultSize[1] + m.genreList.itemSpacing[1]))
+
+    m.loadItemsTask.numberOfColumns = numberOfColumns
 end sub
 
 function setOptions() as object

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -388,6 +388,7 @@ sub loadInitialItems()
 
     m.emptyText.translation = "[0, 750]"
     m.itemGrid.itemSpacing = "[20, 20]"
+    m.itemGrid.numRows = 3
 
     m.selectedItemOverview.visible = true
     m.infoGroup.visible = true
@@ -398,6 +399,7 @@ sub loadInitialItems()
     m.newBackdrop.opacity = 0
 
     m.emptyText.visible = false
+
 
     if isStringEqual(m.view, "grid")
         m.top.showItemTitles = m.global.session.user.settings["itemgrid.gridTitles"]
@@ -449,7 +451,7 @@ sub loadInitialItems()
         m.itemGrid.itemSize = "[400, 330]"
         m.itemGrid.rowHeights = "[330]"
         m.itemGrid.itemSpacing = "[40, 20]"
-        m.itemGrid.numColumns = "4"
+        m.itemGrid.numColumns = 4
         m.top.imageDisplayMode = "scaleToZoom"
     end if
 
@@ -458,7 +460,7 @@ sub loadInitialItems()
         m.itemGrid.itemSize = "[400, 330]"
         m.itemGrid.rowHeights = "[330]"
         m.itemGrid.itemSpacing = "[40, 20]"
-        m.itemGrid.numColumns = "4"
+        m.itemGrid.numColumns = 4
         m.top.imageDisplayMode = "scaleToZoom"
 
         m.genreList.itemComponentName = "GridItemMedium"
@@ -471,7 +473,7 @@ sub loadInitialItems()
         m.itemGrid.itemSize = "[400, 330]"
         m.itemGrid.rowHeights = "[330]"
         m.itemGrid.itemSpacing = "[40, 20]"
-        m.itemGrid.numColumns = "4"
+        m.itemGrid.numColumns = 4
         m.top.imageDisplayMode = "scaleToZoom"
 
         m.genreList.itemComponentName = "GridItemMedium"
@@ -479,7 +481,9 @@ sub loadInitialItems()
         m.genreList.rowHeights = "[360]"
     end if
 
-    setColumnSizes()
+    if not inArray([ItemType.PHOTO, ItemType.PHOTOALBUM, ItemType.MUSICVIDEO, ItemType.MYLIST], m.top.mediaType)
+        setColumnSizes()
+    end if
 
     m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.control = TaskControl.RUN
@@ -1577,10 +1581,9 @@ function getOverhangingButton()
             return shortButtonList[m.itemGrid.currFocusColumn]
         end if
 
-        numberOfColumns = chainLookupReturn(m.global.session, "user.settings.numberOfColumns", "7")
         buttonList = [m.voiceBox, m.sortButton, m.sortOrderButton, m.filterButton, m.viewButton]
 
-        columnDisplacement = (Val(numberOfColumns) / buttonList.count())
+        columnDisplacement = (m.itemGrid.numColumns / buttonList.count())
 
         calculatedButtonIndex = CInt(((m.itemGrid.currFocusColumn + 1) / columnDisplacement) - 1)
         if calculatedButtonIndex < 0 then calculatedButtonIndex = 0

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -5,9 +5,9 @@
     "visible": false,
     "children": [
       {
-        "title": "Library Column Count",
-        "description": "Number of columns in library view",
-        "settingName": "numberOfColumns",
+        "title": "Library Portrait Column Count",
+        "description": "Number of columns in library view when showing portrait (tall) images",
+        "settingName": "numberOfColumnsPortrait",
         "type": "slider",
         "default": "7",
         "options": [
@@ -34,6 +34,39 @@
               {
                 "value": "11",
                 "data": "139"
+              }
+            ]
+      },
+      {
+        "title": "Library Landscape Column Count",
+        "description": "Number of columns in library view when showing landscape (wide) images",
+        "settingName": "numberOfColumnsLandscape",
+        "type": "slider",
+        "default": "4",
+        "options": [
+              {
+                "value": "3",
+                "data": "550"
+              },
+              {
+                "value": "4",
+                "data": "400"
+              },
+              {
+                "value": "5",
+                "data": "313"
+              },
+              {
+                "value": "6",
+                "data": "255"
+              },
+              {
+                "value": "7",
+                "data": "212"
+              },
+              {
+                "value": "8",
+                "data": "181"
               }
             ]
       },

--- a/source/enums/ImageLayout.bs
+++ b/source/enums/ImageLayout.bs
@@ -1,0 +1,4 @@
+enum ImageLayout
+    LANDSCAPE = "landscape"
+    PORTRAIT = "portrait"
+end enum


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Creates column count setting for libraries and views that use landscape poster images. Due to their wider resolution, there is less room on screen for them, so the option values are reduced slightly.

This PR will fix the issue below, but will keep the setting in the secret menu until it's applied across all library views - currently it's on applied to libraries that use the visual library view.

## Issues
Fixes #366
