### PR TITLE
Add played checkmark to individual items in playlists

### DIFF
--- a/components/data/PlaylistItemData.xml
+++ b/components/data/PlaylistItemData.xml
@@ -12,6 +12,7 @@
     <field id="ParentIndexNumber" type="integer" />
     <field id="ProductionYear" type="integer" />
     <field id="OfficialRating" type="string" />
+    <field id="played" type="boolean" />
     <field id="album" type="string" />
     <field id="image" type="node" onChange="setPoster" />
     <field id="overview" type="string" />

--- a/components/music/PlaylistItem.bs
+++ b/components/music/PlaylistItem.bs
@@ -29,10 +29,14 @@ sub itemContentChanged()
         tracklength.text = ticksToHuman(itemData.LookupCI("RunTimeTicks"))
     end if
 
-    playedIndicator = m.top.findNode("playedIndicator")
-    playedIndicator.data = {
-        played: chainLookupReturn(itemData, "played", false)
-    }
+    ' Only apply the played checkmark to specific item types
+    playlistItemType = chainLookupReturn(itemData, "type", string.EMPTY)
+    if inArray([ItemType.MOVIE, ItemType.MUSICVIDEO, ItemType.EPISODE, ItemType.RECORDING, ItemType.VIDEO, ItemType.PROGRAM], playlistItemType)
+        playedIndicator = m.top.findNode("playedIndicator")
+        playedIndicator.data = {
+            played: chainLookupReturn(itemData, "played", false)
+        }
+    end if
 end sub
 
 function getSubtitleText(itemData as object) as string

--- a/components/music/PlaylistItem.bs
+++ b/components/music/PlaylistItem.bs
@@ -28,6 +28,11 @@ sub itemContentChanged()
         tracklength = m.top.findNode("tracklength")
         tracklength.text = ticksToHuman(itemData.LookupCI("RunTimeTicks"))
     end if
+
+    playedIndicator = m.top.findNode("playedIndicator")
+    playedIndicator.data = {
+        played: chainLookupReturn(itemData, "played", false)
+    }
 end sub
 
 function getSubtitleText(itemData as object) as string

--- a/components/music/PlaylistItem.xml
+++ b/components/music/PlaylistItem.xml
@@ -9,7 +9,10 @@
         <ScrollingText height="25" id="subtitle" horizAlign="left" vertAlign="center" font="font:SmallSystemFont" maxWidth="850" />
       </LayoutGroup>
 
-      <PlayedCheckmark id="playedIndicator" width="60" height="46" />
+      <LayoutGroup layoutDirection="vert" horizAlignment="left" itemSpacings="[0]">
+        <Rectangle width="60" height="10" color="0X00000000" />
+        <PlayedCheckmark id="playedIndicator" width="60" height="46" scale="[.75, .75]" scaleRotateCenter="[0, 0]" />
+      </LayoutGroup>
 
       <Text id="tracklength" height="60" horizAlign="right" vertAlign="center" font="font:SmallBoldSystemFont" width="150" />
     </LayoutGroup>

--- a/components/music/PlaylistItem.xml
+++ b/components/music/PlaylistItem.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="PlaylistItem" extends="Group">
   <children>
-    <LayoutGroup layoutDirection="horiz" horizAlignment="left" itemSpacings="[25, 0]" translation="[0, 15]">
+    <LayoutGroup layoutDirection="horiz" horizAlignment="left" itemSpacings="[25]" translation="[0, 15]">
       <Poster id="mediaTypeIcon" width="32" height="32" />
-      <LayoutGroup layoutDirection="vert" horizAlignment="left" itemSpacings="[0, 10]">
-        <ScrollingText height="40" id="title" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" maxWidth="960" />
-        <ScrollingText height="25" id="subtitle" horizAlign="left" vertAlign="center" font="font:SmallSystemFont" maxWidth="960" />
+
+      <LayoutGroup layoutDirection="vert" horizAlignment="left" itemSpacings="[0]">
+        <ScrollingText height="40" id="title" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" maxWidth="850" />
+        <ScrollingText height="25" id="subtitle" horizAlign="left" vertAlign="center" font="font:SmallSystemFont" maxWidth="850" />
       </LayoutGroup>
+
+      <PlayedCheckmark id="playedIndicator" width="60" height="46" />
+
       <Text id="tracklength" height="60" horizAlign="right" vertAlign="center" font="font:SmallBoldSystemFont" width="150" />
     </LayoutGroup>
   </children>

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -423,6 +423,7 @@ function PlaylistItemList(id as string)
         tmp.SeasonName = item.LookupCI("SeasonName")
         tmp.IndexNumberEnd = item.LookupCI("IndexNumberEnd")
         tmp.ParentIndexNumber = item.LookupCI("ParentIndexNumber")
+        tmp.played = chainLookupReturn(item, "UserData.played", false)
         results.push(tmp)
     end for
 

--- a/source/static/whatsNew/3.0.9.json
+++ b/source/static/whatsNew/3.0.9.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "",
-    "author": ""
+    "description": "Add played checkmark to individual items in playlists",
+    "author": "1hitsong"
   }
 ]

--- a/source/static/whatsNew/3.0.9.json
+++ b/source/static/whatsNew/3.0.9.json
@@ -2,7 +2,7 @@
   {
     "description": "Fix possible crash on home screen",
     "author": "1hitsong"
-  }.
+  },
   {
     "description": "Add played checkmark to individual items in playlists",
     "author": "1hitsong"    


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Adds played checkmark to playlist items if they have been played
- Max width of title and subtitle text reduced to make room
- Uses existing played checkmark component so color settings are honored for customization

## Issues
Fixes #485

## Screenshot
![WIN_20250825_20_34_17_Pro](https://github.com/user-attachments/assets/b32f4fd5-3ea5-4961-9c57-48ab0976dfea)

