### PR TITLE
Fix bug causing some audiobooks to show incorrect poster image in audio player

### DIFF
--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -229,11 +229,11 @@ function ItemMetaData(id as string)
         tmp = CreateObject("roSGNode", "MusicSongData")
 
         ' Try using song's parent for poster image
-        tmp.image = PosterImage(data.ParentId, { "MaxWidth": 500, "MaxHeight": 500 })
+        tmp.image = PosterImage(data.id, { "MaxWidth": 500, "MaxHeight": 500 })
 
         ' Song's parent poster image is no good, try using the song's poster image
         if not isValid(tmp.image)
-            tmp.image = PosterImage(data.id, { "MaxWidth": 500, "MaxHeight": 500 })
+            tmp.image = PosterImage(data.ParentId, { "MaxWidth": 500, "MaxHeight": 500 })
         end if
 
         tmp.json = data

--- a/source/static/whatsNew/3.0.6.json
+++ b/source/static/whatsNew/3.0.6.json
@@ -30,5 +30,9 @@
   {
     "description": "Honor user settings for landing page and displayed live/repeat indicators in live TV",
     "author": "michaelcresswell"
+  },
+  {
+    "description": "Fix bug causing some audiobooks to show incorrect poster image in audio player",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
For audiobook metadata lookup, look 1st to the item for the poster image URL instead of the parent item.

## Issues
Fixes #417

## Demo video showing fix
https://github.com/user-attachments/assets/649c0a15-1815-44c4-b590-2b8952c09040
