### PR TITLE
Fix end time when FF forward and skipping back

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1053,6 +1053,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             if seekTime = m.playbackEnum.null then return true
 
             m.top.seek = seekTime
+            m.positionText.text = secondsToHuman(seekTime, true)
             return true
         end if
 

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -132,7 +132,10 @@ sub handleChapterSkipAction(action as string)
         ' If there is no next chapter, exit
         if gotoChapter > m.chapters.count() - 1 then return
 
-        m.top.seek = m.chapters[gotoChapter].StartPositionTicks / 10000000#
+        newPosition = m.chapters[gotoChapter].StartPositionTicks / 10000000#
+        m.top.seek = newPosition
+        setVideoEndingTime(newPosition)
+        m.positionText.text = secondsToHuman(newPosition, true)
         return
     end if
 
@@ -141,7 +144,10 @@ sub handleChapterSkipAction(action as string)
         ' If there is no previous chapter, restart current chapter
         if gotoChapter < 0 then gotoChapter = 0
 
-        m.top.seek = m.chapters[gotoChapter].StartPositionTicks / 10000000#
+        newPosition = m.chapters[gotoChapter].StartPositionTicks / 10000000#
+        m.top.seek = newPosition
+        setVideoEndingTime(newPosition)
+        m.positionText.text = secondsToHuman(newPosition, true)
         return
     end if
 end sub
@@ -841,7 +847,7 @@ sub onTrickPlayBarVisibleChange()
     end if
 end sub
 
-sub setVideoEndingTime()
+sub setVideoEndingTime(videoSeekPosition = 0 as integer)
     m.clock = m.osd.findNode("clock")
     if not isValid(m.clock) then return
     if not isValid(m.top.content) then return
@@ -849,7 +855,7 @@ sub setVideoEndingTime()
     if m.top.content.live then return
 
     currentTime = m.clock.callFunc("getCurrentTime")
-    remainingTime = getremainingTime()
+    remainingTime = getremainingTime(videoSeekPosition)
 
     videoEndingTime = m.clock.callFunc("getFormattedTime", (currentTime + remainingTime), false)
 
@@ -857,7 +863,7 @@ sub setVideoEndingTime()
     m.osd.videoEndingTime = videoEndingTime
 end sub
 
-function getRemainingTime()
+function getRemainingTime(videoSeekPosition = 0 as integer)
     if not isChainValid(m.positionText, "text")
         return m.top.duration - m.top.position
     end if
@@ -880,6 +886,10 @@ function getRemainingTime()
     ' add seconds
     seekTime += seekPosition[seekPosition.count() - 1].toint()
 
+    if videoSeekPosition > 0
+        seekTime = videoSeekPosition
+    end if
+
     seekTime = seekTime = 0 ? m.top.position : seekTime
 
     return m.top.duration - seekTime
@@ -888,7 +898,7 @@ end function
 sub onTrickPlayBarTextChange()
     if not m.top.trickPlayBar.visible then return
 
-    setVideoEndingTime()
+    setVideoEndingTime(0)
 
     ' If Roku has pulled thumbnailtiles from the video stream, use them instead
     if not m.global.session.user.settings["playback.trickplay.forcecustom"]

--- a/source/static/whatsNew/3.0.5.json
+++ b/source/static/whatsNew/3.0.5.json
@@ -18,5 +18,9 @@
   {
     "description": "Create library specific watched checkmark setting",
     "author": "1hitsong"
+  },
+  {
+    "description": "Fix issue that can cause video end time to be incorrect",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Fix issue where end time can be wrong when you fast forward then skip back a chapter.

## Issues
Fixes #367