### PR TITLE
Prevent translation of item type value

### DIFF
--- a/components/data/RecordingData.bs
+++ b/components/data/RecordingData.bs
@@ -1,9 +1,11 @@
+import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub setFields()
     datum = m.top.json
 
     m.top.id = datum.id
+    m.top.type = ItemType.RECORDING
     m.top.title = datum.name
     m.top.showID = datum.SeriesID
     m.top.seasonID = datum.SeasonID

--- a/components/data/RecordingData.xml
+++ b/components/data/RecordingData.xml
@@ -8,7 +8,7 @@
     <field id="showID" type="string" />
     <field id="seasonID" type="string" />
     <field id="overview" type="string" />
-    <field id="type" type="string" value="Recording" />
+    <field id="type" type="string" value="" />
     <field id="startingPoint" type="longinteger" value="0" />
     <field id="json" type="assocarray" onChange="setFields" />
     <field id="selectedVideoStreamId" type="string" />

--- a/components/data/TVEpisodeData.bs
+++ b/components/data/TVEpisodeData.bs
@@ -1,3 +1,4 @@
+import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub setFields()
@@ -5,6 +6,7 @@ sub setFields()
     datum = m.top.json
 
     m.top.id = datum.id
+    m.top.type = ItemType.EPISODE
     m.top.title = datum.name
     m.top.showID = datum.SeriesID
     m.top.seasonID = datum.SeasonID

--- a/components/data/TVEpisodeData.xml
+++ b/components/data/TVEpisodeData.xml
@@ -8,7 +8,7 @@
     <field id="showID" type="string" />
     <field id="seasonID" type="string" />
     <field id="overview" type="string" />
-    <field id="type" type="string" value="Episode" />
+    <field id="type" type="string" value="" />
     <field id="startingPoint" type="longinteger" value="0" />
     <field id="json" type="assocarray" onChange="setFields" />
     <field id="selectedVideoStreamId" type="string" />


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
String fields are automatically translated by BrightScript when possible. This code change removes the default string value and instead applies the value in code so it isn't translated.

As a follow up to this change, we should likewise move all string values into code to prevent possible translations.

## Issues
Fixes #455
