### PR TITLE
Hide Skip Outro if back button pressed. Reset if user seeks video

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -91,6 +91,7 @@ sub init()
 
     'Play Next Episode button
     m.nextupbuttonseconds = m.global.session.user.settings["playback.nextupbuttonseconds"].ToInt()
+    m.originalNextupbuttonseconds = m.nextupbuttonseconds
 
     m.checkedForNextEpisode = false
     m.getNextEpisodeTask = createObject("roSGNode", "GetNextEpisodeTask")
@@ -680,6 +681,7 @@ sub onNextEpisodeDataLoaded()
     ' If there is no next episode, disable next episode button
     if m.getNextEpisodeTask.nextEpisodeData.Items.count() <> 2
         m.nextupbuttonseconds = 0
+        m.originalNextupbuttonseconds = 0
     end if
 end sub
 
@@ -710,7 +712,7 @@ sub displaySegmentSkipButton(segmentType as string, endticks as double)
     end if
 
     ' Check if button is already showing
-    if isStringEqual(m.skipSegmentButton.text, `Skip ${segmentType}`) then return
+    if isStringEqual(m.skipSegmentButton.text, `${tr("Skip")} ${segmentType}`) then return
 
     if m.osd.visible then return ' Don't show if OSD is visible
 
@@ -908,6 +910,8 @@ function getRemainingTime(videoSeekPosition = 0 as integer)
 end function
 
 sub onTrickPlayBarTextChange()
+    m.nextupbuttonseconds = m.originalNextupbuttonseconds
+
     if not m.top.trickPlayBar.visible then return
 
     setVideoEndingTime(0)
@@ -1207,6 +1211,15 @@ function onKeyEvent(key as string, press as boolean) as boolean
     end if
 
     if key = KeyCode.BACK
+        ' If user presses back when Skip Outro button is showing, hide button and disable it so it doesn't show again
+        if m.skipSegmentButton.visible
+            if isStringEqual(m.skipSegmentButton.text, `${tr("Skip")} ${MediaSegmentType.OUTRO}`)
+                m.nextupbuttonseconds = 0
+                hideSegmentSkipButton()
+                return true
+            end if
+        end if
+
         m.PreloadTrickplayImagesTask.method = "REMOVE"
         m.PreloadTrickplayImagesTask.control = TaskControl.RUN
 

--- a/source/static/whatsNew/3.0.6.json
+++ b/source/static/whatsNew/3.0.6.json
@@ -50,5 +50,9 @@
   {
     "description": "Increase shown buttons on detail screen from 5 to 6",
     "author": "1hitsong"
+  },
+  {
+    "description": "Hide Skip Outro if back button pressed. Reset if user seeks video",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
If user presses back button when Skip Outro button is showing, hide button and don't show again unless they seek the video, then allow button to show again as usual.

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
