### PR TITLE
Remove unused showItemCount setting

### DIFF
--- a/components/ItemGrid/ItemGrid.bs
+++ b/components/ItemGrid/ItemGrid.bs
@@ -20,8 +20,6 @@ sub init()
 
     m.options = m.top.findNode("options")
 
-    m.showItemCount = m.global.session.user.settings["itemgrid.showItemCount"]
-
     m.data = CreateObject("roSGNode", "ContentNode")
     createItemGrid()
 

--- a/components/Libraries/AudioBookLibraryView.bs
+++ b/components/Libraries/AudioBookLibraryView.bs
@@ -12,8 +12,6 @@ sub init()
 
     m.options = m.top.findNode("options")
 
-    m.showItemCount = m.global.session.user.settings["itemgrid.showItemCount"]
-
     m.itemGrid = m.top.findNode("itemGrid")
     m.backdrop = m.top.findNode("backdrop")
     m.newBackdrop = m.top.findNode("backdropTransition")
@@ -464,11 +462,4 @@ sub updateTitle()
     if m.options.view = "Genres" or m.view = "Genres"
         m.top.overhangTitle = "%s (%s)".Format(m.top.parentItem.title, tr("Genres"))
     end if
-
-    actInt = m.itemGrid.itemFocused + 1
-
-    if m.showItemCount and m.loadItemsTask.totalRecordCount > 0 and m.options.view <> "Genres" and m.view <> "Genres"
-        m.top.overhangTitle += " (" + tr("%1 of %2").Replace("%1", actInt.toStr()).Replace("%2", m.loadItemsTask.totalRecordCount.toStr()) + ")"
-    end if
-
 end sub

--- a/components/Libraries/MusicLibraryView.bs
+++ b/components/Libraries/MusicLibraryView.bs
@@ -73,8 +73,6 @@ sub init()
 
     m.overhang.isVisible = false
 
-    m.showItemCount = m.global.session.user.settings["itemgrid.showItemCount"]
-
     m.options.observeField("visible", "onOptionsVisibleChange")
     m.swapAnimation.observeField("state", "swapDone")
 

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -93,8 +93,6 @@ sub init()
 
     m.overhang.isVisible = false
 
-    m.showItemCount = m.global.session.user.settings["itemgrid.showItemCount"]
-
     m.swapAnimation.observeField("state", "swapDone")
     m.options.observeField("visible", "onOptionsVisibleChange")
 

--- a/components/liveTv/LiveTVLibraryView.bs
+++ b/components/liveTv/LiveTVLibraryView.bs
@@ -13,8 +13,6 @@ sub init()
 
     m.options = m.top.findNode("options")
 
-    m.showItemCount = m.global.session.user.settings["itemgrid.showItemCount"]
-
     m.tvGuide = invalid
     m.channelFocused = invalid
 

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -623,13 +623,6 @@
                 "description": "Settings that apply when Grid views are enabled.",
                 "children": [
                   {
-                    "title": "Item Count",
-                    "description": "Show item count in the library and index of selected item.",
-                    "settingName": "itemgrid.showItemCount",
-                    "type": "bool",
-                    "default": "false"
-                  },
-                  {
                     "title": "Item Titles",
                     "description": "Select when to show titles.",
                     "settingName": "itemgrid.gridTitles",

--- a/source/static/whatsNew/3.0.6.json
+++ b/source/static/whatsNew/3.0.6.json
@@ -6,5 +6,9 @@
   {
     "description": "Refresh OSD data on demand if media is Live TV",
     "author": "1hitsong"
+  },
+  {
+    "description": "Remove unused showItemCount setting",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
The showItemCount setting is not used in the app. This PR removes the setting and accompanying code.