### PR TITLE
Refresh OSD data on demand if media is Live TV

### DIFF
--- a/components/data/ScheduleProgramData.bs
+++ b/components/data/ScheduleProgramData.bs
@@ -1,18 +1,23 @@
-import "pkg:/source/api/Image.bs"
 import "pkg:/source/api/baserequest.bs"
+import "pkg:/source/api/Image.bs"
 import "pkg:/source/utils/config.bs"
 
 sub setFields()
     json = m.top.json
 
-    startDate = createObject("roDateTime")
-    endDate = createObject("roDateTime")
-    startDate.FromISO8601String(json.StartDate)
-    endDate.FromISO8601String(json.EndDate)
+    if isChainValid(json, "StartDate")
+        startDate = createObject("roDateTime")
+        startDate.FromISO8601String(json.StartDate)
+        m.top.PlayStart = startDate.AsSeconds()
+    end if
+
+    if isChainValid(json, "EndDate")
+        endDate = createObject("roDateTime")
+        endDate.FromISO8601String(json.EndDate)
+        m.top.PlayDuration = endDate.AsSeconds() - m.top.PlayStart
+    end if
 
     m.top.Title = json.Name
-    m.top.PlayStart = startDate.AsSeconds()
-    m.top.PlayDuration = endDate.AsSeconds() - m.top.PlayStart
     m.top.Id = json.Id
     m.top.Description = json.overview
     m.top.EpisodeTitle = json.EpisodeTitle

--- a/components/video/OSD.bs
+++ b/components/video/OSD.bs
@@ -27,6 +27,7 @@ sub init()
     m.top.observeField("videoEndingTime", "setVideoEndingTime")
 
     m.top.observeField("itemTitleText", "onItemTitleTextChanged")
+    m.top.observeField("itemSubtitleText", "onItemSubtitleTextChanged")
     m.top.observeField("seasonNumber", "onSeasonNumberChanged")
     m.top.observeField("episodeNumber", "onEpisodeNumberChanged")
     m.top.observeField("episodeNumberEnd", "onEpisodeNumberEndChanged")
@@ -91,6 +92,18 @@ end sub
 '
 sub onItemTitleTextChanged()
     m.itemTitle.text = m.top.itemTitleText
+end sub
+
+sub onItemSubtitleTextChanged()
+    itemSeason = m.top.findNode("itemSeason")
+    itemSeason.font.size = 32
+    itemSeason.text = m.top.itemSubtitleText
+
+    ' Move the option controls down to give room for season number
+    if not m.optionControlsMoved
+        moveOptionControls(0, OPTIONCONTROLS_TOP_PADDING)
+        m.optionControlsMoved = true
+    end if
 end sub
 
 ' onSeasonNumberChanged: Handler for changes to m.top.seasonNumber param.

--- a/components/video/OSD.xml
+++ b/components/video/OSD.xml
@@ -76,6 +76,7 @@
   </children>
   <interface>
     <field id="itemTitleText" type="string" />
+    <field id="itemSubtitleText" type="string" />
     <field id="seasonNumber" type="integer" />
     <field id="episodeNumber" type="integer" />
     <field id="episodeNumberEnd" type="integer" />

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -10,6 +10,9 @@ import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
+    m.LoadProgramDetailsTask = createObject("roSGNode", "LoadProgramDetailsTask")
+    m.LoadProgramDetailsTask.observeField("programDetails", "onProgramDetailsLoaded")
+
     ' Hide the overhang on init to prevent showing 2 clocks
     m.top.getScene().findNode("overhang").visible = false
     currentItem = m.global.queueManager.callFunc("getCurrentItem")
@@ -272,7 +275,17 @@ sub handleShowVideoOverviewPopupAction()
         m.overview = "No overview data available"
     end if
 
-    m.global.sceneManager.callFunc("standardDialog", m.top.content.title, { data: ["<p>" + m.overview + "</p>"] })
+    overviewPopupTitle = m.top.content.title
+
+    if m.top.content.live
+        if isValidAndNotEmpty(m.osd.itemSubtitleText)
+            overviewPopupTitle = m.osd.itemSubtitleText
+        else if isValidAndNotEmpty(m.osd.itemTitleText)
+            overviewPopupTitle = m.osd.itemTitleText
+        end if
+    end if
+
+    m.global.sceneManager.callFunc("standardDialog", overviewPopupTitle, { data: ["<p>" + m.overview + "</p>"] })
 end sub
 
 ' onOSDAction: Process action events from OSD to their respective handlers
@@ -1039,6 +1052,36 @@ sub skipCurrentSegment()
     m.top.seek = seekPosition
 end sub
 
+sub onProgramDetailsLoaded()
+    if not isChainValid(m.LoadProgramDetailsTask, "programDetails.json") then return
+
+    titleText = string.EMPTY
+
+    if isValidAndNotEmpty(m.LoadProgramDetailsTask.programDetails.json.CurrentProgram.ChannelNumber)
+        titleText += `${tr("CH")} ${m.LoadProgramDetailsTask.programDetails.json.CurrentProgram.ChannelNumber} `
+    end if
+
+    if isValidAndNotEmpty(m.LoadProgramDetailsTask.programDetails.json.CurrentProgram.Name)
+        titleText += m.LoadProgramDetailsTask.programDetails.json.CurrentProgram.Name
+    end if
+
+    m.osd.itemTitleText = titleText
+
+    if isValidAndNotEmpty(m.LoadProgramDetailsTask.programDetails.json.CurrentProgram.EpisodeTitle)
+        m.osd.itemSubtitleText = m.LoadProgramDetailsTask.programDetails.json.CurrentProgram.EpisodeTitle
+    else
+        m.osd.itemSubtitleText = string.EMPTY
+    end if
+
+    m.overview = m.LoadProgramDetailsTask.programDetails.json.CurrentProgram.Overview
+end sub
+
+sub refreshLiveOSDContent()
+    if not m.top.content.live then return
+    m.LoadProgramDetailsTask.programId = m.top.id
+    m.LoadProgramDetailsTask.control = TaskControl.RUN
+end sub
+
 function onKeyEvent(key as string, press as boolean) as boolean
     ' Keypress handler while user is inside the chapter menu
     if m.chapterMenu.hasFocus()
@@ -1094,6 +1137,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             if m.skipSegmentButton.visible
                 hideSegmentSkipButton()
             end if
+            refreshLiveOSDContent()
             m.osd.visible = true
             m.osd.hasFocus = true
             m.osd.setFocus(true)
@@ -1109,6 +1153,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             if m.skipSegmentButton.visible
                 hideSegmentSkipButton()
             end if
+            refreshLiveOSDContent()
             m.osd.visible = true
             m.osd.hasFocus = true
             m.osd.setFocus(true)
@@ -1125,6 +1170,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             if m.skipSegmentButton.visible
                 hideSegmentSkipButton()
             end if
+            refreshLiveOSDContent()
             m.osd.visible = true
             m.osd.hasFocus = true
             m.osd.setFocus(true)
@@ -1153,6 +1199,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             if m.skipSegmentButton.visible
                 hideSegmentSkipButton()
             end if
+            refreshLiveOSDContent()
             m.osd.visible = true
             m.osd.hasFocus = true
             m.osd.setFocus(true)

--- a/source/static/whatsNew/3.0.6.json
+++ b/source/static/whatsNew/3.0.6.json
@@ -1,1 +1,6 @@
-[]
+[
+  {
+    "description": "Refresh OSD data on demand if media is Live TV",
+    "author": "1hitsong"
+  }
+]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
If media is live, refresh OSD content when showing so it is up to date with possible program changes.

## Issues
Fixes #392