### PR TITLE
Apply Community & Critical Ratings setting to remaining rating locations

### DIFF
--- a/components/tvshows/TVListDetails.bs
+++ b/components/tvshows/TVListDetails.bs
@@ -67,7 +67,7 @@ sub itemContentChanged()
         end if
     end if
 
-    if m.global.session.user.settings["ui.tvshows.disableCommunityRating"] = false
+    if chainLookupReturn(m.global.session, "user.settings.`ui.itemdetail.showRatings`", true)
         if isValid(itemData.communityRating)
             m.top.findNode("star").visible = true
             m.top.findNode("communityRating").text = str(int(itemData.communityRating * 10) / 10)

--- a/components/tvshows/TVShowDetails.bs
+++ b/components/tvshows/TVShowDetails.bs
@@ -47,9 +47,13 @@ sub itemContentChanged()
     end if
 
     'Check communityRating, if invalid remove label
-    if isValid(itemData.communityRating)
-        m.top.findNode("star").visible = true
-        setFieldText("communityRating", int(itemData.communityRating * 10) / 10)
+    if chainLookupReturn(m.global.session, "user.settings.`ui.itemdetail.showRatings`", true)
+        if isValid(itemData.communityRating)
+            m.top.findNode("star").visible = true
+            setFieldText("communityRating", int(itemData.communityRating * 10) / 10)
+        else
+            m.top.findNode("star").visible = false
+        end if
     else
         m.top.findNode("main_group").removeChild(m.top.findNode("communityRating"))
         m.top.findNode("main_group").removeChild(m.top.findNode("star"))

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -556,6 +556,13 @@
             ]
           },
           {
+            "title": "Community and Critical Ratings",
+            "description": "Community and critic review ratings from Rotten Tomatoes.",
+            "settingName": "ui.itemdetail.showRatings",
+            "type": "bool",
+            "default": "true"
+          },
+          {
             "title": "Episode Images Next Up",
             "description": "What type of images to use for Episodes shown in the 'Next Up' and 'Continue Watching' sections.",
             "settingName": "ui-general-episodeimagesnextup",
@@ -624,13 +631,6 @@
         "title": "Item Detail Screen",
         "description": "Settings relating to the appearance of the item detail screen.",
         "children": [
-          {
-            "title": "Community and Critical Ratings",
-            "description": "Community and critic review ratings from Rotten Tomatoes.",
-            "settingName": "ui.itemdetail.showRatings",
-            "type": "bool",
-            "default": "true"
-          },
           {
             "title": "Overview Content",
             "description": "A quick overview of the item selected - typically a short plot outline.",

--- a/source/static/whatsNew/3.0.8.json
+++ b/source/static/whatsNew/3.0.8.json
@@ -2,5 +2,9 @@
   {
     "description": "Wrap director label and ellipt if too long on movie detail screen",
     "author": "1hitsong"
+  },
+  {
+    "description": "Apply \"Community and Critical Ratings\" setting to remaining rating locations",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Moves Community and Critical Ratings setting out from Item Detail Screen folder and to the General folder since it applies to other screens
- Reads and uses the setting value on the ratings on the main series screen and the list of episodes on the season screen.

## Issues
Fixes #382

## Screenshots
Ratings enabled
![WIN_20250801_22_32_17_Pro](https://github.com/user-attachments/assets/37ce969f-fe7c-404f-977e-8aff0ef7d384)

Ratings disabled
![WIN_20250801_22_30_21_Pro](https://github.com/user-attachments/assets/320fa495-1976-47ef-beba-73aef5b9a5ee)

