### PR TITLE
Add support for VTT line property to custom subs

### DIFF
--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -99,10 +99,10 @@ sub updateCaption()
     if LCase(m.top.playerState) = "playingon"
         m.top.currentPos = m.top.currentPos + 100
         texts = []
-        captionPosition = ""
+        captionStyles = {}
         for each entry in m.captionList
             if entry["start"] <= m.top.currentPos and m.top.currentPos < entry["end"]
-                captionPosition = entry["position"]
+                captionStyles = entry["styles"]
                 t = m.tags.replaceAll(entry["text"], "")
                 texts.push(t)
             end if
@@ -115,9 +115,7 @@ sub updateCaption()
         rect = newRect(lines)
         m.top.currentCaption = [rect, lines]
 
-        if not isStringEqual(m.top.captionPosition, captionPosition)
-            m.top.captionPosition = captionPosition
-        end if
+        m.top.captionStyles = captionStyles
     else if LCase(m.top.playerState.right(1)) = "w"
         m.top.playerState = m.top.playerState.left(len (m.top.playerState) - 1)
     end if
@@ -158,21 +156,19 @@ function parseVTT(lines)
     lines = lines.split(chr(10))
     curStart = -1
     curEnd = -1
-    curLinePosition = "0"
     entries = []
 
     for i = 0 to lines.count() - 1
         if isTime(lines[i])
-            curLinePosition = "0"
             curStart = toMs(lines[i])
             lineData = extractStyles(lines[i + 1])
             curEnd = toMs(lineData.LookupCI("endTimestamp"))
-            curLinePosition = chainLookup(lineData, "styles.line")
+            curstyles = chainLookup(lineData, "styles")
             i += 1
         else if curStart <> -1
             trimmed = lines[i].trim()
             if trimmed <> chr(0)
-                entry = { "start": curStart, "end": curEnd, "text": trimmed, "position": curLinePosition }
+                entry = { "start": curStart, "end": curEnd, "text": trimmed, "styles": curstyles }
                 entries.push(entry)
             end if
         end if

--- a/components/captionTask.xml
+++ b/components/captionTask.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="captionTask" extends="Task">
        <interface>
-              <field id="captionPosition" type="string" />
+              <field id="captionStyles" type="assocarray" alwaysNotify="true" />
               <field id="url" type="string" />
               <field id="currentCaption" type="roArray" />
               <field id="playerState" type="string" />

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -384,7 +384,7 @@ sub onAllowCaptionsChange()
     m.captionGroup = m.top.findNode("captionGroup")
     m.captionGroup.createchildren(9, "LayoutGroup")
     m.captionTask = createObject("roSGNode", "captionTask")
-    m.captionTask.observeField("captionPosition", "updateCaptionPosition")
+    m.captionTask.observeField("captionStyles", "updateCaptionStyles")
     m.captionTask.observeField("currentCaption", "updateCaption")
     m.captionTask.observeField("useThis", "checkCaptionMode")
     m.top.observeField("subtitleTrack", "loadCaption")
@@ -416,24 +416,56 @@ sub toggleCaption()
     end if
 end sub
 
-sub updateCaptionPosition()
-    captionPosition = m.captionTask.captionPosition
+sub updateCaptionStyles()
+    captionStyles = m.captionTask.captionStyles
+    if not isValidAndNotEmpty(captionStyles)
+        m.captionGroup.translation = [960, 1020]
+    end if
 
-    if not isValidAndNotEmpty(captionPosition) then captionPosition = "0"
+    captionLine = chainLookupReturn(captionStyles, "line", string.EMPTY)
 
-    if captionPosition.Instr("%") <> -1
-        calculatedPosition = 1080 * (val(captionPosition) / 100)
-        calculatedPosition += m.captionGroup.BoundingRect().height
+    ' Line
+    if not isStringEqual(captionLine, string.EMPTY)
+        ' A percentage
+        if captionLine.Instr("%") <> -1
+            calculatedPosition = 1080 * (val(captionLine) / 100)
+            calculatedPosition += m.captionGroup.BoundingRect().height
 
-        if calculatedPosition > 1020
-            calculatedPosition = 1020
+            if calculatedPosition > 1020
+                calculatedPosition = 1020
+            end if
+
+            m.captionGroup.translation = [960, calculatedPosition]
+            return
+        end if
+
+        ' Note: Non-numeric values are treated as 0
+        lineValue = val(captionLine)
+
+        ' A positive line value. Count from the top
+        if lineValue >= 0
+            calculatedPosition = (lineValue + 1) * m.captionGroup.BoundingRect().height
+
+            if calculatedPosition > 1020
+                calculatedPosition = 1020
+            end if
+
+            m.captionGroup.translation = [960, calculatedPosition]
+            return
+        end if
+
+        ' A negative line value. Count from the bottom
+        calculatedPosition = 1080 - Abs((lineValue + 1) * m.captionGroup.BoundingRect().height)
+
+        if calculatedPosition < 0
+            calculatedPosition = 0
         end if
 
         m.captionGroup.translation = [960, calculatedPosition]
         return
     end if
 
-    ' No position passed, reset to default position
+    ' No styles passed, reset to default position
     m.captionGroup.translation = [960, 1020]
 end sub
 

--- a/source/static/whatsNew/3.0.8.json
+++ b/source/static/whatsNew/3.0.8.json
@@ -28,7 +28,7 @@
     "author": "1hitsong"
   },
   {
-    "description": "Add support for VTT percentage line placement to custom subs",
+    "description": "Add support for VTT line property to custom subs",
     "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Updates the custom sub line logic to accept line numbers (both positive and negative)

Logic based on https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API/Web_Video_Text_Tracks_Format#line