### PR TITLE
Respect User Settings for Live TV

### DIFF
--- a/components/liveTv/ProgramDetails.bs
+++ b/components/liveTv/ProgramDetails.bs
@@ -58,7 +58,7 @@ sub init()
 
     m.focusAnimation.observeField("state", "onAnimationComplete")
 
-    m.userPreferenceDisplayNew = chainLookupReturn(m.global, "session.user.settings.`ui.guide.indicator.new`", true)
+    m.userPreferenceDisplayLive = chainLookupReturn(m.global, "session.user.settings.`ui.guide.indicator.live`", true)
     m.userPreferenceDisplayRepeat = chainLookupReturn(m.global, "session.user.settings.`ui.guide.indicator.repeat`", false)
 
     setupLabels()
@@ -165,7 +165,7 @@ sub programUpdated()
 
     m.episodeDetailsGroup.removeChildrenIndex(m.episodeDetailsGroup.getChildCount(), 0)
 
-    if prog.isLive and m.userPreferenceDisplayNew
+    if prog.isLive and m.userPreferenceDisplayLive
         m.episodeDetailsGroup.appendChild(m.isLiveGroup)
     else if prog.isRepeat and m.userPreferenceDisplayRepeat
         m.episodeDetailsGroup.appendChild(m.isRepeatGroup)

--- a/components/liveTv/ProgramDetails.bs
+++ b/components/liveTv/ProgramDetails.bs
@@ -58,8 +58,8 @@ sub init()
 
     m.focusAnimation.observeField("state", "onAnimationComplete")
 
-    m.userPreferenceDisplayNew = m.global.session.user.settings["ui.guide.indicator.new"]
-    m.userPreferenceDisplayRepeat = m.global.session.user.settings["ui.guide.indicator.repeat"]
+    m.userPreferenceDisplayNew = chainLookupReturn(m.global, "session.user.settings.`ui.guide.indicator.new`", true)
+    m.userPreferenceDisplayRepeat = chainLookupReturn(m.global, "session.user.settings.`ui.guide.indicator.repeat`", true)
 
     setupLabels()
 end sub

--- a/components/liveTv/ProgramDetails.bs
+++ b/components/liveTv/ProgramDetails.bs
@@ -59,7 +59,7 @@ sub init()
     m.focusAnimation.observeField("state", "onAnimationComplete")
 
     m.userPreferenceDisplayNew = chainLookupReturn(m.global, "session.user.settings.`ui.guide.indicator.new`", true)
-    m.userPreferenceDisplayRepeat = chainLookupReturn(m.global, "session.user.settings.`ui.guide.indicator.repeat`", true)
+    m.userPreferenceDisplayRepeat = chainLookupReturn(m.global, "session.user.settings.`ui.guide.indicator.repeat`", false)
 
     setupLabels()
 end sub

--- a/components/liveTv/ProgramDetails.bs
+++ b/components/liveTv/ProgramDetails.bs
@@ -58,6 +58,7 @@ sub init()
 
     m.focusAnimation.observeField("state", "onAnimationComplete")
 
+    m.userPreferenceDisplayNew = m.global.session.user.settings["ui.guide.indicator.new"]
     m.userPreferenceDisplayRepeat = m.global.session.user.settings["ui.guide.indicator.repeat"]
 
     setupLabels()
@@ -164,7 +165,7 @@ sub programUpdated()
 
     m.episodeDetailsGroup.removeChildrenIndex(m.episodeDetailsGroup.getChildCount(), 0)
 
-    if prog.isLive
+    if prog.isLive and m.userPreferenceDisplayNew
         m.episodeDetailsGroup.appendChild(m.isLiveGroup)
     else if prog.isRepeat and m.userPreferenceDisplayRepeat
         m.episodeDetailsGroup.appendChild(m.isRepeatGroup)

--- a/components/liveTv/ProgramDetails.bs
+++ b/components/liveTv/ProgramDetails.bs
@@ -58,6 +58,8 @@ sub init()
 
     m.focusAnimation.observeField("state", "onAnimationComplete")
 
+    m.userPreferenceDisplayRepeat = m.global.session.user.settings["ui.guide.indicator.repeat"]
+
     setupLabels()
 end sub
 
@@ -164,7 +166,7 @@ sub programUpdated()
 
     if prog.isLive
         m.episodeDetailsGroup.appendChild(m.isLiveGroup)
-    else if prog.isRepeat
+    else if prog.isRepeat and m.userPreferenceDisplayRepeat
         m.episodeDetailsGroup.appendChild(m.isRepeatGroup)
     end if
 

--- a/source/enums/LiveTVScreen.bs
+++ b/source/enums/LiveTVScreen.bs
@@ -1,0 +1,4 @@
+enum LiveTVScreen
+    CHANNELS = "channels"
+    GUIDE = "guide"
+end enum

--- a/source/static/whatsNew/3.0.6.json
+++ b/source/static/whatsNew/3.0.6.json
@@ -28,7 +28,7 @@
     "author": "1hitsong"
   },
   {
-    "description": "Honor user settings for landing page and displayed indicators in live TV",
+    "description": "Honor user settings for landing page and displayed live/repeat indicators in live TV",
     "author": "michaelcresswell"
   }
 ]

--- a/source/static/whatsNew/3.0.6.json
+++ b/source/static/whatsNew/3.0.6.json
@@ -26,5 +26,9 @@
   {
     "description": "Add Go To Artist to album option menu in recently added in music on home screen",
     "author": "1hitsong"
+  },
+  {
+    "description": "Honor user settings for landing page and displayed indicators in live TV",
+    "author": "michaelcresswell"
   }
 ]

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -252,17 +252,17 @@ namespace session
 
         ' Saves user's Live TV guide settings as Roku guide user settings.
         sub SaveUserGuideSettings(customPrefs as object)
-            displayNew = "true"
+            displayLive = "true"
             displayRepeat = "false"
             displayScreen = "guide"
 
             if isValid(customPrefs)
-                userPreferenceDisplayNew = customPrefs["guide-indicator-new"]
+                userPreferenceDisplayLive = customPrefs["guide-indicator-live"]
                 userPreferenceDisplayRepeat = customPrefs["guide-indicator-repeat"]
                 userPreferenceDisplayScreen = customPrefs["landing-livetv"]
 
-                if isValidAndNotEmpty(userPreferenceDisplayNew)
-                    displayNew = userPreferenceDisplayNew
+                if isValidAndNotEmpty(userPreferenceDisplayLive)
+                    displayLive = userPreferenceDisplayLive
                 end if
                 if isValidAndNotEmpty(userPreferenceDisplayRepeat)
                     displayRepeat = userPreferenceDisplayRepeat
@@ -274,7 +274,7 @@ namespace session
 
             end if
 
-            set_user_setting("ui.guide.indicator.new", displayNew)
+            set_user_setting("ui.guide.indicator.live", displayLive)
             set_user_setting("ui.guide.indicator.repeat", displayRepeat)
             set_user_setting("display.livetv.landing", displayScreen)
         end sub

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -267,7 +267,7 @@ namespace session
                 if isValidAndNotEmpty(userPreferenceDisplayRepeat)
                     displayRepeat = userPreferenceDisplayRepeat
                 end if
-                if isValidAndNotEmpty(userPreferenceDisplayScreen) and isStringEqual(userPreferenceDisplayScreen, "channels")
+                if isStringEqual(userPreferenceDisplayScreen, "channels")
                     ' Live TV has five options but Roku only supports guide and channels in this context
                     displayScreen = userPreferenceDisplayScreen
                 end if

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -252,17 +252,31 @@ namespace session
 
         ' Saves user's Live TV guide settings as Roku guide user settings.
         sub SaveUserGuideSettings(customPrefs as object)
+            displayNew = "true"
             displayRepeat = "true"
+            displayScreen = "guide"
 
             if isValid(customPrefs)
+                userPreferenceDisplayNew = customPrefs["guide-indicator-new"]
                 userPreferenceDisplayRepeat = customPrefs["guide-indicator-repeat"]
+                userPreferenceDisplayScreen = customPrefs["landing-livetv"]
 
+                if isValidAndNotEmpty(userPreferenceDisplayNew)
+                    displayNew = userPreferenceDisplayNew
+                end if
                 if isValidAndNotEmpty(userPreferenceDisplayRepeat)
                     displayRepeat = userPreferenceDisplayRepeat
                 end if
+                if isValidAndNotEmpty(userPreferenceDisplayScreen) and isStringEqual(userPreferenceDisplayScreen, "channels")
+                    ' Live TV has five options but Roku only supports guide and channels in this context
+                    displayScreen = userPreferenceDisplayScreen
+                end if
+
             end if
 
+            set_user_setting("ui.guide.indicator.new", displayNew)
             set_user_setting("ui.guide.indicator.repeat", displayRepeat)
+            set_user_setting("display.livetv.landing", displayScreen)
         end sub
 
         ' Saves user's web client home sections as Roku user settings.

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -234,6 +234,7 @@ namespace session
                     session.user.Update("Configuration", tmpConfig)
                 end if
 
+                session.user.SaveUserGuideSettings(jsonResponse.CustomPrefs)
                 session.user.SaveUserHomeSections(jsonResponse.CustomPrefs)
             else
                 ' User has no custom prefs. Save default home section values.
@@ -247,6 +248,21 @@ namespace session
                     homesection6: "none"
                 })
             end if
+        end sub
+
+        ' Saves user's Live TV guide settings as Roku guide user settings.
+        sub SaveUserGuideSettings(customPrefs as object)
+            displayRepeat = "true"
+
+            if isValid(customPrefs)
+                userPreferenceDisplayRepeat = customPrefs["guide-indicator-repeat"]
+
+                if isValidAndNotEmpty(userPreferenceDisplayRepeat)
+                    displayRepeat = userPreferenceDisplayRepeat
+                end if
+            end if
+
+            set_user_setting("ui.guide.indicator.repeat", displayRepeat)
         end sub
 
         ' Saves user's web client home sections as Roku user settings.

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -253,7 +253,7 @@ namespace session
         ' Saves user's Live TV guide settings as Roku guide user settings.
         sub SaveUserGuideSettings(customPrefs as object)
             displayNew = "true"
-            displayRepeat = "true"
+            displayRepeat = "false"
             displayScreen = "guide"
 
             if isValid(customPrefs)

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -1,6 +1,7 @@
 ' these are needed for ServerInfo() inside session.server.Populate()
 import "pkg:/source/api/baserequest.bs"
 import "pkg:/source/api/userauth.bs"
+import "pkg:/source/enums/LiveTVScreen.bs"
 import "pkg:/source/utils/misc.bs"
 
 namespace session
@@ -254,7 +255,7 @@ namespace session
         sub SaveUserGuideSettings(customPrefs as object)
             displayLive = "true"
             displayRepeat = "false"
-            displayScreen = "guide"
+            displayScreen = LiveTVScreen.Guide
 
             if isValid(customPrefs)
                 userPreferenceDisplayLive = customPrefs["guide-indicator-live"]
@@ -267,7 +268,7 @@ namespace session
                 if isValidAndNotEmpty(userPreferenceDisplayRepeat)
                     displayRepeat = userPreferenceDisplayRepeat
                 end if
-                if isStringEqual(userPreferenceDisplayScreen, "channels")
+                if isStringEqual(userPreferenceDisplayScreen, LiveTVScreen.CHANNELS)
                     ' Live TV has five options but Roku only supports guide and channels in this context
                     displayScreen = userPreferenceDisplayScreen
                 end if


### PR DESCRIPTION
## Changes
Allow user settings to influence Roku client behavior for the Live TV library type.

## Issues
Fixes #400
