### PR TITLE
Add "Shuffle Play Collection" to collection's option menu

### DIFF
--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -2077,7 +2077,11 @@ sub onMyListLoaded()
     focusedItem = getItemFocused()
     if not isValid(focusedItem) then return
 
-    dialogData = isInMyListData[0] ? [tr("Remove From My List")] : [tr("Add To My List")]
+    dialogData = [tr("Shuffle Play Collection")]
+
+    myListOption = isInMyListData[0] ? [tr("Remove From My List")] : [tr("Add To My List")]
+    dialogData.push(myListOption)
+
     dialogData.push(tr("Add To Playlist"))
     paramData = {
         id: focusedItem.LookupCI("id")

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2113,5 +2113,9 @@
             <source>The text color of the user's name in the header.</source>
             <translation>The text color of the user's name in the header.</translation>
         </message>
+        <message>
+            <source>Shuffle Play Collection</source>
+            <translation>Shuffle Play Collection</translation>
+        </message>
     </context>
 </TS>

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -1658,6 +1658,21 @@ sub processLibraryItemPopup(selectedPopupButton as string, itemID as string, par
         return
     end if
 
+    if isStringEqual(selectedPopupButton, tr("Shuffle Play Collection"))
+        quickplay.boxset({
+            id: itemID
+        })
+
+        if not m.global.queueManager.callFunc("getIsShuffled")
+            m.global.queueManager.callFunc("toggleShuffle")
+        end if
+
+        m.global.queueManager.callFunc("getIsShuffled")
+
+        m.global.queueManager.callFunc("playQueue")
+        return
+    end if
+
     ' Remove item from user's list
     if isStringEqual(selectedPopupButton, tr("Remove From My List"))
         MainAction.removeItemFromMyList(itemID)

--- a/source/static/whatsNew/3.0.8.json
+++ b/source/static/whatsNew/3.0.8.json
@@ -30,5 +30,9 @@
   {
     "description": "Add support for VTT percentage line placement to custom subs",
     "author": "1hitsong"
+  },
+  {
+    "description": "Add \"Shuffle Play Collection\" to collection's option menu",
+    "author": "1hitsong"
   }
 ]

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -619,7 +619,7 @@ end function
 ' Takes an array of data, shuffles the order, then returns the array
 ' uses the Fisher-Yates shuffling algorithm
 function shuffleArray(array as object) as object
-    for i = array.count() - 1 to 1 step -1
+    for i = array.count() - 1 to 0 step -1
         j = Rnd(i + 1) - 1
         t = array[i] : array[i] = array[j] : array[j] = t
     end for


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Updates the array shuffle function to include the 1st item
- Adds Shuffle Play Collection to the collection's option menu
  - Clicking the option will shuffle all items in the collection and play them back in the shuffled order

## Screenshot
![WIN_20250817_11_54_22_Pro](https://github.com/user-attachments/assets/bd187985-1355-4331-97a1-c97616f0f1d0)
