### PR TITLE
Automatically enable force transcode option if video is rotated

### DIFF
--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -23,6 +23,7 @@ sub init()
     m.scrollBar = m.top.findnode("scrollBar")
     m.thumb = m.top.findnode("thumb")
     m.thumbStep = 0
+    m.performRotationCheck = true
 
     m.scrollBar.opacity = .75
     m.scrollBar.color = ColorPalette.BLACK77
@@ -148,6 +149,7 @@ sub OnScreenShown()
         if isChainValid(m.top.itemContent, "json.mediaStreams")
             SetDefaultAudioTrack(m.top.itemContent.json)
             SetUpAudioOptions(m.top.itemContent.json.mediaStreams)
+            SetUpVideoOptions(m.top.itemContent.json.mediaSources)
         end if
     end if
 
@@ -530,21 +532,32 @@ sub SetUpVideoOptions(streams)
     videos = []
     codecDetailsSet = false
 
+    setFieldText("rotationWarning", string.EMPTY)
+
     for i = 0 to streams.Count() - 1
         if LCase(streams[i].VideoType) = VideoType.VIDEOFILE
             codec = ""
             if isValidAndNotEmpty(streams[i].mediaStreams)
 
                 ' find the first (default) video track to get the codec for the details screen
-                if not codecDetailsSet
-                    for index = 0 to streams[i].mediaStreams.Count() - 1
-                        if LCase(streams[i].mediaStreams[index].Type) = MediaStreamType.VIDEO
+
+                for index = 0 to streams[i].mediaStreams.Count() - 1
+                    if LCase(streams[i].mediaStreams[index].Type) = MediaStreamType.VIDEO
+                        if m.performRotationCheck
+                            rotation = chainLookupReturn(streams[i].mediaStreams[index], "rotation", 0)
+                            if rotation <> 0
+                                setFieldText("rotationWarning", tr("Note: Force transcode option automatically enabled due to video rotation"))
+                                m.global.queueManager.callFunc("setForceTranscode", true)
+                            end if
+                        end if
+
+                        if not codecDetailsSet
                             setFieldText("video_codec", tr("Video") + ": " + streams[i].mediaStreams[index].displayTitle)
                             codecDetailsSet = true
-                            exit for
                         end if
-                    end for
-                end if
+                        exit for
+                    end if
+                end for
 
                 codec = streams[i].mediaStreams[0].displayTitle
             end if
@@ -778,6 +791,13 @@ sub videoOptionsClosed()
         m.top.observeField("itemContent", "itemContentChanged")
     end if
     m.buttonGrp.setFocus(true)
+
+    ' If user manually disables force transcode, disable rotation check
+    m.performRotationCheck = m.global.queueManager.callFunc("getForceTranscode")
+    if not m.performRotationCheck
+        setFieldText("rotationWarning", string.EMPTY)
+    end if
+
     group = m.global.sceneManager.callFunc("getActiveScene")
     group.lastFocus = m.buttonGrp
 end sub

--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -150,8 +150,8 @@ sub OnScreenShown()
             SetDefaultAudioTrack(m.top.itemContent.json)
             SetUpAudioOptions(m.top.itemContent.json.mediaStreams)
         end if
-        if isChainValid(m.top.itemContent, "json.mediaStreams")
-            SetUpVideoOptions(m.top.itemContent.json.mediaStreams)
+        if isChainValid(m.top.itemContent, "json.mediaSources")
+            SetUpVideoOptions(m.top.itemContent.json.mediaSources)
         end if
     end if
 

--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -149,7 +149,9 @@ sub OnScreenShown()
         if isChainValid(m.top.itemContent, "json.mediaStreams")
             SetDefaultAudioTrack(m.top.itemContent.json)
             SetUpAudioOptions(m.top.itemContent.json.mediaStreams)
-            SetUpVideoOptions(m.top.itemContent.json.mediaSources)
+        end if
+        if isChainValid(m.top.itemContent, "json.mediaStreams")
+            SetUpVideoOptions(m.top.itemContent.json.mediaStreams)
         end if
     end if
 

--- a/components/movies/MovieDetails.xml
+++ b/components/movies/MovieDetails.xml
@@ -37,6 +37,9 @@
 
           <LayoutGroup layoutDirection="vert" itemSpacings="[0]">
             <LayoutGroup layoutDirection="horiz" horizAlignment="left">
+              <Text id="rotationWarning" font="font:smallestboldSystemFont" vertAlign="top" color="#eeeeee" />
+            </LayoutGroup>
+            <LayoutGroup layoutDirection="horiz" horizAlignment="left">
               <ScrollingText id="video_codec" vertAlign="bottom" height="39" maxwidth="990" font="font:SmallestSystemFont" color="#aaaaaa" />
               <Text id="video_codec_count" font="font:smallestSystemFont" vertAlign="top" color="#aaaaaa" />
             </LayoutGroup>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2117,5 +2117,9 @@
             <source>Shuffle Play Collection</source>
             <translation>Shuffle Play Collection</translation>
         </message>
+        <message>
+            <source>Note: Force transcode option automatically enabled due to video rotation</source>
+            <translation>Note: Force transcode option automatically enabled due to video rotation</translation>
+        </message>
     </context>
 </TS>

--- a/source/static/whatsNew/3.0.9.json
+++ b/source/static/whatsNew/3.0.9.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "",
-    "author": ""
+    "description": "Automatically enable force transcode option if video is rotated",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Reads the rotation property of the media stream and if it is not 0 enables the force transcode option
- Adds a note on the movie detail screen to display if the force transcode option was automatically enabled

## Issues
Fixes #500

## Demo Video
https://github.com/user-attachments/assets/dde5b9d9-b8bc-460e-be0d-1e29dfbb3238

