### PR TITLE
Fix show checkmark/unplayed count update bug

### DIFF
--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -891,6 +891,9 @@ function CreateSeasonDetailsGroupByID(seriesID as string, seasonID as string) as
     group.seasonData = seasonMetaData.json
     group.objects = TVEpisodes(seriesID, seasonID)
     group.episodeObjects = group.objects
+
+    group.observeField("refreshSeasonDetailsData", m.port)
+
     ' watch for button presses
     group.observeFieldScoped("selectedItem", m.port)
     group.observeField("quickPlayNode", m.port)

--- a/source/static/whatsNew/3.0.6.json
+++ b/source/static/whatsNew/3.0.6.json
@@ -34,5 +34,9 @@
   {
     "description": "Fix bug causing some audiobooks to show incorrect poster image in audio player",
     "author": "1hitsong"
+  },
+  {
+    "description": "Fix show checkmark/unplayed count update bug",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Add goStraightToEpisodeListing observer to episode list screens created when `goStraightToEpisodeListing` setting is enabled and series only has 1 season.

## Issues
Fixes #410
