### PR TITLE
Create setting to customize number of columns in libraries

### DIFF
--- a/components/ItemGrid/AudioBookGridItem.bs
+++ b/components/ItemGrid/AudioBookGridItem.bs
@@ -4,6 +4,7 @@ import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
+    m.titleGroup = m.top.findNode("title_group")
     m.itemPoster = m.top.findNode("itemPoster")
     m.posterText = m.top.findNode("posterText")
     m.posterText.font.size = 26
@@ -27,6 +28,26 @@ sub init()
     end if
 
     m.gridTitles = m.global.session.user.settings["itemgrid.gridTitles"]
+end sub
+
+sub onHeightChanged()
+    calculatedHeight = m.top.height
+
+    showItemTitles = chainLookupReturn(m.topParent, "showItemTitles", "showonhover")
+    if not isStringEqual(showItemTitles, "hidealways")
+        calculatedHeight -= 65
+    end if
+
+    m.backdrop.height = calculatedHeight
+    m.itemPoster.height = calculatedHeight
+    m.titleGroup.translation = [0, calculatedHeight + 20]
+end sub
+
+sub onWidthChanged()
+    m.backdrop.width = m.top.width
+    m.itemPoster.width = m.top.width
+    m.posterText.maxwidth = m.top.width
+    m.subText.maxWidth = m.top.width
 end sub
 
 sub drawProgressBar(itemData)

--- a/components/ItemGrid/AudioBookGridItem.xml
+++ b/components/ItemGrid/AudioBookGridItem.xml
@@ -33,6 +33,8 @@
     </Animation>
   </children>
   <interface>
+    <field id="height" type="float" onChange="onHeightChanged" />
+    <field id="width" type="float" onChange="onWidthChanged" />
     <field id="itemContent" type="node" onChange="itemContentChanged" />
     <field id="itemHasFocus" type="boolean" onChange="focusChanged" />
   </interface>

--- a/components/ItemGrid/GridItemSmall.bs
+++ b/components/ItemGrid/GridItemSmall.bs
@@ -39,7 +39,7 @@ sub onHeightChanged()
     m.backdrop.height = calculatedHeight
     m.itemPoster.height = calculatedHeight
     m.posterText.height = calculatedHeight
-    m.title.translation = [0, calculatedHeight + 35]
+    m.title.translation = [0, calculatedHeight + 25]
 end sub
 
 sub onWidthChanged()

--- a/components/ItemGrid/MusicArtistGridItem.bs
+++ b/components/ItemGrid/MusicArtistGridItem.bs
@@ -21,7 +21,19 @@ sub init()
     m.gridTitles = m.global.session.user.settings["itemgrid.gridTitles"]
     m.posterText.visible = false
     m.postTextBackground.visible = false
+end sub
 
+sub onHeightChanged()
+    m.backdrop.height = m.top.height
+    m.itemPoster.height = m.top.height
+    m.postTextBackground.translation = [5, m.top.height - 40]
+end sub
+
+sub onWidthChanged()
+    m.backdrop.width = m.top.width
+    m.itemPoster.width = m.top.width
+    m.posterText.maxwidth = m.top.width
+    m.postTextBackground.width = m.top.width - 10
 end sub
 
 sub itemContentChanged()

--- a/components/ItemGrid/MusicArtistGridItem.xml
+++ b/components/ItemGrid/MusicArtistGridItem.xml
@@ -8,6 +8,8 @@
     </Rectangle>
   </children>
   <interface>
+    <field id="height" type="float" onChange="onHeightChanged" />
+    <field id="width" type="float" onChange="onWidthChanged" />
     <field id="itemContent" type="node" onChange="itemContentChanged" />
     <field id="itemHasFocus" type="boolean" onChange="focusChanged" />
   </interface>

--- a/components/Libraries/AudioBookLibraryView.bs
+++ b/components/Libraries/AudioBookLibraryView.bs
@@ -437,8 +437,4 @@ sub updateTitle()
     if m.options.view = "Studios" or m.view = "Studios"
         m.top.overhangTitle = "%s (%s)".Format(m.top.parentItem.title, tr("Studios"))
     end if
-
-    if m.options.view = "Genres" or m.view = "Genres"
-        m.top.overhangTitle = "%s (%s)".Format(m.top.parentItem.title, tr("Genres"))
-    end if
 end sub

--- a/components/Libraries/AudioBookLibraryView.bs
+++ b/components/Libraries/AudioBookLibraryView.bs
@@ -21,11 +21,6 @@ sub init()
 
     m.itemGrid.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 
-    m.genreList = m.top.findNode("genrelist")
-    m.genreList.observeField("itemSelected", "onGenreItemSelected")
-    m.genreData = CreateObject("roSGNode", "ContentNode")
-    m.genreList.content = m.genreData
-
     m.swapAnimation = m.top.findNode("backroundSwapAnimation")
     m.swapAnimation.observeField("state", "swapDone")
 
@@ -60,11 +55,6 @@ sub init()
     m.loadItemsTask.totalRecordCount = 0
 
     m.top.gridTitles = m.global.session.user.settings["itemgrid.gridTitles"]
-end sub
-
-'Genre Item Selected
-sub onGenreItemSelected()
-    m.top.selectedItem = m.genreList.content.getChild(m.genreList.rowItemSelected[0]).getChild(m.genreList.rowItemSelected[1])
 end sub
 
 'Load initial set of Data
@@ -113,11 +103,30 @@ sub loadInitialItems()
     m.loadItemsTask.recursive = true
     m.loadItemsTask.itemId = m.top.parentItem.Id
 
+    setColumnSizes()
 
     m.loadItemsTask.observeField("content", "ItemDataLoaded")
     startLoadingSpinner(false)
     m.loadItemsTask.control = "RUN"
     SetUpOptions()
+end sub
+
+sub setColumnSizes()
+    numberOfColumns = chainLookupReturn(m.global.session, "user.settings.numberOfColumnsSquare", "6")
+    imageWidthData = val(chainLookupReturn(m.global.session, "user.settings.numberOfColumnsSquareData", "270"))
+
+    defaultSize = [imageWidthData, imageWidthData]
+
+    if not isStringEqual(m.top.showItemTitles, "hidealways")
+        defaultSize = [imageWidthData, imageWidthData + 65]
+    end if
+
+    m.itemGrid.itemSize = defaultSize
+    m.itemGrid.rowHeights = [defaultSize[1]]
+    m.itemGrid.numRows = abs(1230 / (defaultSize[1] + m.itemGrid.itemSpacing[1]))
+    m.itemGrid.numColumns = numberOfColumns
+
+    m.loadItemsTask.numberOfColumns = numberOfColumns
 end sub
 
 ' Set Default view, sort, and filter options
@@ -190,34 +199,11 @@ sub ItemDataLoaded(msg)
         return
     end if
 
-    if m.loadItemsTask.view = "Genres"
-        ' Reset genre list data
-        m.genreData.removeChildren(m.genreData.getChildren(-1, 0))
-
-        for each item in itemData
-            m.genreData.appendChild(item)
-        end for
-
-        m.itemGrid.opacity = "0"
-        m.genreList.opacity = "1"
-
-        m.itemGrid.setFocus(false)
-        m.genreList.setFocus(true)
-        group = m.global.sceneManager.callFunc("getActiveScene")
-        group.lastFocus = m.genreList
-
-        m.loading = false
-        stopLoadingSpinner()
-        return
-    end if
-
     m.data.appendChildren(itemData)
 
     m.itemGrid.opacity = "1"
-    m.genreList.opacity = "0"
 
     m.itemGrid.setFocus(true)
-    m.genreList.setFocus(false)
     group = m.global.sceneManager.callFunc("getActiveScene")
     group.lastFocus = m.itemGrid
 
@@ -366,20 +352,15 @@ sub optionsClosed()
     end if
 
     m.itemGrid.setFocus(m.itemGrid.opacity = 1)
-    m.genreList.setFocus(m.genreList.opacity = 1)
 
     group = m.global.sceneManager.callFunc("getActiveScene")
-    group.lastFocus = m.itemGrid.opacity = 1 ? m.itemGrid : m.genreList
+    group.lastFocus = m.itemGrid
 end sub
 
 'Returns Focused Item
 function getItemFocused()
     if m.itemGrid.isinFocusChain() and isValid(m.itemGrid.itemFocused)
         return m.itemGrid.content.getChild(m.itemGrid.itemFocused)
-    else if m.genreList.isinFocusChain() and isValid(m.genreList.rowItemFocused)
-        return m.genreList.content.getChild(m.genreList.rowItemFocused[0]).getChild(m.genreList.rowItemFocused[1])
-    else if isValid(m.scheduleGrid) and m.scheduleGrid.isinFocusChain() and isValid(m.scheduleGrid.itemFocused)
-        return m.scheduleGrid.content.getChild(m.scheduleGrid.itemFocused)
     end if
     return invalid
 end function
@@ -459,13 +440,9 @@ sub updateTitle()
         m.top.overhangTitle = "%s (%s)".Format(m.top.parentItem.title, tr("Studios"))
     end if
 
-    if m.options.view = "Genres" or m.view = "Genres"
-        m.top.overhangTitle = "%s (%s)".Format(m.top.parentItem.title, tr("Genres"))
-    end if
-
     actInt = m.itemGrid.itemFocused + 1
 
-    if m.showItemCount and m.loadItemsTask.totalRecordCount > 0 and m.options.view <> "Genres" and m.view <> "Genres"
+    if m.showItemCount and m.loadItemsTask.totalRecordCount > 0
         m.top.overhangTitle += " (" + tr("%1 of %2").Replace("%1", actInt.toStr()).Replace("%2", m.loadItemsTask.totalRecordCount.toStr()) + ")"
     end if
 

--- a/components/Libraries/AudioBookLibraryView.bs
+++ b/components/Libraries/AudioBookLibraryView.bs
@@ -211,9 +211,7 @@ sub ItemDataLoaded(msg)
         return
     end if
 
-    for each item in itemData
-        m.data.appendChild(item)
-    end for
+    m.data.appendChildren(itemData)
 
     m.itemGrid.opacity = "1"
     m.genreList.opacity = "0"

--- a/components/Libraries/AudioBookLibraryView.xml
+++ b/components/Libraries/AudioBookLibraryView.xml
@@ -8,27 +8,9 @@
       id="itemGrid"
       translation="[96, 60]"
       itemComponentName="AudioBookGridItem"
-      numColumns="5"
-      numRows="3"
-      rowHeights="[355]"
       vertFocusAnimationStyle="fixed"
-      itemSize="[290, 355]"
-      itemSpacing="[40, 40]"
+      itemSpacing="[20, 20]"
       drawFocusFeedback="true" />
-
-    <RowList
-      opacity="0"
-      id="genrelist"
-      translation="[120, 160]"
-      showRowLabel="true"
-      itemComponentName="GridItemSmall"
-      numColumns="1"
-      numRows="3"
-      vertFocusAnimationStyle="fixed"
-      itemSize="[1900, 360]"
-      rowItemSize="[ [230, 345] ]"
-      rowItemSpacing="[ [20, 0] ]"
-      itemSpacing="[0, 60]" />
 
     <Text translation="[0,540]" id="emptyText" font="font:LargeSystemFont" width="1910" horizAlign="center" vertAlign="center" height="64" visible="false" />
     <ItemGridOptions id="options" visible="false" />

--- a/components/Libraries/LiveTVLibraryView.bs
+++ b/components/Libraries/LiveTVLibraryView.bs
@@ -1,11 +1,17 @@
 import "pkg:/source/api/baserequest.bs"
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/enums/ImageLayout.bs"
 import "pkg:/source/enums/KeyCode.bs"
 import "pkg:/source/enums/String.bs"
 import "pkg:/source/enums/TaskControl.bs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/deviceCapabilities.bs"
 import "pkg:/source/utils/misc.bs"
+
+const ASPECT_RATIO_PORTRAIT_NO_TITLE = 1.52173
+const ASPECT_RATIO_LANDSCAPE_NO_TITLE = .825
+const ASPECT_RATIO_PORTRAIT_WITH_TITLE = 1.69565
+const ASPECT_RATIO_LANDSCAPE_WITH_TITLE = .925
 
 sub init()
     overhang = m.top.getScene().findNode("overhang")
@@ -50,6 +56,8 @@ sub init()
 
     m.loadItemsTask = createObject("roSGNode", "LoadItemsTask2")
 
+    setColumnSizes(ImageLayout.PORTRAIT)
+
     'set inital counts for overhang before content is loaded.
     m.loadItemsTask.totalRecordCount = 0
 
@@ -59,22 +67,36 @@ sub init()
     m.top.gridTitles = m.global.session.user.settings["itemgrid.gridTitles"]
 end sub
 
+sub setColumnSizes(layout = ImageLayout.PORTRAIT as string)
+
+    if isStringEqual(layout, ImageLayout.PORTRAIT)
+        numberOfColumns = chainLookupReturn(m.global.session, "user.settings.numberOfColumnsPortrait", "7")
+        imageWidthData = val(chainLookupReturn(m.global.session, "user.settings.numberOfColumnsPortraitData", "230"))
+    else
+        numberOfColumns = chainLookupReturn(m.global.session, "user.settings.numberOfColumnsLandscape", "4")
+        imageWidthData = val(chainLookupReturn(m.global.session, "user.settings.numberOfColumnsLandscapeData", "400"))
+    end if
+
+    if isStringEqual(m.top.showItemTitles, "hidealways")
+        aspectRatio = isStringEqual(layout, ImageLayout.PORTRAIT) ? ASPECT_RATIO_PORTRAIT_NO_TITLE : ASPECT_RATIO_LANDSCAPE_NO_TITLE
+    else
+        aspectRatio = isStringEqual(layout, ImageLayout.PORTRAIT) ? ASPECT_RATIO_PORTRAIT_WITH_TITLE : ASPECT_RATIO_LANDSCAPE_WITH_TITLE
+    end if
+
+    defaultSize = [imageWidthData, CInt(imageWidthData * aspectRatio)]
+
+    m.itemGrid.itemSize = defaultSize
+    m.itemGrid.rowHeights = [defaultSize[1]]
+    m.itemGrid.numRows = abs(1230 / (defaultSize[1] + m.itemGrid.itemSpacing[1]))
+    m.itemGrid.numColumns = numberOfColumns
+
+    m.loadItemsTask.numberOfColumns = numberOfColumns
+end sub
+
 'Load initial set of Data
 sub loadInitialItems()
     m.loadItemsTask.control = "stop"
     startLoadingSpinner()
-
-    m.itemGrid.itemComponentName = "GridItemSmall"
-    m.itemGrid.numColumns = "7"
-    m.itemGrid.numRows = "3"
-
-    if LCase(m.top.showItemTitles) = "hidealways"
-        m.itemGrid.itemSize = "[230, 345]"
-        m.itemGrid.rowHeights = "[345]"
-    else
-        m.itemGrid.itemSize = "[230, 390]"
-        m.itemGrid.rowHeights = "[390]"
-    end if
 
     if m.top.parentItem.json.Type = "CollectionFolder"
         m.top.HomeLibraryItem = m.top.parentItem.Id

--- a/components/Libraries/LiveTVLibraryView.xml
+++ b/components/Libraries/LiveTVLibraryView.xml
@@ -1,32 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<component name="ItemGrid" extends="JFScreen">
+<component name="LiveTVLibraryView" extends="JFGroup">
   <children>
     <VoiceTextEditBox id="VoiceBox" visible="true" width="0" translation="[33, 40]" />
+    <Alpha id="alpha" />
 
-    <poster id="backdrop" loadDisplayMode="scaleToFill" width="1920" height="1080" opacity="0.25" />
-    <poster id="backdropTransition" loadDisplayMode="scaleToFill" width="1920" height="1080" opacity="0.25" />
-
-    <RowList
-      opacity="0"
-      id="genrelist"
-      translation="[120, 160]"
-      showRowLabel="true"
+    <MarkupGrid
+      id="itemGrid"
+      translation="[96, 60]"
       itemComponentName="GridItemSmall"
-      numColumns="1"
-      numRows="3"
       vertFocusAnimationStyle="fixed"
-      itemSize="[1900, 360]"
-      rowItemSize="[ [230, 345] ]"
-      rowItemSpacing="[ [20, 0] ]"
-      itemSpacing="[0, 60]" />
-
+      itemSpacing="[20, 20]"
+      drawFocusFeedback="true"
+    />
     <Text translation="[0,540]" id="emptyText" font="font:LargeSystemFont" width="1910" horizAlign="center" vertAlign="center" height="64" visible="false" />
     <ItemGridOptions id="options" visible="false" />
-    <Animation id="backroundSwapAnimation" duration="1" repeat="false" easeFunction="linear">
-      <FloatFieldInterpolator id="fadeinLoading" key="[0.0, 1.0]" keyValue="[ 0.00, 0.25 ]" fieldToInterp="backdropTransition.opacity" />
-      <FloatFieldInterpolator id="fadeoutLoaded" key="[0.0, 1.0]" keyValue="[ 0.25, 0.00 ]" fieldToInterp="backdrop.opacity" />
-    </Animation>
-    <Alpha id="alpha" />
   </children>
   <interface>
     <field id="HomeLibraryItem" type="string" />

--- a/components/Libraries/MusicLibraryView.bs
+++ b/components/Libraries/MusicLibraryView.bs
@@ -3,6 +3,7 @@ import "pkg:/source/api/Image.bs"
 import "pkg:/source/enums/AnimationControl.bs"
 import "pkg:/source/enums/AnimationState.bs"
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/enums/ImageLayout.bs"
 import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/enums/KeyCode.bs"
 import "pkg:/source/enums/SearchButtonState.bs"
@@ -388,6 +389,8 @@ sub loadInitialItems()
         m.selectedArtistName.visible = false
     end if
 
+    setColumnSizes()
+
     m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.control = TaskControl.RUN
 
@@ -397,6 +400,25 @@ sub loadInitialItems()
         parentid: m.top.parentItem.Id
     }
     m.getFiltersTask.control = TaskControl.RUN
+end sub
+
+sub setColumnSizes()
+    numberOfColumns = chainLookupReturn(m.global.session, "user.settings.numberOfColumnsSquare", "6")
+    imageWidthData = val(chainLookupReturn(m.global.session, "user.settings.numberOfColumnsSquareData", "270"))
+
+    defaultSize = [imageWidthData, imageWidthData]
+
+    m.itemGrid.itemSize = defaultSize
+    m.itemGrid.rowHeights = [defaultSize[1]]
+    m.itemGrid.numRows = abs(1230 / (defaultSize[1] + m.itemGrid.itemSpacing[1]))
+    m.itemGrid.numColumns = numberOfColumns
+
+    m.genreList.itemSize = defaultSize
+    m.genreList.rowHeights = [defaultSize[1]]
+    m.genreList.numRows = abs(1230 / (defaultSize[1] + m.itemGrid.itemSpacing[1]))
+    m.genreList.numColumns = numberOfColumns
+
+    m.loadItemsTask.numberOfColumns = numberOfColumns
 end sub
 
 '
@@ -1116,30 +1138,21 @@ end sub
 
 ' Using the user's cursor position, determine which dropdown is above them
 function getOverhangingButton()
-    if m.itemGrid.isinFocusChain()
-        if m.itemGrid.numColumns = 4
-            buttonList = [m.voiceBox, m.sortButton, m.filterButton, m.viewButton]
-            return buttonList[m.itemGrid.itemFocused]
-        end if
+    gridNode = m.itemGrid.isinFocusChain() ? m.itemGrid : m.genreList
 
-        if m.itemGrid.numColumns = 6
-            if m.itemGrid.itemFocused <= 0 then return m.voiceBox
-            if m.itemGrid.itemFocused <= 2 then return m.sortButton
-            if m.itemGrid.itemFocused <= 3 then return m.sortOrderButton
-            if m.itemGrid.itemFocused <= 4 then return m.filterButton
-            return m.viewButton
-        end if
+    if gridNode.numColumns = 4
+        buttonList = [m.voiceBox, m.sortButton, m.filterButton, m.viewButton]
+        return buttonList[gridNode.currFocusColumn]
     end if
 
-    if m.genreList.isinFocusChain()
-        if m.genreList.itemFocused <= 0 then return m.voiceBox
-        if m.genreList.itemFocused <= 2 then return m.sortButton
-        if m.genreList.itemFocused <= 3 then return m.sortOrderButton
-        if m.genreList.itemFocused <= 4 then return m.filterButton
-        return m.viewButton
-    end if
+    buttonList = [m.voiceBox, m.sortButton, m.sortOrderButton, m.filterButton, m.viewButton]
 
-    return m.voiceBox
+    columnDisplacement = (gridNode.numColumns / buttonList.count())
+
+    calculatedButtonIndex = CInt(((gridNode.currFocusColumn + 1) / columnDisplacement) - 1)
+    if calculatedButtonIndex < 0 then calculatedButtonIndex = 0
+    if calculatedButtonIndex >= buttonList.count() then calculatedButtonIndex = buttonList.count() - 1
+    return buttonList[calculatedButtonIndex]
 end function
 
 function onKeyEvent(key as string, press as boolean) as boolean

--- a/components/Libraries/MusicLibraryView.bs
+++ b/components/Libraries/MusicLibraryView.bs
@@ -714,9 +714,7 @@ sub ItemDataLoaded(msg)
         group.lastFocus = m.itemGrid
     end if
 
-    for each item in itemData
-        m.data.appendChild(item)
-    end for
+    m.data.appendChildren(itemData)
 
     'Update the stored counts
     m.loadedItems = m.itemGrid.content.getChildCount()

--- a/components/Libraries/MusicLibraryView.xml
+++ b/components/Libraries/MusicLibraryView.xml
@@ -9,20 +9,14 @@
     <MarkupGrid
       id="itemGrid"
       itemComponentName="MusicArtistGridItem"
-      numColumns="6"
-      numRows="2"
       vertFocusAnimationStyle="fixed"
-      itemSize="[270, 270]"
       itemSpacing="[20, 20]" />
 
     <MarkupGrid
       id="genrelist"
       itemComponentName="MusicArtistGridItem"
-      numColumns="6"
-      numRows="4"
       vertFocusAnimationStyle="fixed"
       translation="[100, 210]"
-      itemSize="[270, 270]"
       itemSpacing="[20, 20]"
       opacity="0" />
 

--- a/components/Libraries/OtherLibrary.bs
+++ b/components/Libraries/OtherLibrary.bs
@@ -642,9 +642,7 @@ sub ItemDataLoaded(msg)
         return
     end if
 
-    for each item in itemData
-        m.data.appendChild(item)
-    end for
+    m.data.appendChildren(itemData)
 
     ' keep focus on alpha menu when loading new data
     if m.top.alphaActive

--- a/components/Libraries/OtherLibrary.bs
+++ b/components/Libraries/OtherLibrary.bs
@@ -2,6 +2,7 @@ import "pkg:/source/api/baserequest.bs"
 import "pkg:/source/enums/AnimationControl.bs"
 import "pkg:/source/enums/AnimationState.bs"
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/enums/ImageLayout.bs"
 import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/enums/KeyCode.bs"
 import "pkg:/source/enums/PosterLoadStatus.bs"
@@ -11,6 +12,11 @@ import "pkg:/source/enums/ViewLoadStatus.bs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/deviceCapabilities.bs"
 import "pkg:/source/utils/misc.bs"
+
+const ASPECT_RATIO_PORTRAIT_NO_TITLE = 1.52173
+const ASPECT_RATIO_LANDSCAPE_NO_TITLE = .825
+const ASPECT_RATIO_PORTRAIT_WITH_TITLE = 1.69565
+const ASPECT_RATIO_LANDSCAPE_WITH_TITLE = .925
 
 sub init()
     m.loadItemsTask1 = createObject("roSGNode", "LoadItemsTask")
@@ -70,6 +76,8 @@ sub init()
     m.getFiltersTask = createObject("roSGNode", "GetFiltersTask")
     m.getPlaylistDataTask = createObject("roSGNode", "GetPlaylistDataTask")
 
+    setColumnSizes(ImageLayout.PORTRAIT)
+
     'set inital counts for overhang before content is loaded.
     m.loadItemsTask.totalRecordCount = 0
 
@@ -86,12 +94,13 @@ sub createItemGrid()
     m.itemGrid.id = "itemGrid"
     m.itemGrid.translation = "[96, 60]"
     m.itemGrid.itemComponentName = "GridItemSmall"
-    m.itemGrid.numColumns = "7"
-    m.itemGrid.numRows = "3"
-    m.itemGrid.rowHeights = "[345]"
     m.itemGrid.vertFocusAnimationStyle = "fixed"
-    m.itemGrid.itemSize = "[230, 345]"
+    'm.itemGrid.numColumns = "7"
+    'm.itemGrid.numRows = "3"
+    'm.itemGrid.rowHeights = "[345]"
+    'm.itemGrid.itemSize = "[230, 345]"
     m.itemGrid.itemSpacing = "[20, 20]"
+
     m.itemGrid.drawFocusFeedback = "true"
     m.itemGrid.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.top.appendChild(m.itemGrid)
@@ -99,6 +108,37 @@ sub createItemGrid()
     m.itemGrid.observeField("itemSelected", "onItemSelected")
     m.itemGrid.content = m.data
     m.itemGrid.setFocus(true)
+end sub
+
+sub setColumnSizes(layout = ImageLayout.PORTRAIT as string)
+
+    if isStringEqual(layout, ImageLayout.PORTRAIT)
+        numberOfColumns = chainLookupReturn(m.global.session, "user.settings.numberOfColumnsPortrait", "7")
+        imageWidthData = val(chainLookupReturn(m.global.session, "user.settings.numberOfColumnsPortraitData", "230"))
+    else
+        numberOfColumns = chainLookupReturn(m.global.session, "user.settings.numberOfColumnsLandscape", "4")
+        imageWidthData = val(chainLookupReturn(m.global.session, "user.settings.numberOfColumnsLandscapeData", "400"))
+    end if
+
+    if isStringEqual(m.top.showItemTitles, "hidealways")
+        aspectRatio = isStringEqual(layout, ImageLayout.PORTRAIT) ? ASPECT_RATIO_PORTRAIT_NO_TITLE : ASPECT_RATIO_LANDSCAPE_NO_TITLE
+    else
+        aspectRatio = isStringEqual(layout, ImageLayout.PORTRAIT) ? ASPECT_RATIO_PORTRAIT_WITH_TITLE : ASPECT_RATIO_LANDSCAPE_WITH_TITLE
+    end if
+
+    defaultSize = [imageWidthData, CInt(imageWidthData * aspectRatio)]
+
+    m.itemGrid.itemSize = defaultSize
+    m.itemGrid.rowHeights = [defaultSize[1]]
+    m.itemGrid.numRows = abs(1230 / (defaultSize[1] + m.itemGrid.itemSpacing[1]))
+    m.itemGrid.numColumns = numberOfColumns
+
+    m.genreList.itemSize = [1900, defaultSize[1] + 30]
+    m.genreList.rowItemSize = [defaultSize]
+    m.genreList.rowHeights = [defaultSize[1] + 30]
+    m.genreList.numRows = abs(1180 / (defaultSize[1] + m.genreList.itemSpacing[1]))
+
+    m.loadItemsTask.numberOfColumns = numberOfColumns
 end sub
 
 'Genre Item Selected
@@ -110,20 +150,6 @@ end sub
 sub loadInitialItems()
     m.loadItemsTask.control = TaskControl.STOP
     startLoadingSpinner()
-
-    m.itemGrid.itemComponentName = "GridItemSmall"
-    m.itemGrid.numColumns = "7"
-    m.itemGrid.numRows = "3"
-
-    m.top.showItemTitles = m.global.session.user.settings["itemgrid.gridTitles"]
-
-    if isStringEqual(m.top.showItemTitles, "hidealways")
-        m.itemGrid.itemSize = "[230, 345]"
-        m.itemGrid.rowHeights = "[345]"
-    else
-        m.itemGrid.itemSize = "[230, 390]"
-        m.itemGrid.rowHeights = "[390]"
-    end if
 
     if isStringEqual(m.top.parentItem.json.Type, "CollectionFolder")
         m.top.HomeLibraryItem = m.top.parentItem.Id

--- a/components/Libraries/OtherLibrary.xml
+++ b/components/Libraries/OtherLibrary.xml
@@ -1,23 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
-<component name="LiveTVLibraryView" extends="JFGroup">
+<component name="OtherLibrary" extends="JFScreen">
   <children>
     <VoiceTextEditBox id="VoiceBox" visible="true" width="0" translation="[33, 40]" />
-    <Alpha id="alpha" />
 
-    <MarkupGrid
-      id="itemGrid"
-      translation="[96, 60]"
+    <poster id="backdrop" loadDisplayMode="scaleToFill" width="1920" height="1080" opacity="0.25" />
+    <poster id="backdropTransition" loadDisplayMode="scaleToFill" width="1920" height="1080" opacity="0.25" />
+
+    <RowList
+      opacity="0"
+      id="genrelist"
+      translation="[120, 160]"
+      showRowLabel="true"
       itemComponentName="GridItemSmall"
-      numColumns="7"
+      numColumns="1"
       numRows="3"
-      rowHeights="[345]"
       vertFocusAnimationStyle="fixed"
-      itemSize="[230, 345]"
-      itemSpacing="[20, 20]"
-      drawFocusFeedback="true"
-    />
+      itemSize="[1900, 360]"
+      rowItemSize="[ [230, 345] ]"
+      rowItemSpacing="[ [20, 0] ]"
+      itemSpacing="[0, 60]" />
+
     <Text translation="[0,540]" id="emptyText" font="font:LargeSystemFont" width="1910" horizAlign="center" vertAlign="center" height="64" visible="false" />
     <ItemGridOptions id="options" visible="false" />
+    <Animation id="backroundSwapAnimation" duration="1" repeat="false" easeFunction="linear">
+      <FloatFieldInterpolator id="fadeinLoading" key="[0.0, 1.0]" keyValue="[ 0.00, 0.25 ]" fieldToInterp="backdropTransition.opacity" />
+      <FloatFieldInterpolator id="fadeoutLoaded" key="[0.0, 1.0]" keyValue="[ 0.25, 0.00 ]" fieldToInterp="backdrop.opacity" />
+    </Animation>
+    <Alpha id="alpha" />
   </children>
   <interface>
     <field id="HomeLibraryItem" type="string" />

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -5,72 +5,6 @@
     "visible": false,
     "children": [
       {
-        "title": "Library Portrait Column Count",
-        "description": "Number of columns in library view when showing portrait (tall) images",
-        "settingName": "numberOfColumnsPortrait",
-        "type": "slider",
-        "default": "7",
-        "options": [
-              {
-                "value": "6",
-                "data": "272"
-              },
-              {
-                "value": "7",
-                "data": "230"
-              },
-              {
-                "value": "8",
-                "data": "198"
-              },
-              {
-                "value": "9",
-                "data": "175"
-              },
-              {
-                "value": "10",
-                "data": "154"
-              },
-              {
-                "value": "11",
-                "data": "139"
-              }
-            ]
-      },
-      {
-        "title": "Library Landscape Column Count",
-        "description": "Number of columns in library view when showing landscape (wide) images",
-        "settingName": "numberOfColumnsLandscape",
-        "type": "slider",
-        "default": "4",
-        "options": [
-              {
-                "value": "3",
-                "data": "550"
-              },
-              {
-                "value": "4",
-                "data": "400"
-              },
-              {
-                "value": "5",
-                "data": "313"
-              },
-              {
-                "value": "6",
-                "data": "255"
-              },
-              {
-                "value": "7",
-                "data": "212"
-              },
-              {
-                "value": "8",
-                "data": "181"
-              }
-            ]
-      },
-      {
         "title": "Color Settings",
         "description": "Change the colors of elements in the app",
         "children": [
@@ -649,6 +583,105 @@
                         "id": "hidealways"
                       }
                     ]
+                  }
+                ]
+              },
+              {
+                "title": "Library Landscape Column Count",
+                "description": "Number of columns in library view when showing landscape (wide) images",
+                "settingName": "numberOfColumnsLandscape",
+                "type": "slider",
+                "default": "4",
+                "options": [
+                  {
+                    "value": "3",
+                    "data": "550"
+                  },
+                  {
+                    "value": "4",
+                    "data": "400"
+                  },
+                  {
+                    "value": "5",
+                    "data": "313"
+                  },
+                  {
+                    "value": "6",
+                    "data": "255"
+                  },
+                  {
+                    "value": "7",
+                    "data": "212"
+                  },
+                  {
+                    "value": "8",
+                    "data": "181"
+                  }
+                ]
+              },
+              {
+                "title": "Library Portrait Column Count",
+                "description": "Number of columns in library view when showing portrait (tall) images",
+                "settingName": "numberOfColumnsPortrait",
+                "type": "slider",
+                "default": "7",
+                "options": [
+                  {
+                    "value": "6",
+                    "data": "272"
+                  },
+                  {
+                    "value": "7",
+                    "data": "230"
+                  },
+                  {
+                    "value": "8",
+                    "data": "198"
+                  },
+                  {
+                    "value": "9",
+                    "data": "175"
+                  },
+                  {
+                    "value": "10",
+                    "data": "154"
+                  },
+                  {
+                    "value": "11",
+                    "data": "139"
+                  }
+                ]
+              },
+              {
+                "title": "Library Square Column Count",
+                "description": "Number of columns in library view when showing square images",
+                "settingName": "numberOfColumnsSquare",
+                "type": "slider",
+                "default": "6",
+                "options": [
+                  {
+                    "value": "5",
+                    "data": "330"
+                  },
+                  {
+                    "value": "6",
+                    "data": "272"
+                  },
+                  {
+                    "value": "7",
+                    "data": "230"
+                  },
+                  {
+                    "value": "8",
+                    "data": "198"
+                  },
+                  {
+                    "value": "9",
+                    "data": "175"
+                  },
+                  {
+                    "value": "10",
+                    "data": "154"
                   }
                 ]
               }

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -476,7 +476,7 @@ sub onLibrarySelection(selectedItem)
     end if
 
     if isStringEqual(selectedItem.collectionType, CollectionType.NEXTUP)
-        group = CreateItemGrid(selectedItem)
+        group = CreateOtherLibrary(selectedItem)
         group.optionsAvailable = false
         m.global.sceneManager.callFunc("pushScene", group)
         return
@@ -488,7 +488,7 @@ sub onLibrarySelection(selectedItem)
         return
     end if
 
-    group = CreateItemGrid(selectedItem)
+    group = CreateOtherLibrary(selectedItem)
     m.global.sceneManager.callFunc("pushScene", group)
 end sub
 
@@ -632,7 +632,7 @@ sub onSelectedItemEvent(msg)
             else if isStringEqual(selectedItem.itemType, `${ItemType.MUSICVIDEO},${ItemType.FOLDER}`)
                 group = CreateVisualLibraryScene(selectedItem, ItemType.MUSICVIDEO)
             else
-                group = CreateItemGrid(selectedItem)
+                group = CreateOtherLibrary(selectedItem)
             end if
             m.global.sceneManager.callFunc("pushScene", group)
         else if isStringEqual(selectedItemType, "folder") and isStringEqual(selectedItem.json.LookupCI("type"), ItemType.PHOTOALBUM)
@@ -648,7 +648,7 @@ sub onSelectedItemEvent(msg)
             group = CreateLiveTVLibraryView(selectedItem)
             m.global.sceneManager.callFunc("pushScene", group)
         else if selectedItemType = "userview" or selectedItemType = "folder" or selectedItemType = "channel"
-            group = CreateItemGrid(selectedItem)
+            group = CreateOtherLibrary(selectedItem)
             m.global.sceneManager.callFunc("pushScene", group)
         else if selectedItemType = "episode" or selectedItemType = "recording"
             group = CreateMovieDetailsGroup(selectedItem)

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -902,11 +902,11 @@ function CreateSeasonDetailsGroupByID(seriesID as string, seasonID as string) as
     return group
 end function
 
-function CreateItemGrid(libraryItem as object) as dynamic
+function CreateOtherLibrary(libraryItem as object) as dynamic
     ' validate libraryItem
     if not isValid(libraryItem) then return invalid
 
-    group = CreateObject("roSGNode", "ItemGrid")
+    group = CreateObject("roSGNode", "OtherLibrary")
     group.parentItem = libraryItem
     group.optionsAvailable = true
     group.observeFieldScoped("selectedItem", m.port)

--- a/source/static/whatsNew/3.0.6.json
+++ b/source/static/whatsNew/3.0.6.json
@@ -6,5 +6,9 @@
   {
     "description": "Refresh OSD data on demand if media is Live TV",
     "author": "1hitsong"
+  },
+  {
+    "description": "Create setting to customize number of columns in libraries",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Adds support for column number setting to music, audiobook, and generic itemgrid libraries.
- Moves setting out of secret menu