### PR TITLE
Create settings allowing users to choose home screen sections

### DIFF
--- a/components/JFOverhang.bs
+++ b/components/JFOverhang.bs
@@ -94,6 +94,8 @@ function onKeyEvent(key as string, press as boolean) as boolean
         if key = KeyCode.DOWN
             homeRows = m.top.getscene().findNode("homeRows")
             if isValid(homeRows)
+                if homeRows.content.getChildCount() = 0 then return false
+
                 dehighlightUser()
                 homeRows.setfocus(true)
                 group = m.global.sceneManager.callFunc("getActiveScene")
@@ -107,6 +109,13 @@ function onKeyEvent(key as string, press as boolean) as boolean
             panel = group.findNode("options")
             panel.visible = true
             panel.findNode("panelList").setFocus(true)
+
+            homeRows = m.top.getscene().findNode("homeRows")
+            if isValid(homeRows)
+                if homeRows.content.getChildCount() = 0
+                    group.lastFocus = m.top
+                end if
+            end if
 
             dehighlightUser()
             return true

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -84,7 +84,7 @@ sub processUserSections()
     sessionUser = m.global.session.user
 
     ' calculate expected row count by processing homesections
-    for i = 0 to 6
+    for i = 0 to 7
         userSection = sessionUser.settings["homesection" + i.toStr()]
         sectionName = userSection ?? "none"
         sectionName = LCase(sectionName)
@@ -104,7 +104,7 @@ sub processUserSections()
 
     ' Add home sections in order based on user settings
     loadedSections = 0
-    for i = 0 to 6
+    for i = 0 to 7
         userSection = sessionUser.settings["homesection" + i.toStr()]
         sectionName = userSection ?? "none"
         sectionName = LCase(sectionName)
@@ -119,16 +119,20 @@ sub processUserSections()
 
         ' If 2 sections with data are loaded or we're at the end of the web client section data, consider the home view loaded
         if not m.global.app_loaded
-            if loadedSections = 2 or i = 6
+            if loadedSections = 2 or i = 7
                 m.top.signalBeacon("AppLaunchComplete") ' Roku Performance monitoring
                 m.global.app_loaded = true
             end if
         end if
     end for
 
-    ' Favorites and my list aren't an option in Web settings, so we manually add them to the end for now
-    addHomeSection("mylist")
-    addHomeSection("favorites")
+    ' Favorites and My List aren't options in web settings. So if user has useWebSectionArrangement setting checked, add the sections to the bottom
+    useWebSectionArrangement = chainLookupReturn(m.global, "session.user.settings.`ui.home.useWebSectionArrangement`", true)
+    if useWebSectionArrangement
+        addHomeSection("mylist")
+        addHomeSection("favorites")
+    end if
+
 
     ' Start the timer for creating the content rows before we set the cursor size
     m.loadingTimer.control = "start"
@@ -158,7 +162,7 @@ function getOriginalSectionIndex(sectionName as string) as integer
 
     sessionUser = m.global.session.user
 
-    for i = 0 to 6
+    for i = 0 to 7
         userSection = sessionUser.settings["homesection" + i.toStr()]
         settingSectionName = userSection ?? "none"
         settingSectionName = LCase(settingSectionName)
@@ -490,6 +494,15 @@ end sub
 ' createMyListRow: Creates a row displaying items from the user's personal list
 '
 sub createMyListRow()
+    sectionName = tr("My List")
+
+    if not sectionExists(sectionName)
+        nextUpRow = m.top.content.CreateChild("HomeRow")
+        nextUpRow.title = sectionName
+        nextUpRow.imageWidth = homeRowItemSizes.WIDE_POSTER[0]
+        nextUpRow.cursorSize = homeRowItemSizes.WIDE_POSTER
+    end if
+
     ' Load the My List Data
     m.LoadMyListTask.observeField("content", "updateMyListItems")
     m.LoadMyListTask.control = "RUN"
@@ -498,6 +511,15 @@ end sub
 ' createFavoritesRow: Creates a row displaying items from the user's favorites list
 '
 sub createFavoritesRow()
+    sectionName = tr("Favorites")
+
+    if not sectionExists(sectionName)
+        nextUpRow = m.top.content.CreateChild("HomeRow")
+        nextUpRow.title = sectionName
+        nextUpRow.imageWidth = homeRowItemSizes.WIDE_POSTER[0]
+        nextUpRow.cursorSize = homeRowItemSizes.WIDE_POSTER
+    end if
+
     ' Load the Favorites Data
     m.LoadFavoritesTask.observeField("content", "updateFavoritesItems")
     m.LoadFavoritesTask.control = "RUN"

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -78,7 +78,7 @@ end sub
 ' processUserSections: Loop through user's chosen home section settings and generate the content for each row
 '
 sub processUserSections()
-    m.expectedRowCount = 1 ' the favorites row is hardcoded to always show atm
+    m.expectedRowCount = 0 ' the favorites row is hardcoded to always show atm
     m.processedRowCount = 0
 
     sessionUser = m.global.session.user
@@ -131,8 +131,13 @@ sub processUserSections()
     if useWebSectionArrangement
         addHomeSection("mylist")
         addHomeSection("favorites")
+        loadedSections += 2
     end if
 
+    if loadedSections = 0
+        m.overhang.callFunc("highlightUser")
+        m.overhang.setfocus(true)
+    end if
 
     ' Start the timer for creating the content rows before we set the cursor size
     m.loadingTimer.control = "start"

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -340,10 +340,10 @@ sub refreshMenu()
     for each item in selectedItem.children
         settingName = chainLookupReturn(item, "settingName", string.EMPTY)
         if isStringEqual(left(settingName, 17), "homescreensection")
-            item.visible = not useWebSectionArrangement
+            item.visible = (not useWebSectionArrangement)
         end if
 
-        if chainLookupReturn(item, "visible", false)
+        if not chainLookupReturn(item, "visible", true)
             continue for
         end if
 
@@ -357,10 +357,6 @@ end sub
 sub boolSettingChanged()
     if m.boolSetting.focusedChild = invalid then return
     selectedSetting = m.userLocation.peek().children[m.settingsMenu.itemFocused]
-
-    if isStringEqual(selectedSetting.settingName, "ui.home.useWebSectionArrangement")
-        refreshMenu()
-    end if
 
     if m.boolSetting.checkedItem
         session.user.settings.Save(selectedSetting.settingName, "true")
@@ -392,6 +388,10 @@ sub boolSettingChanged()
             ' save to user specific registry block
             set_user_setting(selectedSetting.settingName, "false")
         end if
+    end if
+
+    if isStringEqual(selectedSetting.settingName, "ui.home.useWebSectionArrangement")
+        refreshMenu()
     end if
 end sub
 

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -163,7 +163,7 @@ sub onKeyGridEscape()
     end if
 end sub
 
-sub LoadMenu(configSection)
+sub LoadMenu(configSection, appendPath = true as boolean)
     if configSection.children = invalid
         ' Load parent menu
         m.userLocation.pop()
@@ -171,50 +171,54 @@ sub LoadMenu(configSection)
     else
         settingsArray = []
 
-        useWebSectionArrangement = chainLookupReturn(m.global, "session.user.settings.`ui.home.useWebSectionArrangement`", true)
-
         for each item in configSection.children
-            settingName = chainLookupReturn(item, "settingName", string.EMPTY)
-            if isStringEqual(left(settingName, 17), "homescreensection")
-                if not useWebSectionArrangement then item.visible = true
-            end if
-
-            if isValid(item.visible)
-                if not item.visible
-                    if not m.showSecretMenu
-                        continue for
-                    end if
-                end if
-            end if
             settingsArray.push(item)
         end for
 
         configSection.children = settingsArray
 
-        if m.userLocation.Count() > 0 then m.userLocation.peek().selectedIndex = m.settingsMenu.itemFocused
-        m.userLocation.push(configSection)
+        if appendPath
+            if m.userLocation.Count() > 0 then m.userLocation.peek().selectedIndex = m.settingsMenu.itemFocused
+            m.userLocation.push(configSection)
+        end if
     end if
 
     result = CreateObject("roSGNode", "ContentNode")
+    m.settingsMenu.content = result
+
+    useWebSectionArrangement = chainLookupReturn(m.global, "session.user.settings.`ui.home.useWebSectionArrangement`", true)
 
     for each item in configSection.children
+        settingName = chainLookupReturn(item, "settingName", string.EMPTY)
+        if isStringEqual(left(settingName, 17), "homescreensection")
+            item.visible = not useWebSectionArrangement
+        end if
+
+        if isValid(item.visible)
+            if not item.visible
+                if not m.showSecretMenu
+                    continue for
+                end if
+            end if
+        end if
+
         listItem = result.CreateChild("ContentNode")
         listItem.title = tr(item.title)
         listItem.Description = tr(item.description)
         listItem.id = item.id
     end for
 
-    m.settingsMenu.content = result
-
     if configSection.selectedIndex <> invalid and configSection.selectedIndex > -1
         m.settingsMenu.jumpToItem = configSection.selectedIndex
     end if
 
     ' Set Path display
-    m.path.text = tr("Settings")
-    for each level in m.userLocation
-        if level.title <> invalid then m.path.text += " / " + tr(level.title)
-    end for
+    if appendPath
+        m.path.text = tr("Settings")
+        for each level in m.userLocation
+            if level.title <> invalid then m.path.text += " / " + tr(level.title)
+        end for
+    end if
 end sub
 
 sub settingFocused()
@@ -331,27 +335,7 @@ end sub
 
 sub refreshMenu()
     selectedItem = m.userLocation[m.userLocation.count() - 1]
-
-    result = CreateObject("roSGNode", "ContentNode")
-    m.settingsMenu.content = result
-
-    useWebSectionArrangement = chainLookupReturn(m.global, "session.user.settings.`ui.home.useWebSectionArrangement`", true)
-
-    for each item in selectedItem.children
-        settingName = chainLookupReturn(item, "settingName", string.EMPTY)
-        if isStringEqual(left(settingName, 17), "homescreensection")
-            item.visible = (not useWebSectionArrangement)
-        end if
-
-        if not chainLookupReturn(item, "visible", true)
-            continue for
-        end if
-
-        listItem = result.CreateChild("ContentNode")
-        listItem.title = tr(item.title)
-        listItem.Description = tr(item.description)
-        listItem.id = item.id
-    end for
+    LoadMenu(selectedItem, false)
 end sub
 
 sub boolSettingChanged()

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -2,6 +2,7 @@ import "pkg:/source/api/sdk.bs"
 import "pkg:/source/enums/ColorPalette.bs"
 import "pkg:/source/enums/KeyCode.bs"
 import "pkg:/source/enums/SettingType.bs"
+import "pkg:/source/enums/String.bs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/deviceCapabilities.bs"
 import "pkg:/source/utils/misc.bs"
@@ -145,7 +146,6 @@ sub onColorSelected()
         overhang = scene.findNode("overhang")
         if isValid(overhang)
             overlayCurrentUser = overhang.findNode("overlayCurrentUser")
-            print "selectedColor", selectedColor
             overlayCurrentUser.color = selectedColor ?? ColorPalette.WHITE
         end if
     end if
@@ -170,7 +170,15 @@ sub LoadMenu(configSection)
         configSection = m.userLocation.peek()
     else
         settingsArray = []
+
+        useWebSectionArrangement = chainLookupReturn(m.global, "session.user.settings.`ui.home.useWebSectionArrangement`", true)
+
         for each item in configSection.children
+            settingName = chainLookupReturn(item, "settingName", string.EMPTY)
+            if isStringEqual(left(settingName, 17), "homescreensection")
+                if not useWebSectionArrangement then item.visible = true
+            end if
+
             if isValid(item.visible)
                 if not item.visible
                     if not m.showSecretMenu
@@ -321,9 +329,38 @@ sub settingSelected()
 
 end sub
 
+sub refreshMenu()
+    selectedItem = m.userLocation[m.userLocation.count() - 1]
+
+    result = CreateObject("roSGNode", "ContentNode")
+    m.settingsMenu.content = result
+
+    useWebSectionArrangement = chainLookupReturn(m.global, "session.user.settings.`ui.home.useWebSectionArrangement`", true)
+
+    for each item in selectedItem.children
+        settingName = chainLookupReturn(item, "settingName", string.EMPTY)
+        if isStringEqual(left(settingName, 17), "homescreensection")
+            item.visible = not useWebSectionArrangement
+        end if
+
+        if chainLookupReturn(item, "visible", false)
+            continue for
+        end if
+
+        listItem = result.CreateChild("ContentNode")
+        listItem.title = tr(item.title)
+        listItem.Description = tr(item.description)
+        listItem.id = item.id
+    end for
+end sub
+
 sub boolSettingChanged()
     if m.boolSetting.focusedChild = invalid then return
     selectedSetting = m.userLocation.peek().children[m.settingsMenu.itemFocused]
+
+    if isStringEqual(selectedSetting.settingName, "ui.home.useWebSectionArrangement")
+        refreshMenu()
+    end if
 
     if m.boolSetting.checkedItem
         session.user.settings.Save(selectedSetting.settingName, "true")

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1829,5 +1829,89 @@
             <source>Episode</source>
             <translation>Episode</translation>
         </message>
+        <message>
+            <source>Section 1</source>
+            <translation>Section 1</translation>
+        </message>
+        <message>
+            <source>Section 2</source>
+            <translation>Section 2</translation>
+        </message>
+        <message>
+            <source>Section 3</source>
+            <translation>Section 3</translation>
+        </message>
+        <message>
+            <source>Section 4</source>
+            <translation>Section 4</translation>
+        </message>
+        <message>
+            <source>Section 5</source>
+            <translation>Section 5</translation>
+        </message>
+        <message>
+            <source>Section 6</source>
+            <translation>Section 6</translation>
+        </message>
+        <message>
+            <source>Section 7</source>
+            <translation>Section 7</translation>
+        </message>
+        <message>
+            <source>Section 8</source>
+            <translation>Section 8</translation>
+        </message>
+        <message>
+            <source>Select what to show in section 1. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.</source>
+            <translation>Select what to show in section 1. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.</translation>
+        </message>
+        <message>
+            <source>Select what to show in section 2. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.</source>
+            <translation>Select what to show in section 2. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.</translation>
+        </message>
+        <message>
+            <source>Select what to show in section 3. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.</source>
+            <translation>Select what to show in section 3. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.</translation>
+        </message>
+        <message>
+            <source>Select what to show in section 4. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.</source>
+            <translation>Select what to show in section 4. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.</translation>
+        </message>
+        <message>
+            <source>Select what to show in section 5. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.</source>
+            <translation>Select what to show in section 5. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.</translation>
+        </message>
+        <message>
+            <source>Select what to show in section 6. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.</source>
+            <translation>Select what to show in section 6. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.</translation>
+        </message>
+        <message>
+            <source>Select what to show in section 7. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.</source>
+            <translation>Select what to show in section 7. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.</translation>
+        </message>
+        <message>
+            <source>Select what to show in section 8. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.</source>
+            <translation>Select what to show in section 8. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.</translation>
+        </message>
+        <message>
+            <source>Live TV</source>
+            <translation>Live TV</translation>
+        </message>
+        <message>
+            <source>My List</source>
+            <translation>My List</translation>
+        </message>
+        <message>
+            <source>Recently Added Media</source>
+            <translation>Recently Added Media</translation>
+        </message>
+        <message>
+            <source>Customize the home screen sections</source>
+            <translation>Customize the home screen sections</translation>
+        </message>
+        <message>
+            <source>Home Rows</source>
+            <translation>Home Rows</translation>
+        </message>
     </context>
 </TS>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -617,13 +617,387 @@
             "settingName": "useFallbackFont",
             "type": "bool",
             "default": "false"
-          },
+          }
+        ]
+      },
+      {
+        "title": "Home Rows",
+        "description": "Customize the home screen sections",
+        "children": [
           {
             "title": "Use Web Client's Home Section Arrangement",
             "description": "Make the arrangement of the Roku home view sections match the web client's home screen. Jellyfin will need to be closed and reopened for change to take effect.",
             "settingName": "ui.home.useWebSectionArrangement",
             "type": "bool",
             "default": "true"
+          },
+          {
+            "title": "Section 1",
+            "visible": false,
+            "description": "Select what to show in section 1. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.",
+            "settingName": "homeScreenSection0",
+            "type": "radio",
+            "default": "smalllibrarytiles",
+            "options": [
+              {
+                "title": "Continue Listening",
+                "id": "resumeaudio"
+              },
+              {
+                "title": "Continue Watching",
+                "id": "resume"
+              },
+              {
+                "title": "Favorites",
+                "id": "favorites"
+              },
+              {
+                "title": "Live TV",
+                "id": "livetv"
+              },
+              {
+                "title": "My List",
+                "id": "mylist"
+              },
+              {
+                "title": "My Media",
+                "id": "smalllibrarytiles"
+              },
+              {
+                "title": "Next Up",
+                "id": "nextup"
+              },
+              {
+                "title": "None",
+                "id": "none"
+              },
+              {
+                "title": "Recently Added Media",
+                "id": "latestmedia"
+              }
+            ]
+          },
+          {
+            "title": "Section 2",
+            "visible": false,
+            "description": "Select what to show in section 2. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.",
+            "settingName": "homeScreenSection1",
+            "type": "radio",
+            "default": "resume",
+            "options": [
+              {
+                "title": "Continue Listening",
+                "id": "resumeaudio"
+              },
+              {
+                "title": "Continue Watching",
+                "id": "resume"
+              },
+              {
+                "title": "Favorites",
+                "id": "favorites"
+              },
+              {
+                "title": "Live TV",
+                "id": "livetv"
+              },
+              {
+                "title": "My List",
+                "id": "mylist"
+              },
+              {
+                "title": "My Media",
+                "id": "smalllibrarytiles"
+              },
+              {
+                "title": "Next Up",
+                "id": "nextup"
+              },
+              {
+                "title": "None",
+                "id": "none"
+              },
+              {
+                "title": "Recently Added Media",
+                "id": "latestmedia"
+              }
+            ]
+          },
+          {
+            "title": "Section 3",
+            "visible": false,
+            "description": "Select what to show in section 3. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.",
+            "settingName": "homeScreenSection2",
+            "type": "radio",
+            "default": "nextup",
+            "options": [
+              {
+                "title": "Continue Listening",
+                "id": "resumeaudio"
+              },
+              {
+                "title": "Continue Watching",
+                "id": "resume"
+              },
+              {
+                "title": "Favorites",
+                "id": "favorites"
+              },
+              {
+                "title": "Live TV",
+                "id": "livetv"
+              },
+              {
+                "title": "My List",
+                "id": "mylist"
+              },
+              {
+                "title": "My Media",
+                "id": "smalllibrarytiles"
+              },
+              {
+                "title": "Next Up",
+                "id": "nextup"
+              },
+              {
+                "title": "None",
+                "id": "none"
+              },
+              {
+                "title": "Recently Added Media",
+                "id": "latestmedia"
+              }
+            ]
+          },
+          {
+            "title": "Section 4",
+            "visible": false,
+            "description": "Select what to show in section 4. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.",
+            "settingName": "homeScreenSection3",
+            "type": "radio",
+            "default": "latestmedia",
+            "options": [
+              {
+                "title": "Continue Listening",
+                "id": "resumeaudio"
+              },
+              {
+                "title": "Continue Watching",
+                "id": "resume"
+              },
+              {
+                "title": "Favorites",
+                "id": "favorites"
+              },
+              {
+                "title": "Live TV",
+                "id": "livetv"
+              },
+              {
+                "title": "My List",
+                "id": "mylist"
+              },
+              {
+                "title": "My Media",
+                "id": "smalllibrarytiles"
+              },
+              {
+                "title": "Next Up",
+                "id": "nextup"
+              },
+              {
+                "title": "None",
+                "id": "none"
+              },
+              {
+                "title": "Recently Added Media",
+                "id": "latestmedia"
+              }
+            ]
+          },
+          {
+            "title": "Section 5",
+            "visible": false,
+            "description": "Select what to show in section 5. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.",
+            "settingName": "homeScreenSection4",
+            "type": "radio",
+            "default": "livetv",
+            "options": [
+              {
+                "title": "Continue Listening",
+                "id": "resumeaudio"
+              },
+              {
+                "title": "Continue Watching",
+                "id": "resume"
+              },
+              {
+                "title": "Favorites",
+                "id": "favorites"
+              },
+              {
+                "title": "Live TV",
+                "id": "livetv"
+              },
+              {
+                "title": "My List",
+                "id": "mylist"
+              },
+              {
+                "title": "My Media",
+                "id": "smalllibrarytiles"
+              },
+              {
+                "title": "Next Up",
+                "id": "nextup"
+              },
+              {
+                "title": "None",
+                "id": "none"
+              },
+              {
+                "title": "Recently Added Media",
+                "id": "latestmedia"
+              }
+            ]
+          },
+          {
+            "title": "Section 6",
+            "visible": false,
+            "description": "Select what to show in section 6. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.",
+            "settingName": "homeScreenSection5",
+            "type": "radio",
+            "default": "mylist",
+            "options": [
+              {
+                "title": "Continue Listening",
+                "id": "resumeaudio"
+              },
+              {
+                "title": "Continue Watching",
+                "id": "resume"
+              },
+              {
+                "title": "Favorites",
+                "id": "favorites"
+              },
+              {
+                "title": "Live TV",
+                "id": "livetv"
+              },
+              {
+                "title": "My List",
+                "id": "mylist"
+              },
+              {
+                "title": "My Media",
+                "id": "smalllibrarytiles"
+              },
+              {
+                "title": "Next Up",
+                "id": "nextup"
+              },
+              {
+                "title": "None",
+                "id": "none"
+              },
+              {
+                "title": "Recently Added Media",
+                "id": "latestmedia"
+              }
+            ]
+          },
+          {
+            "title": "Section 7",
+            "visible": false,
+            "description": "Select what to show in section 7. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.",
+            "settingName": "homeScreenSection6",
+            "type": "radio",
+            "default": "favorites",
+            "options": [
+              {
+                "title": "Continue Listening",
+                "id": "resumeaudio"
+              },
+              {
+                "title": "Continue Watching",
+                "id": "resume"
+              },
+              {
+                "title": "Favorites",
+                "id": "favorites"
+              },
+              {
+                "title": "Live TV",
+                "id": "livetv"
+              },
+              {
+                "title": "My List",
+                "id": "mylist"
+              },
+              {
+                "title": "My Media",
+                "id": "smalllibrarytiles"
+              },
+              {
+                "title": "Next Up",
+                "id": "nextup"
+              },
+              {
+                "title": "None",
+                "id": "none"
+              },
+              {
+                "title": "Recently Added Media",
+                "id": "latestmedia"
+              }
+            ]
+          },
+          {
+            "title": "Section 8",
+            "visible": false,
+            "description": "Select what to show in section 8. This setting has no effect if \"Use Web Client's Home Section Arrangement\" is enabled. Jellyfin will need to be closed and reopened for change to take effect.",
+            "settingName": "homeScreenSection7",
+            "type": "radio",
+            "default": "none",
+            "options": [
+              {
+                "title": "Continue Listening",
+                "id": "resumeaudio"
+              },
+              {
+                "title": "Continue Watching",
+                "id": "resume"
+              },
+              {
+                "title": "Favorites",
+                "id": "favorites"
+              },
+              {
+                "title": "Live TV",
+                "id": "livetv"
+              },
+              {
+                "title": "My List",
+                "id": "mylist"
+              },
+              {
+                "title": "My Media",
+                "id": "smalllibrarytiles"
+              },
+              {
+                "title": "Next Up",
+                "id": "nextup"
+              },
+              {
+                "title": "None",
+                "id": "none"
+              },
+              {
+                "title": "Recently Added Media",
+                "id": "latestmedia"
+              }
+            ]
           }
         ]
       },

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1,183 +1,5 @@
 [
   {
-    "title": "Secret",
-    "description": "Settings that are not for public consumption. Do not get mad if these things change without notice.",
-    "visible": false,
-    "children": [
-      {
-        "title": "Color Settings",
-        "description": "Change the colors of elements in the app",
-        "children": [
-          {
-            "title": "Home",
-            "description": "Change the colors of elements on the home screen",
-            "children": [
-              {
-                "title": "My List Icon",
-                "description": "",
-                "settingName": "colorHomeMyListIcon",
-                "type": "colorgrid",
-                "default": "#FFFFFF"
-              },
-              {
-                "title": "Row Headers",
-                "description": "",
-                "settingName": "colorHomeRowHeaders",
-                "type": "colorgrid",
-                "default": "#FFFFFF"
-              },
-              {
-                "title": "Row Item Background",
-                "description": "",
-                "settingName": "colorHomeRowItemBackground",
-                "type": "colorgrid",
-                "default": "#000033"
-              },
-              {
-                "title": "Row Item Progress",
-                "description": "",
-                "settingName": "colorHomeRowItemProgress",
-                "type": "colorgrid",
-                "default": "#6867ff"
-              },
-              {
-                "title": "Row Item Progress Background",
-                "description": "",
-                "settingName": "colorHomeRowItemProgressBackground",
-                "type": "colorgrid",
-                "default": "#000000"
-              },
-              {
-                "title": "Row Item Title",
-                "description": "",
-                "settingName": "colorHomeRowItemTitle",
-                "type": "colorgrid",
-                "default": "#FFFFFF"
-              },
-              {
-                "title": "Row Item Subtitle",
-                "description": "",
-                "settingName": "colorHomeRowItemSubtitle",
-                "type": "colorgrid",
-                "default": "#777777"
-              },
-              {
-                "title": "Username In Header",
-                "description": "",
-                "settingName": "colorHomeUsername",
-                "type": "colorgrid",
-                "default": "#FFFFFF"
-              }
-            ]
-          },
-          {
-            "title": "Dialog Popups",
-            "description": "Change the colors of elements in dialog popups",
-            "children": [
-              {
-                "title": "Background",
-                "description": "The background color for all dialog popups.",
-                "settingName": "colorDialogBackground",
-                "type": "colorgrid",
-                "default": "#000033"
-              },
-              {
-                "title": "Bold Text",
-                "description": "The text color for bold text.",
-                "settingName": "colorDialogBoldText",
-                "type": "colorgrid",
-                "default": "#66FF33"
-              },
-              {
-                "title": "Horizontal Border line",
-                "description": "The color of the thin border line under the header text.",
-                "settingName": "colorDialogBorderLine",
-                "type": "colorgrid",
-                "default": "#CCFFF"
-              },
-              {
-                "title": "Selected Text",
-                "description": "The text color for the item the cursor is over.",
-                "settingName": "colorDialogSelectedText",
-                "type": "colorgrid",
-                "default": "#FFFFFF"
-              },
-              {
-                "title": "Text Color",
-                "description": "The text color for title and items the cursor is not over.",
-                "settingName": "colorDialogText",
-                "type": "colorgrid",
-                "default": "#FFFFFF"
-              },
-              {
-                "title": "What's New Author",
-                "description": "The text color for the author in the What's New popup.",
-                "settingName": "colorWhatsNewAuthor",
-                "type": "colorgrid",
-                "default": "#FF6666"
-              }
-            ]
-          },
-          {
-            "title": "Background",
-            "description": "The base background color for all screens in Jellyfin.",
-            "settingName": "colorBackground",
-            "type": "colorgrid",
-            "default": "#000018"
-          },
-          {
-            "title": "Primary Text",
-            "description": "The primary text color for all screens in Jellyfin.",
-            "settingName": "colorText",
-            "type": "colorgrid",
-            "default": "#FFFFFF"
-          },
-          {
-            "title": "Secondary Text",
-            "description": "The secondary text color for all screens in Jellyfin.",
-            "settingName": "colorSubText",
-            "type": "colorgrid",
-            "default": "#777777FF"
-          },
-          {
-            "title": "Cursor",
-            "description": "The highlight color for the cursor showing where the user's focus is.",
-            "settingName": "colorCursor",
-            "type": "colorgrid",
-            "default": "#FF6666"
-          },
-          {
-            "title": "Watched Check Mark & Unplayed Count",
-            "description": "Watched Check Mark & Unplayed Count color settings",
-            "children": [
-              {
-                "title": "Background",
-                "description": "The background color of the check mark & unplayed count shown in the top right corner of items.",
-                "settingName": "colorPlayedCheckmarkBackground",
-                "type": "colorgrid",
-                "default": "#6666FF"
-              },
-              {
-                "title": "Watched Check Mark",
-                "description": "The color of the watched check mark.",
-                "settingName": "colorPlayedCheckmarkIcon",
-                "type": "colorgrid",
-                "default": "#FFFFFF"
-              },
-              {
-                "title": "Unplayed Count",
-                "description": "The text color of the unplayed count number.",
-                "settingName": "colorUnplayedCountTextColor",
-                "type": "colorgrid",
-                "default": "#FFFFFF"
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  },
-  {
     "title": "Global",
     "description": "Global settings that affect everyone that uses this Roku device.",
     "children": [
@@ -1174,6 +996,184 @@
                 "settingName": "ui.tvshows.goStraightToEpisodeListing",
                 "type": "bool",
                 "default": "false"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "title": "Secret",
+    "description": "Settings that are not for public consumption. Do not get mad if these things change without notice.",
+    "visible": false,
+    "children": [
+      {
+        "title": "Color Settings",
+        "description": "Change the colors of elements in the app",
+        "children": [
+          {
+            "title": "Home",
+            "description": "Change the colors of elements on the home screen",
+            "children": [
+              {
+                "title": "My List Icon",
+                "description": "",
+                "settingName": "colorHomeMyListIcon",
+                "type": "colorgrid",
+                "default": "#FFFFFF"
+              },
+              {
+                "title": "Row Headers",
+                "description": "",
+                "settingName": "colorHomeRowHeaders",
+                "type": "colorgrid",
+                "default": "#FFFFFF"
+              },
+              {
+                "title": "Row Item Background",
+                "description": "",
+                "settingName": "colorHomeRowItemBackground",
+                "type": "colorgrid",
+                "default": "#000033"
+              },
+              {
+                "title": "Row Item Progress",
+                "description": "",
+                "settingName": "colorHomeRowItemProgress",
+                "type": "colorgrid",
+                "default": "#6867ff"
+              },
+              {
+                "title": "Row Item Progress Background",
+                "description": "",
+                "settingName": "colorHomeRowItemProgressBackground",
+                "type": "colorgrid",
+                "default": "#000000"
+              },
+              {
+                "title": "Row Item Title",
+                "description": "",
+                "settingName": "colorHomeRowItemTitle",
+                "type": "colorgrid",
+                "default": "#FFFFFF"
+              },
+              {
+                "title": "Row Item Subtitle",
+                "description": "",
+                "settingName": "colorHomeRowItemSubtitle",
+                "type": "colorgrid",
+                "default": "#777777"
+              },
+              {
+                "title": "Username In Header",
+                "description": "",
+                "settingName": "colorHomeUsername",
+                "type": "colorgrid",
+                "default": "#FFFFFF"
+              }
+            ]
+          },
+          {
+            "title": "Dialog Popups",
+            "description": "Change the colors of elements in dialog popups",
+            "children": [
+              {
+                "title": "Background",
+                "description": "The background color for all dialog popups.",
+                "settingName": "colorDialogBackground",
+                "type": "colorgrid",
+                "default": "#000033"
+              },
+              {
+                "title": "Bold Text",
+                "description": "The text color for bold text.",
+                "settingName": "colorDialogBoldText",
+                "type": "colorgrid",
+                "default": "#66FF33"
+              },
+              {
+                "title": "Horizontal Border line",
+                "description": "The color of the thin border line under the header text.",
+                "settingName": "colorDialogBorderLine",
+                "type": "colorgrid",
+                "default": "#CCFFF"
+              },
+              {
+                "title": "Selected Text",
+                "description": "The text color for the item the cursor is over.",
+                "settingName": "colorDialogSelectedText",
+                "type": "colorgrid",
+                "default": "#FFFFFF"
+              },
+              {
+                "title": "Text Color",
+                "description": "The text color for title and items the cursor is not over.",
+                "settingName": "colorDialogText",
+                "type": "colorgrid",
+                "default": "#FFFFFF"
+              },
+              {
+                "title": "What's New Author",
+                "description": "The text color for the author in the What's New popup.",
+                "settingName": "colorWhatsNewAuthor",
+                "type": "colorgrid",
+                "default": "#FF6666"
+              }
+            ]
+          },
+          {
+            "title": "Background",
+            "description": "The base background color for all screens in Jellyfin.",
+            "settingName": "colorBackground",
+            "type": "colorgrid",
+            "default": "#000018"
+          },
+          {
+            "title": "Primary Text",
+            "description": "The primary text color for all screens in Jellyfin.",
+            "settingName": "colorText",
+            "type": "colorgrid",
+            "default": "#FFFFFF"
+          },
+          {
+            "title": "Secondary Text",
+            "description": "The secondary text color for all screens in Jellyfin.",
+            "settingName": "colorSubText",
+            "type": "colorgrid",
+            "default": "#777777FF"
+          },
+          {
+            "title": "Cursor",
+            "description": "The highlight color for the cursor showing where the user's focus is.",
+            "settingName": "colorCursor",
+            "type": "colorgrid",
+            "default": "#FF6666"
+          },
+          {
+            "title": "Watched Check Mark & Unplayed Count",
+            "description": "Watched Check Mark & Unplayed Count color settings",
+            "children": [
+              {
+                "title": "Background",
+                "description": "The background color of the check mark & unplayed count shown in the top right corner of items.",
+                "settingName": "colorPlayedCheckmarkBackground",
+                "type": "colorgrid",
+                "default": "#6666FF"
+              },
+              {
+                "title": "Watched Check Mark",
+                "description": "The color of the watched check mark.",
+                "settingName": "colorPlayedCheckmarkIcon",
+                "type": "colorgrid",
+                "default": "#FFFFFF"
+              },
+              {
+                "title": "Unplayed Count",
+                "description": "The text color of the unplayed count number.",
+                "settingName": "colorUnplayedCountTextColor",
+                "type": "colorgrid",
+                "default": "#FFFFFF"
               }
             ]
           }

--- a/source/static/whatsNew/3.0.8.json
+++ b/source/static/whatsNew/3.0.8.json
@@ -14,5 +14,9 @@
   {
     "description": "Fix audio track selection bug",
     "author": "1hitsong"
+  },
+  {
+    "description": "Create settings allowing users to choose home screen sections",
+    "author": "1hitsong"
   }
 ]

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -239,13 +239,13 @@ namespace session
                 session.user.SaveUserHomeSections(jsonResponse.CustomPrefs)
             else
                 homeSection0 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection0", "smalllibrarytiles")
-                homeSection1 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection0", "resume")
-                homeSection2 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection0", "nextup")
-                homeSection3 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection0", "latestmedia")
-                homeSection4 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection0", "livetv")
-                homeSection5 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection0", "mylist")
-                homeSection6 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection0", "favorites")
-                homeSection7 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection0", "none")
+                homeSection1 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection1", "resume")
+                homeSection2 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection2", "nextup")
+                homeSection3 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection3", "latestmedia")
+                homeSection4 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection4", "livetv")
+                homeSection5 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection5", "mylist")
+                homeSection6 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection6", "favorites")
+                homeSection7 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection7", "none")
 
                 ' User has no custom prefs. Save default home section values.
                 session.user.SaveUserHomeSections({
@@ -305,22 +305,29 @@ namespace session
             end if
 
             homeSection0 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection0", "smalllibrarytiles")
+            homeSection1 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection1", "resume")
+            homeSection2 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection2", "nextup")
+            homeSection3 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection3", "latestmedia")
+            homeSection4 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection4", "livetv")
+            homeSection5 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection5", "mylist")
+            homeSection6 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection6", "favorites")
+            homeSection7 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection7", "none")
 
             ' If user has no section preferences, use default settings
             if not userPreferences.doesExist("homesection0")
                 userPreferences = {
                     homesection0: homeSection0,
-                    homesection1: "resume",
-                    homesection2: "nextup",
-                    homesection3: "latestmedia",
-                    homesection4: "livetv",
-                    homesection5: "mylist",
-                    homesection6: "favorites",
-                    homesection7: "none"
+                    homesection1: homeSection1,
+                    homesection2: homeSection2,
+                    homesection3: homeSection3,
+                    homesection4: homeSection4,
+                    homesection5: homeSection5,
+                    homesection6: homeSection6,
+                    homesection7: homeSection7
                 }
             end if
 
-            for i = 0 to 6
+            for i = 0 to 7
                 homeSectionKey = "homesection" + i.toStr()
 
                 ' If home section doesn't exist, create it as a none row

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -238,15 +238,25 @@ namespace session
                 session.user.SaveUserGuideSettings(jsonResponse.CustomPrefs)
                 session.user.SaveUserHomeSections(jsonResponse.CustomPrefs)
             else
+                homeSection0 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection0", "smalllibrarytiles")
+                homeSection1 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection0", "resume")
+                homeSection2 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection0", "nextup")
+                homeSection3 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection0", "latestmedia")
+                homeSection4 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection0", "livetv")
+                homeSection5 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection0", "mylist")
+                homeSection6 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection0", "favorites")
+                homeSection7 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection0", "none")
+
                 ' User has no custom prefs. Save default home section values.
                 session.user.SaveUserHomeSections({
-                    homesection0: "smalllibrarytiles",
-                    homesection1: "resume",
-                    homesection2: "nextup",
-                    homesection3: "latestmedia",
-                    homesection4: "livetv",
-                    homesection5: "none",
-                    homesection6: "none"
+                    homesection0: homeSection0,
+                    homesection1: homeSection1,
+                    homesection2: homeSection2,
+                    homesection3: homeSection3,
+                    homesection4: homeSection4,
+                    homesection5: homeSection5,
+                    homesection6: homeSection6,
+                    homesection7: homeSection7
                 })
             end if
         end sub
@@ -294,16 +304,19 @@ namespace session
                 end if
             end if
 
+            homeSection0 = chainLookupReturn(m.global, "session.user.settings.homeScreenSection0", "smalllibrarytiles")
+
             ' If user has no section preferences, use default settings
             if not userPreferences.doesExist("homesection0")
                 userPreferences = {
-                    homesection0: "smalllibrarytiles",
+                    homesection0: homeSection0,
                     homesection1: "resume",
                     homesection2: "nextup",
                     homesection3: "latestmedia",
                     homesection4: "livetv",
-                    homesection5: "none",
-                    homesection6: "none"
+                    homesection5: "mylist",
+                    homesection6: "favorites",
+                    homesection7: "none"
                 }
             end if
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Create settings for each home screen section, allowing users to select what kind of section they want
- If "Use Web Client's Home Section Arrangement" is enabled, hides individual section settings
- Defaults remain untouched

This change allows users to place My List and Favorites anywhere they want instead of them always being at the bottom of the screen.

## Demo Video

https://github.com/user-attachments/assets/470215af-02ef-4637-b3b6-43d2b22f7544