### PR TITLE
Exclude missing episodes

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -586,6 +586,7 @@ sub addNextEpisodesToQueue(showID, additionalPartsCount as integer, queueLimit a
     urlParams = { "UserId": m.global.session.user.id }
     urlParams.Append({ "StartItemId": videoID })
     urlParams.Append({ "Limit": queueLimit + 1 })
+    urlParams.Append({ "isMissing": false })
     resp = APIRequest(url, urlParams)
     data = getJson(resp)
 

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -649,7 +649,8 @@ function TVEpisodeShuffleList(show_id as string)
     resp = APIRequest(url, {
         "UserId": m.global.session.user.id,
         "Limit": 200,
-        "sortBy": "Random"
+        "sortBy": "Random",
+        "isMissing": false
     })
 
     data = getJson(resp)

--- a/source/static/whatsNew/3.0.7.json
+++ b/source/static/whatsNew/3.0.7.json
@@ -18,5 +18,9 @@
   {
     "description": "Fix auto generated outro segments",
     "author": "1hitsong"
+  },
+  {
+    "description": "Exclude missing episodes when populating playback queue",
+    "author": "michaelcresswell"
   }
 ]

--- a/source/utils/quickplay.bs
+++ b/source/utils/quickplay.bs
@@ -214,7 +214,8 @@ namespace quickplay
                     "userid": m.global.session.user.id,
                     "SortBy": "Random",
                     "limit": 2000,
-                    "EnableTotalRecordCount": false
+                    "EnableTotalRecordCount": false,
+                    "isMissing": false
                 })
 
                 if isValid(data) and isValidAndNotEmpty(data.Items)
@@ -240,7 +241,8 @@ namespace quickplay
                     "SortBy": "Random",
                     "imageTypeLimit": 0,
                     "EnableTotalRecordCount": false,
-                    "enableImages": false
+                    "enableImages": false,
+                    "isMissing": false
                 })
 
                 if isValid(showData) and isValidAndNotEmpty(showData.items)
@@ -313,7 +315,8 @@ namespace quickplay
                 "imageTypeLimit": 0,
                 "enableUserData": false,
                 "EnableTotalRecordCount": false,
-                "enableImages": false
+                "enableImages": false,
+                "isMissing": false
             })
 
             if isValid(tvshowsData) and isValidAndNotEmpty(tvshowsData.items)
@@ -343,7 +346,8 @@ namespace quickplay
             "seasonId": itemNode.id,
             "userid": m.global.session.user.id,
             "limit": 2000,
-            "EnableTotalRecordCount": false
+            "EnableTotalRecordCount": false,
+            "isMissing": false
         })
 
         if isValid(unwatchedData) and isValidAndNotEmpty(unwatchedData.Items)


### PR DESCRIPTION
## Changes
Use isMissing parameter to exclude missing episodes when populating playback queue via quickplay, autoplay next episode, etc.

## Issues
Fixes #404
