### PR TITLE
Improve automatic audio track selection logic

### DIFF
--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -622,20 +622,30 @@ sub SetDefaultAudioTrack(itemData)
     preferredLanguage = m.global.session.user.Configuration.AudioLanguagePreference
     firstAudioTrack = -1
 
+    defaultAudioTrackIndex = getDefaultAudioTrackIndex(itemData.mediaStreams)
+    defaultAudioTrackName = string.EMPTY
+
     ' If user has not selected an audio track and PlayDefaultAudioTrack setting is enabled, find the default track
     if preferredAudioTrackIndex < 0 and chainLookupReturn(m.global.session, "user.Configuration.PlayDefaultAudioTrack", false)
-        preferredAudioTrackIndex = findDefaultTrack(itemData.mediaStreams)
+        preferredAudioTrackIndex = defaultAudioTrackIndex
     end if
 
     audioStreamCount = 1
     for i = 0 to itemData.mediaStreams.Count() - 1
         if itemData.mediaStreams[i].Type = "Audio"
-            if firstAudioTrack < 0 then firstAudioTrack = i
-
             rokuTrackName = `#uniq:${itemData.mediaStreams[i].LookupCI("Title") ?? string.EMPTY}(${audioStreamCount})`
 
+            if firstAudioTrack < 0 then firstAudioTrack = i
+
+            if i = defaultAudioTrackIndex then defaultAudioTrackName = rokuTrackName
+
+            if i = preferredAudioTrackIndex
+                m.global.queueManager.callFunc("setPreferredAudioTrackName", rokuTrackName)
+                preferredAudioTrackName = rokuTrackName
+            end if
+
+            ' No user selection and not configured to play the default, how about a preferred language?
             if preferredAudioTrackIndex < 0 and isValid(preferredLanguage)
-                ' No user selection and not configured to play the default, how about a preferred language?
                 if isStringEqual(chainLookupReturn(itemData.mediaStreams[i], "Language", invalid), preferredLanguage)
                     m.top.selectedAudioStreamIndex = i
                     m.global.queueManager.callFunc("setPreferredAudioTrackName", rokuTrackName)
@@ -653,6 +663,13 @@ sub SetDefaultAudioTrack(itemData)
             audioStreamCount++
         end if
     end for
+
+    if defaultAudioTrackIndex > -1
+        m.top.selectedAudioStreamIndex = defaultAudioTrackIndex
+        m.global.queueManager.callFunc("setPreferredAudioTrackName", defaultAudioTrackName)
+        setFieldText("audio_codec", tr("Audio") + ": " + itemData.mediaStreams[defaultAudioTrackIndex].displayTitle)
+        return
+    end if
 
     ' If we got here, then nothing matched.  First track it is...
     if firstAudioTrack > -1

--- a/source/static/whatsNew/3.0.9.json
+++ b/source/static/whatsNew/3.0.9.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "",
-    "author": ""
+    "description": "Improve automatic audio selection logic",
+    "author": "1hitsong"
   }
 ]

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -694,3 +694,15 @@ function findDefaultTrack(streams as dynamic)
     return 1
 end function
 
+function getDefaultAudioTrackIndex(streams as dynamic)
+    for i = 0 to streams.Count() - 1
+        if isStringEqual(streams[i].LookupCI("type"), "audio")
+            if chainLookupReturn(streams[i], "IsDefault", false)
+                return i
+            end if
+        end if
+    end for
+
+    return -1
+end function
+


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Updates automatic audio track selection logic to work down this list and stop at the first possible item:
- If user has manually selected an audio track, use it
- If user has the Play Default setting enabled, play default track
- If user has a language set, play first found track in that language
- Play default track
- Play 1st found audio track

Previously default tracks were **only** being used if the Play Default setting was enabled.

## Issues
Fixes #502
