### PR TITLE
Update chainLookupReturn to accept property names with periods

### DIFF
--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -378,22 +378,27 @@ end function
 ' @return {dynamic} value of final chain of properties
 function chainLookupReturn(root as dynamic, propertyPath as string, default as dynamic) as dynamic
     rootPath = root
-    properties = propertyPath.Split(".")
+
+    regex = CreateObject("roRegex", "[^\.`]+|`[^`]+`", "")
+    properties = regex.MatchAll(propertyPath)
 
     if not isValid(rootPath) then return default
 
     ' Root path is valid, and no properties were passed. Return state of root
     if properties.count() = 0 then return rootPath
-    if properties[0] = "" then return rootPath
+    if properties[0].count() = 0 then return rootPath
+    if properties[0][0] = "" then return rootPath
 
-    rootPath = rootPath.LookupCI(properties[0])
+    rootPath = rootPath.LookupCI(properties[0][0].Replace("`", ""))
 
     if not isValid(rootPath) then return default
+
+    propertyLength = Len(properties[0][0])
 
     properties.shift()
 
     if properties.count() <> 0
-        nextPath = properties.join(".")
+        nextPath = propertyPath.Mid(propertyLength + 1)
         return chainLookupReturn(rootPath, nextPath, default)
     end if
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Changes the chainLookupReturn function to accept property names with periods if wrapped in backticks `

Example: ```chainLookupReturn(m.global, "session.user.settings.`ui.guide.indicator.repeat`", true)``` checks for validity and looks up the value for m.global.session.user.settings["ui.guide.indicator.repeat"]

It also works if the backticks are not at the end of the propertychain.

Example: ```chainLookupReturn(m.global, "session.user.settings.`ui.guide.indicator.repeat`.subvalue", true)``` is allowed.
