### PR TITLE
Reset cursor position when returning to library

### DIFF
--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -239,10 +239,16 @@ sub redrawItems()
     m.itemGrid.content = m.data
     m.data.appendChildren(itemGridContent)
 
+    ' Reset cursor back to its previous location
+    m.itemGrid.jumpToItem = m.itemGrid.itemFocused
+
     genreContent = m.genreData.getChildren(-1, 0)
     m.genreData = CreateObject("roSGNode", "ContentNode")
     m.genreList.content = m.genreData
     m.genreData.appendChildren(genreContent)
+
+    ' Reset cursor back to its previous location
+    m.genreList.jumpToRowItem = m.genreList.rowItemSelected
 end sub
 
 '


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Scroll down the movie library and click on a movie. Press back. The cursor is set back to the 1st item. This PR resets the cursor position back to the user's previous location.
