### PR TITLE
Wrap director label and ellipt if too long on movie detail screen

### DIFF
--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -410,7 +410,8 @@ sub itemContentChanged()
     end for
 
     if isValidAndNotEmpty(directors)
-        setFieldText("director", tr("Director") + ": " + directors.join(", "))
+        directorLabel = directors.Count() > 1 ? tr("Directors") : tr("Director")
+        setFieldText("director", `${directorLabel}: ${directors.join(", ")}`)
     else
         setFieldText("director", "")
     end if

--- a/components/movies/MovieDetails.xml
+++ b/components/movies/MovieDetails.xml
@@ -26,7 +26,14 @@
       <LayoutGroup id="infoGroup" layoutDirection="horiz" horizAlignment="left" itemSpacings="[50]">
         <LayoutGroup layoutDirection="vert" itemSpacings="[30]">
           <Text id="overview" wrap="true" maxLines="8" width="1000" />
-          <Text id="director" font="font:SmallestSystemFont" color="#aaaaaa" />
+          <Text
+            id="director"
+            font="font:SmallestSystemFont"
+            color="#aaaaaa"
+            wrap="true"
+            maxLines="2"
+            width="1000"
+            ellipsisText="..." />
 
           <LayoutGroup layoutDirection="vert" itemSpacings="[0]">
             <LayoutGroup layoutDirection="horiz" horizAlignment="left">

--- a/source/static/whatsNew/3.0.8.json
+++ b/source/static/whatsNew/3.0.8.json
@@ -1,1 +1,6 @@
-[]
+[
+  {
+    "description": "Wrap director label and ellipt if too long on movie detail screen",
+    "author": "1hitsong"
+  }
+]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
On media detail screen:
- Sets max width of director field
- Allows director field to wrap to 2 lines
- If media has more than 1 director, the label changes to the plural, "Directors"
- If director value is too long, the field will ellipt with "..."

## Issues
Fixes #466

## Screenshot
![WIN_20250801_13_43_40_Pro](https://github.com/user-attachments/assets/76da408f-2c26-44e5-8ef4-1594e65b1d5d)

