### PR TITLE
Add support for displaying multiple captions, in different locations, at the same time

### DIFF
--- a/bslint.json
+++ b/bslint.json
@@ -1,5 +1,5 @@
 {
-    "rules": {
-        "unused-variable": "error"
-    }
+  "rules": {
+    "unused-variable": "warn"
+  }
 }

--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -206,7 +206,7 @@ function processLineCue(captionLine as string, captionLineHeight as float) as in
         calculatedPosition = 1080 * (val(captionLine) / 100)
 
         if calculatedPosition + captionLineHeight > 1080
-            calculatedPosition = 1080
+            calculatedPosition = 1080 - captionLineHeight
         end if
 
         return calculatedPosition
@@ -315,7 +315,6 @@ function parseVTT(lines)
             if i = (lines.count() - 1)
                 entry.AddReplace("text", currentLine)
                 entries.push(entry)
-                isNewLine = false
 
                 exit for
             end if

--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -1,5 +1,6 @@
 import "pkg:/source/api/baserequest.bs"
 import "pkg:/source/enums/MediaPlaybackState.bs"
+import "pkg:/source/enums/String.bs"
 import "pkg:/source/utils/config.bs"
 
 sub init()
@@ -95,31 +96,101 @@ end function
 
 
 sub updateCaption()
-    m.top.currentCaption = []
-    if LCase(m.top.playerState) = "playingon"
-        m.top.currentPos = m.top.currentPos + 100
-        texts = []
-        captionStyles = {}
-        for each entry in m.captionList
-            if entry["start"] <= m.top.currentPos and m.top.currentPos < entry["end"]
-                captionStyles = entry["styles"]
-                t = m.tags.replaceAll(entry["text"], "")
-                texts.push(t)
-            end if
-        end for
-        labels = []
-        for each text in texts
-            labels.push(newlabel (text))
-        end for
-        lines = newLayoutGroup(labels)
-        rect = newRect(lines)
-        m.top.currentCaption = [rect, lines]
-
-        m.top.captionStyles = captionStyles
-    else if LCase(m.top.playerState.right(1)) = "w"
+    if LCase(m.top.playerState.right(1)) = "w"
         m.top.playerState = m.top.playerState.left(len (m.top.playerState) - 1)
+        return
     end if
+
+    m.top.currentCaption = []
+
+    if not isStringEqual(m.top.playerState, "playingon") then return
+
+    m.top.currentPos = m.top.currentPos + 100
+    captions = []
+
+    for each entry in m.captionList
+        if entry["start"] <= m.top.currentPos and m.top.currentPos < entry["end"]
+
+            labels = []
+            for each text in entry["text"]
+                labels.push(newlabel(text))
+            end for
+
+            lines = newLayoutGroup(labels)
+            rect = newRect(lines)
+
+            finalStyles = prepareStyles(entry["styles"], rect)
+            lines.translation = finalStyles.translation
+
+            rectxy = lines.BoundingRect()
+            rect.translation = [finalStyles.translation[0], finalStyles.translation[1] - (rectxy.height / 2)]
+
+            captions.push([rect, lines])
+        end if
+    end for
+
+    m.top.currentCaption = captions
 end sub
+
+function prepareStyles(styles as object, rect) as object
+    captionStyles = styles
+    finalStyles = { translation: [960, 1020] }
+
+    verticalPosition = 1020
+
+    if not isValidAndNotEmpty(captionStyles)
+        return finalStyles
+    end if
+
+    captionLine = chainLookupReturn(captionStyles, "line", string.EMPTY)
+
+    ' Line
+    if not isStringEqual(captionLine, string.EMPTY)
+        captionLineHeight = rect.BoundingRect().height
+        verticalPosition = processLineCue(captionLine, captionLineHeight)
+    end if
+
+    finalStyles.translation = [960, verticalPosition]
+
+    return finalStyles
+end function
+
+function processLineCue(captionLine as string, captionLineHeight as float) as integer
+    ' A percentage
+    if captionLine.Instr("%") <> -1
+        calculatedPosition = 1080 * (val(captionLine) / 100)
+        calculatedPosition += captionLineHeight
+
+        if calculatedPosition > 1020
+            calculatedPosition = 1020
+        end if
+
+        return calculatedPosition
+    end if
+
+    ' Note: Non-numeric values are treated as 0
+    lineValue = val(captionLine)
+
+    ' A positive line value. Count from the top
+    if lineValue >= 0
+        calculatedPosition = (lineValue + 1) * captionLineHeight
+
+        if calculatedPosition > 1020
+            calculatedPosition = 1020
+        end if
+
+        return calculatedPosition
+    end if
+
+    ' A negative line value. Count from the bottom
+    calculatedPosition = 1080 - Abs((lineValue + 1) * captionLineHeight)
+
+    if calculatedPosition < 0
+        calculatedPosition = 0
+    end if
+
+    return calculatedPosition
+end function
 
 function isTime(text)
     return text.right(1) = chr(31)
@@ -158,20 +229,40 @@ function parseVTT(lines)
     curEnd = -1
     entries = []
 
+    currentLine = []
+    entry = {}
+
+    isNewLine = false
+
     for i = 0 to lines.count() - 1
         if isTime(lines[i])
+            currentLine = []
+
             curStart = toMs(lines[i])
             lineData = extractStyles(lines[i + 1])
             curEnd = toMs(lineData.LookupCI("endTimestamp"))
             curstyles = chainLookup(lineData, "styles")
+            entry = { "start": curStart, "end": curEnd, "styles": curstyles }
+            isNewLine = true
+
             i += 1
-        else if curStart <> -1
+            continue for
+        end if
+
+        if isNewLine
             trimmed = lines[i].trim()
-            if trimmed <> chr(0)
-                entry = { "start": curStart, "end": curEnd, "text": trimmed, "styles": curstyles }
+            finalText = m.tags.replaceAll(trimmed, "")
+
+            if isStringEqual(finalText, string.EMPTY)
+                entry.AddReplace("text", currentLine)
                 entries.push(entry)
+                isNewLine = false
+            else
+                currentLine.push(finalText)
             end if
+
         end if
     end for
+
     return entries
 end function

--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -1,4 +1,5 @@
 import "pkg:/source/api/baserequest.bs"
+import "pkg:/source/enums/CaptionMoveDirection.bs"
 import "pkg:/source/enums/MediaPlaybackState.bs"
 import "pkg:/source/enums/String.bs"
 import "pkg:/source/utils/config.bs"
@@ -77,10 +78,11 @@ function newLayoutGroup(labels)
     return newlg
 end function
 
-function newRect(lg)
+function newRect(lg, id as string)
     rectxy = lg.BoundingRect()
 
     rect = CreateObject("roSGNode", "Rectangle")
+    rect.addreplace("id", id)
     rect.appendchild(lg)
     lg.translation = [5, 5]
 
@@ -120,10 +122,12 @@ sub updateCaption()
             end for
 
             lines = newLayoutGroup(labels)
-            rect = newRect(lines)
+            rect = newRect(lines, entry.LookupCI("id"))
 
-            finalStyles = prepareStyles(entry["styles"], rect)
+            finalStyles = prepareStyles(entry["styles"], rect, labels.count())
             rect.translation = finalStyles.translation
+
+            adjustForCaptionOverlaps(rect, captions)
 
             captions.push(rect)
         end if
@@ -132,7 +136,47 @@ sub updateCaption()
     m.top.currentCaption = captions
 end sub
 
-function prepareStyles(styles as object, rect) as object
+sub adjustForCaptionOverlaps(newCaption, existingCaptions, moveDirection = CaptionMoveDirection.UP)
+    newCaptionBounds = newCaption.sceneBoundingRect()
+
+    for i = existingCaptions.count() - 1 to 0 step -1
+        comparisonCaption = existingCaptions[i]
+
+        ' Don't compare the caption to itself
+        if isStringEqual(newCaption.lookupCI("id"), comparisonCaption.lookupCI("id")) then continue for
+
+        comparisonCaptionBounds = comparisonCaption.sceneBoundingRect()
+
+        overlapping = isOverlapping(newCaption, comparisonCaption)
+
+        if overlapping
+            ' If we're in the top half of the screen, push the other caption down
+            ' otherwise push the other caption up
+            if newCaptionBounds.y < 540
+                moveDirection = CaptionMoveDirection.DOWN
+            end if
+
+            if moveDirection = CaptionMoveDirection.DOWN
+                calculatedVerticalPosition = newCaptionBounds.y + newCaptionBounds.height + 5
+            else
+                calculatedVerticalPosition = newCaptionBounds.y - comparisonCaptionBounds.height - 5
+            end if
+
+            if calculatedVerticalPosition < 0 then calculatedVerticalPosition = 0
+
+            comparisonCaption.translation = [comparisonCaption.translation[0], calculatedVerticalPosition]
+            adjustForCaptionOverlaps(comparisonCaption, existingCaptions, moveDirection)
+        end if
+    end for
+end sub
+
+function isOverlapping(node1, node2) as boolean
+    node1Bounds = node1.sceneBoundingRect()
+    node2Bounds = node2.sceneBoundingRect()
+    return node1Bounds.x < (node2Bounds.x + node2Bounds.width) and node2Bounds.x < (node1Bounds.x + node1Bounds.width) and node1Bounds.y < (node2Bounds.y + node2Bounds.height) and node2Bounds.y < (node1Bounds.y + node1Bounds.height)
+end function
+
+function prepareStyles(styles as object, rect, lineCount = 1 as integer) as object
     captionStyles = styles
     finalStyles = { translation: [960, 1020] }
 
@@ -147,7 +191,7 @@ function prepareStyles(styles as object, rect) as object
 
     ' Line
     if not isStringEqual(captionLine, string.EMPTY)
-        captionLineHeight = rect.BoundingRect().height
+        captionLineHeight = (rect.BoundingRect().height / lineCount)
         verticalPosition = processLineCue(captionLine, captionLineHeight)
     end if
 
@@ -178,7 +222,7 @@ function processLineCue(captionLine as string, captionLineHeight as float) as in
         calculatedPosition = lineValue * captionLineHeight
 
         if calculatedPosition + captionLineHeight > 1080
-            calculatedPosition = 1080
+            calculatedPosition = 1080 - captionLineHeight
         end if
 
         return calculatedPosition
@@ -244,7 +288,7 @@ function parseVTT(lines)
             lineData = extractStyles(lines[i + 1])
             curEnd = toMs(lineData.LookupCI("endTimestamp"))
             curstyles = chainLookup(lineData, "styles")
-            entry = { "start": curStart, "end": curEnd, "styles": curstyles }
+            entry = { "start": curStart, "end": curEnd, "styles": curstyles, "id": `caption${i}` }
             isNewLine = true
 
             i += 1
@@ -255,12 +299,25 @@ function parseVTT(lines)
             trimmed = lines[i].trim()
             finalText = m.tags.replaceAll(trimmed, "")
 
+            ' We reached a blank line
             if isStringEqual(finalText, string.EMPTY)
                 entry.AddReplace("text", currentLine)
                 entries.push(entry)
                 isNewLine = false
-            else
-                currentLine.push(finalText)
+
+                continue for
+            end if
+
+            ' We're inside a text block
+            currentLine.push(finalText)
+
+            ' We reached the end of the file and it doesn't end with a blank line
+            if i = (lines.count() - 1)
+                entry.AddReplace("text", currentLine)
+                entries.push(entry)
+                isNewLine = false
+
+                exit for
             end if
 
         end if

--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -70,28 +70,31 @@ end function
 function newLayoutGroup(labels)
     newlg = CreateObject("roSGNode", "LayoutGroup")
     newlg.appendchildren(labels)
-    newlg.horizalignment = "center"
-    newlg.vertalignment = "bottom"
+    newlg.layoutDirection = "vert"
+    newlg.horizalignment = "left"
+    newlg.vertalignment = "top"
+    newlg.itemSpacings = "[5]"
     return newlg
 end function
 
 function newRect(lg)
-    rectLG = CreateObject("roSGNode", "LayoutGroup")
     rectxy = lg.BoundingRect()
+
     rect = CreateObject("roSGNode", "Rectangle")
+    rect.appendchild(lg)
+    lg.translation = [5, 5]
+
     rect.color = m.bgColor
     rect.opacity = m.bgOpac
-    rect.width = rectxy.width + 50
-    rect.height = rectxy.height
+    rect.width = rectxy.width + 10
+    rect.height = rectxy.height + 10
+
     if lg.getchildCount() = 0
         rect.width = 0
         rect.height = 0
     end if
-    rectLG.translation = [0, -rect.height / 2]
-    rectLG.horizalignment = "center"
-    rectLG.vertalignment = "center"
-    rectLG.appendchild(rect)
-    return rectLG
+
+    return rect
 end function
 
 
@@ -120,12 +123,9 @@ sub updateCaption()
             rect = newRect(lines)
 
             finalStyles = prepareStyles(entry["styles"], rect)
-            lines.translation = finalStyles.translation
+            rect.translation = finalStyles.translation
 
-            rectxy = lines.BoundingRect()
-            rect.translation = [finalStyles.translation[0], finalStyles.translation[1] - (rectxy.height / 2)]
-
-            captions.push([rect, lines])
+            captions.push(rect)
         end if
     end for
 
@@ -137,6 +137,7 @@ function prepareStyles(styles as object, rect) as object
     finalStyles = { translation: [960, 1020] }
 
     verticalPosition = 1020
+    horizontalPositon = 960 - (rect.BoundingRect().width / 2)
 
     if not isValidAndNotEmpty(captionStyles)
         return finalStyles
@@ -150,7 +151,7 @@ function prepareStyles(styles as object, rect) as object
         verticalPosition = processLineCue(captionLine, captionLineHeight)
     end if
 
-    finalStyles.translation = [960, verticalPosition]
+    finalStyles.translation = [horizontalPositon, verticalPosition]
 
     return finalStyles
 end function
@@ -159,10 +160,9 @@ function processLineCue(captionLine as string, captionLineHeight as float) as in
     ' A percentage
     if captionLine.Instr("%") <> -1
         calculatedPosition = 1080 * (val(captionLine) / 100)
-        calculatedPosition += captionLineHeight
 
-        if calculatedPosition > 1020
-            calculatedPosition = 1020
+        if calculatedPosition + captionLineHeight > 1080
+            calculatedPosition = 1080
         end if
 
         return calculatedPosition
@@ -171,19 +171,21 @@ function processLineCue(captionLine as string, captionLineHeight as float) as in
     ' Note: Non-numeric values are treated as 0
     lineValue = val(captionLine)
 
+    if lineValue = 0 then return 0
+
     ' A positive line value. Count from the top
     if lineValue >= 0
-        calculatedPosition = (lineValue + 1) * captionLineHeight
+        calculatedPosition = lineValue * captionLineHeight
 
-        if calculatedPosition > 1020
-            calculatedPosition = 1020
+        if calculatedPosition + captionLineHeight > 1080
+            calculatedPosition = 1080
         end if
 
         return calculatedPosition
     end if
 
     ' A negative line value. Count from the bottom
-    calculatedPosition = 1080 - Abs((lineValue + 1) * captionLineHeight)
+    calculatedPosition = 1080 - Abs(lineValue * captionLineHeight)
 
     if calculatedPosition < 0
         calculatedPosition = 0

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -418,23 +418,25 @@ end sub
 ' Removes old subtitle lines and adds new subtitle lines
 sub updateCaption()
     m.captionGroup.removeChildrenIndex(m.captionGroup.getChildCount(), 0)
+    m.captionGroup.appendChildren(m.captionTask.currentCaption)
+    ' adjustForCaptionOverlaps()
+end sub
 
-    for each currentCaption in m.captionTask.currentCaption
-        for each caption in currentCaption
-            captionBounds = caption.sceneBoundingRect()
+sub adjustForCaptionOverlaps()
+    activeCaptions = m.captionGroup.getChildren(-1, 0)
 
-            fullCaptionList = m.captionGroup.getChildren(-1, 0)
-            for each activeCaption in fullCaptionList
-                activeCaptionBounds = activeCaption.sceneBoundingRect()
+    for each currentCaption in activeCaptions
+        captionBounds = currentCaption.sceneBoundingRect()
 
-                isOverlapping = captionBounds.x < (activeCaptionBounds.x + activeCaptionBounds.width) and activeCaptionBounds.x < (captionBounds.x + captionBounds.width) and captionBounds.y < (activeCaptionBounds.y + activeCaptionBounds.height) and activeCaptionBounds.y < (captionBounds.y + captionBounds.width)
-                if isOverlapping
-                    activeCaption.translation = [activeCaption.translation[0], activeCaption.translation[1] - activeCaptionBounds.height]
-                end if
-            end for
+        for each activeCaption in activeCaptions
+            activeCaptionBounds = activeCaption.sceneBoundingRect()
 
+            isOverlapping = captionBounds.x < (activeCaptionBounds.x + activeCaptionBounds.width) and activeCaptionBounds.x < (captionBounds.x + captionBounds.width) and captionBounds.y < (activeCaptionBounds.y + activeCaptionBounds.height) and activeCaptionBounds.y < (captionBounds.y + captionBounds.width)
+            if isOverlapping
+                activeCaption.translation = [activeCaption.translation[0], activeCaption.translation[1] - activeCaptionBounds.height]
+            end if
         end for
-        m.captionGroup.appendChildren(currentCaption)
+
     end for
 end sub
 

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -384,7 +384,6 @@ sub onAllowCaptionsChange()
     m.captionGroup = m.top.findNode("captionGroup")
     m.captionGroup.createchildren(9, "LayoutGroup")
     m.captionTask = createObject("roSGNode", "captionTask")
-    m.captionTask.observeField("captionStyles", "updateCaptionStyles")
     m.captionTask.observeField("currentCaption", "updateCaption")
     m.captionTask.observeField("useThis", "checkCaptionMode")
     m.top.observeField("subtitleTrack", "loadCaption")
@@ -416,63 +415,13 @@ sub toggleCaption()
     end if
 end sub
 
-sub updateCaptionStyles()
-    captionStyles = m.captionTask.captionStyles
-    if not isValidAndNotEmpty(captionStyles)
-        m.captionGroup.translation = [960, 1020]
-    end if
-
-    captionLine = chainLookupReturn(captionStyles, "line", string.EMPTY)
-
-    ' Line
-    if not isStringEqual(captionLine, string.EMPTY)
-        ' A percentage
-        if captionLine.Instr("%") <> -1
-            calculatedPosition = 1080 * (val(captionLine) / 100)
-            calculatedPosition += m.captionGroup.BoundingRect().height
-
-            if calculatedPosition > 1020
-                calculatedPosition = 1020
-            end if
-
-            m.captionGroup.translation = [960, calculatedPosition]
-            return
-        end if
-
-        ' Note: Non-numeric values are treated as 0
-        lineValue = val(captionLine)
-
-        ' A positive line value. Count from the top
-        if lineValue >= 0
-            calculatedPosition = (lineValue + 1) * m.captionGroup.BoundingRect().height
-
-            if calculatedPosition > 1020
-                calculatedPosition = 1020
-            end if
-
-            m.captionGroup.translation = [960, calculatedPosition]
-            return
-        end if
-
-        ' A negative line value. Count from the bottom
-        calculatedPosition = 1080 - Abs((lineValue + 1) * m.captionGroup.BoundingRect().height)
-
-        if calculatedPosition < 0
-            calculatedPosition = 0
-        end if
-
-        m.captionGroup.translation = [960, calculatedPosition]
-        return
-    end if
-
-    ' No styles passed, reset to default position
-    m.captionGroup.translation = [960, 1020]
-end sub
-
 ' Removes old subtitle lines and adds new subtitle lines
 sub updateCaption()
     m.captionGroup.removeChildrenIndex(m.captionGroup.getChildCount(), 0)
-    m.captionGroup.appendChildren(m.captionTask.currentCaption)
+
+    for each caption in m.captionTask.currentCaption
+        m.captionGroup.appendChildren(caption)
+    end for
 end sub
 
 ' Event handler for when selectedSubtitle changes

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -419,25 +419,6 @@ end sub
 sub updateCaption()
     m.captionGroup.removeChildrenIndex(m.captionGroup.getChildCount(), 0)
     m.captionGroup.appendChildren(m.captionTask.currentCaption)
-    ' adjustForCaptionOverlaps()
-end sub
-
-sub adjustForCaptionOverlaps()
-    activeCaptions = m.captionGroup.getChildren(-1, 0)
-
-    for each currentCaption in activeCaptions
-        captionBounds = currentCaption.sceneBoundingRect()
-
-        for each activeCaption in activeCaptions
-            activeCaptionBounds = activeCaption.sceneBoundingRect()
-
-            isOverlapping = captionBounds.x < (activeCaptionBounds.x + activeCaptionBounds.width) and activeCaptionBounds.x < (captionBounds.x + captionBounds.width) and captionBounds.y < (activeCaptionBounds.y + activeCaptionBounds.height) and activeCaptionBounds.y < (captionBounds.y + captionBounds.width)
-            if isOverlapping
-                activeCaption.translation = [activeCaption.translation[0], activeCaption.translation[1] - activeCaptionBounds.height]
-            end if
-        end for
-
-    end for
 end sub
 
 ' Event handler for when selectedSubtitle changes

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -419,8 +419,22 @@ end sub
 sub updateCaption()
     m.captionGroup.removeChildrenIndex(m.captionGroup.getChildCount(), 0)
 
-    for each caption in m.captionTask.currentCaption
-        m.captionGroup.appendChildren(caption)
+    for each currentCaption in m.captionTask.currentCaption
+        for each caption in currentCaption
+            captionBounds = caption.sceneBoundingRect()
+
+            fullCaptionList = m.captionGroup.getChildren(-1, 0)
+            for each activeCaption in fullCaptionList
+                activeCaptionBounds = activeCaption.sceneBoundingRect()
+
+                isOverlapping = captionBounds.x < (activeCaptionBounds.x + activeCaptionBounds.width) and activeCaptionBounds.x < (captionBounds.x + captionBounds.width) and captionBounds.y < (activeCaptionBounds.y + activeCaptionBounds.height) and activeCaptionBounds.y < (captionBounds.y + captionBounds.width)
+                if isOverlapping
+                    activeCaption.translation = [activeCaption.translation[0], activeCaption.translation[1] - activeCaptionBounds.height]
+                end if
+            end for
+
+        end for
+        m.captionGroup.appendChildren(currentCaption)
     end for
 end sub
 

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -30,7 +30,7 @@
   </interface>
 
   <children>
-    <Group id="captionGroup" translation="[960,1020]" />
+    <Group id="captionGroup" translation="[0,0]" />
     <timer id="playbackTimer" repeat="true" duration="30" />
     <timer id="bufferCheckTimer" repeat="true" />
     <OSD id="osd" visible="false" inactiveTimeout="5" />

--- a/source/enums/CaptionMoveDirection.bs
+++ b/source/enums/CaptionMoveDirection.bs
@@ -1,0 +1,5 @@
+enum CaptionMoveDirection
+    NOTSET
+    UP
+    DOWN
+end enum

--- a/source/static/whatsNew/3.0.9.json
+++ b/source/static/whatsNew/3.0.9.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "",
-    "author": ""
+    "description": "Add custom subtitle support for multiple captions, in different locations, at the same time",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Update the caption task code to support sending multiple captions at once
- Update video player logic to support displaying multiple captions at once
- Move style code to captionTask
- Add logic to "push" displayed captions when a new caption overlaps its location on screen

## Screenshot
![WIN_20250823_14_37_50_Pro](https://github.com/user-attachments/assets/9a19f261-7c98-40cc-a58d-1cb53fbcc8ca)
