### PR TITLE
Show next episode info when skip outro button is shown

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -145,7 +145,7 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
     end if
 
     ' If an episode does not have an outro segment, create a fake one at the user's requested timestamp
-    if isStringEqual(video.content.contenttype, ItemType.EPISODE)
+    if video.content.contenttype = 4
         if not hasOutroSegment
             if isValid(meta.json.RunTimeTicks)
                 if m.global.session.user.settings["playback.nextupbuttonseconds"].ToInt() <> 0

--- a/components/manager/QueueManager.bs
+++ b/components/manager/QueueManager.bs
@@ -1,6 +1,7 @@
 import "pkg:/source/api/baserequest.bs"
 import "pkg:/source/api/Image.bs"
 import "pkg:/source/api/Items.bs"
+import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/deviceCapabilities.bs"
 import "pkg:/source/utils/misc.bs"
@@ -425,6 +426,10 @@ function getItemType(item) as string
     if not isValid(item) then return ""
 
     if isValid(item.json) and isValid(item.json.mediatype) and item.json.mediatype <> ""
+        if isStringEqual(chainLookup(item, "type"), ItemType.EPISODE)
+            return ItemType.EPISODE
+        end if
+
         return LCase(item.json.mediatype)
     end if
 

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -740,13 +740,14 @@ sub displayNextItem()
     ' Disable for mixed playlists
     if m.global.queueManager.callFunc("getQueueUniqueTypes").count() <> 1 then return
 
+    ' Disable if we're at the end of the queue
+    if m.global.queueManager.callFunc("getPosition") >= m.global.queueManager.callFunc("getCount") - 1 then return
+
     ' Only show if next in queue is an episode
     currentQueuePosition = m.global.queueManager.callFunc("getPosition")
     nextItem = m.global.queueManager.callFunc("getItemByIndex", currentQueuePosition + 1)
+    if not isValid(nextItem) then return
     if not isStringEqual(nextItem.lookupCI("Type"), ItemType.EPISODE) then return
-
-    ' Disable if we're at the end of the queue
-    if m.global.queueManager.callFunc("getPosition") >= m.global.queueManager.callFunc("getCount") - 1 then return
 
     if m.nextUpInfoLoaded
         m.nextUp.visible = true

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -97,7 +97,6 @@ sub init()
 
     'Play Next Episode button
     m.nextupbuttonseconds = m.global.session.user.settings["playback.nextupbuttonseconds"].ToInt()
-    m.originalNextupbuttonseconds = m.nextupbuttonseconds
 
     m.checkedForNextEpisode = false
     m.getNextEpisodeTask = createObject("roSGNode", "GetNextEpisodeTask")
@@ -687,7 +686,6 @@ sub onNextEpisodeDataLoaded()
     ' If there is no next episode, disable next episode button
     if m.getNextEpisodeTask.nextEpisodeData.Items.count() <> 2
         m.nextupbuttonseconds = 0
-        m.originalNextupbuttonseconds = 0
     end if
 end sub
 
@@ -963,7 +961,7 @@ function getRemainingTime(videoSeekPosition = 0 as integer)
 end function
 
 sub onTrickPlayBarTextChange()
-    m.nextupbuttonseconds = m.originalNextupbuttonseconds
+    m.nextupbuttonseconds = m.global.session.user.settings["playback.nextupbuttonseconds"].ToInt()
 
     if not m.top.trickPlayBar.visible then return
 
@@ -972,7 +970,6 @@ sub onTrickPlayBarTextChange()
     ' If Roku has pulled thumbnailtiles from the video stream, use them instead
     if not m.global.session.user.settings["playback.trickplay.forcecustom"]
         if isValidAndNotEmpty(m.top.thumbnailTiles)
-            m.positionText.unobserveField("text")
             return
         end if
     end if

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1,4 +1,7 @@
+import "pkg:/source/api/Image.bs"
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/enums/ImageType.bs"
+import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/enums/KeyCode.bs"
 import "pkg:/source/enums/MediaPlaybackState.bs"
 import "pkg:/source/enums/MediaSegmentAction.bs"
@@ -82,6 +85,9 @@ sub init()
     end if
 
     m.videoEndingTime = m.top.findNode("videoEndingTime")
+
+    m.nextUp = m.top.findNode("nextUp")
+    m.nextUpInfoLoaded = false
 
     m.skipSegmentButton = m.top.findNode("skipSegment")
     m.skipSegmentButton.background = ColorPalette.LIGHTBLUE
@@ -691,6 +697,7 @@ sub hideSegmentSkipButton()
     m.skipSegmentButton.text = string.EMPTY
     m.skipSegmentButton.setFocus(false)
     m.skipSegmentButton.focus = false
+    hideNextItem()
     m.top.setFocus(true)
 end sub
 
@@ -718,12 +725,58 @@ sub displaySegmentSkipButton(segmentType as string, endticks as double)
 
     if isStringEqual(segmentType, MediaSegmentType.OUTRO)
         if m.nextupbuttonseconds = 0 then return ' is the button disabled?
+        displayNextItem()
     end if
 
     m.skipSegmentButton.visible = true
     m.skipSegmentButton.text = `${tr("Skip")} ${segmentType}`
     m.skipSegmentButton.setFocus(true)
     m.skipSegmentButton.focus = true
+end sub
+
+sub hideNextItem()
+    m.nextUp.visible = false
+end sub
+
+sub displayNextItem()
+    ' Disable for mixed playlists
+    if m.global.queueManager.callFunc("getQueueUniqueTypes").count() <> 1 then return
+
+    ' Only show if next in queue is an episode
+    currentQueuePosition = m.global.queueManager.callFunc("getPosition")
+    nextItem = m.global.queueManager.callFunc("getItemByIndex", currentQueuePosition + 1)
+    if not isStringEqual(nextItem.lookupCI("Type"), ItemType.EPISODE) then return
+
+    ' Disable if we're at the end of the queue
+    if m.global.queueManager.callFunc("getPosition") >= m.global.queueManager.callFunc("getCount") - 1 then return
+
+    if m.nextUpInfoLoaded
+        m.nextUp.visible = true
+        return
+    end if
+
+    imageTags = nextItem.lookupCI("ImageTags")
+    nextItemPoster = m.top.findNode("nextItemPoster")
+    if isValid(nextItemPoster)
+        nextItemPoster.uri = ImageURL(nextItem.lookupCI("id"), ImageType.PRIMARY, { "maxHeight": 124, "maxWidth": 150, "Tag": chainLookupReturn(imageTags, ImageType.PRIMARY, `cacheBuster${rnd(99999)}`) })
+    end if
+
+    nextItemSeriesTitle = m.top.findNode("nextItemSeriesTitle")
+    if isValid(nextItemSeriesTitle)
+        nextItemSeriesTitle.font.size = 25
+        nextItemSeriesTitle.text = nextItem.lookupCI("SeriesName")
+    end if
+
+    nextItemEpisodeTitle = m.top.findNode("nextItemEpisodeTitle")
+    if isValid(nextItemEpisodeTitle)
+        seasonName = nextItem.lookupCI("SeasonName") ?? ""
+        seasonName = seasonName.Replace("Season ", "S")
+        nextItemEpisodeTitle.font.size = 22
+        nextItemEpisodeTitle.text = `${seasonName}E${nextItem.lookupCI("IndexNumber")} - ${nextItem.lookupCI("name")}`
+    end if
+
+    m.nextUp.visible = true
+    m.nextUpInfoLoaded = true
 end sub
 
 sub checkSegmentSkipButton()

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -43,6 +43,15 @@
 
     <Text id="videoEndingTime" font="font:SmallSystemFont" color="0xffffffFF" horizAlign="right" width="200" translation="[1617,900]" visible="false" />
 
+    <Rectangle id="nextUp" visible="false" color="0x000000CC" height="144" width="500" translation="[1250, 750]">
+      <Poster id="nextItemPoster" width="150" height="124" translation="[10, 10]" />
+      <LayoutGroup layoutDirection="vert" horizAlignment="left" itemSpacings="[10, 10]" translation="[180, 15]">
+        <Text text="Next Up" color="#FFFFFF" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="center" />
+        <ScrollingText id="nextItemSeriesTitle" maxWidth="300" color="#FFFFFF" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="top" />
+        <ScrollingText id="nextItemEpisodeTitle" maxWidth="300" color="#AAAAAA" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="top" />
+      </LayoutGroup>
+    </Rectangle>
+
     <StandardButton id="skipSegment" visible="false" height="85" width="250" translation="[1500, 900]" />
   </children>
 </component>

--- a/source/static/whatsNew/3.0.7.json
+++ b/source/static/whatsNew/3.0.7.json
@@ -10,5 +10,13 @@
   {
     "description": "Show next episode info when skip outro button is shown",
     "author": "1hitsong"
+  },
+  {
+    "description": "Fix bug that caused end time to stop updating if video is transcoding",
+    "author": "1hitsong"
+  },
+  {
+    "description": "Fix auto generated outro segments",
+    "author": "1hitsong"
   }
 ]

--- a/source/static/whatsNew/3.0.7.json
+++ b/source/static/whatsNew/3.0.7.json
@@ -6,5 +6,9 @@
   {
     "description": "Fix crash with OSD with LiveTV from search results",
     "author": "jimdogx"
+  },
+  {
+    "description": "Show next episode info when skip outro button is shown",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
If the queue holds only episodes and we're not at the end of the queue, when the skip outro button is shown, show information about the next episode.

## Screenshot
![WIN_20250705_08_40_59_Pro](https://github.com/user-attachments/assets/87577793-8e44-49cd-b389-f4015e2f8838)
