### PR TITLE
Roku Crach Log: Fix possible crash in OSD for Roku models running older OS version

### DIFF
--- a/components/Clock.bs
+++ b/components/Clock.bs
@@ -51,7 +51,13 @@ sub onCurrentTimeTimerFire()
 end sub
 
 function getCurrentTime()
-    return m.dateTimeObject.AsSecondsLong()
+    try
+        timeInSeconds = m.dateTimeObject.AsSecondsLong()
+    catch e
+        timeInSeconds = m.dateTimeObject.AsSeconds() * 1&
+    end try
+
+    return timeInSeconds
 end function
 
 function getFormattedTime(timestamp as object, allowPastTime = true as boolean)

--- a/components/Clock.bs
+++ b/components/Clock.bs
@@ -1,4 +1,5 @@
 import "pkg:/source/enums/String.bs"
+import "pkg:/source/enums/TimerControl.bs"
 import "pkg:/source/utils/misc.bs"
 
 ' @fileoverview Clock component to display current time formatted based on user's chosen 12 or 24 hour setting
@@ -22,7 +23,7 @@ sub init()
     m.dateTimeObject = CreateObject("roDateTime")
 
     m.currentTimeTimer.observeField("fire", "onCurrentTimeTimerFire")
-    m.currentTimeTimer.control = "start"
+    m.currentTimeTimer.control = TimerControl.START
 
     ' Default to 12 hour clock
     m.format = ClockFormat.h12

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -8,6 +8,7 @@ import "pkg:/source/enums/MediaSegmentAction.bs"
 import "pkg:/source/enums/MediaSegmentType.bs"
 import "pkg:/source/enums/String.bs"
 import "pkg:/source/enums/TaskControl.bs"
+import "pkg:/source/enums/TimerControl.bs"
 import "pkg:/source/enums/VideoControl.bs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/misc.bs"
@@ -1355,6 +1356,9 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
         m.PreloadTrickplayImagesTask.method = "REMOVE"
         m.PreloadTrickplayImagesTask.control = TaskControl.RUN
+
+        currentTimeTimer = m.clock.findNode("currentTimeTimer")
+        if isValid(currentTimeTimer) then currentTimeTimer.control = TimerControl.STOP
 
         m.global.queueManager.callFunc("bypassNextPreferredAudioTrackIndexReset")
         m.global.queueManager.callFunc("clear")

--- a/source/enums/TimerControl.bs
+++ b/source/enums/TimerControl.bs
@@ -1,0 +1,4 @@
+enum TimerControl
+    START = "start"
+    STOP = "stop"
+end enum

--- a/source/static/whatsNew/3.0.9.json
+++ b/source/static/whatsNew/3.0.9.json
@@ -26,5 +26,9 @@
   {
     "description": "Add season and episode information to Roku's video player screen",
     "author": "1hitsong"
+  },
+  {
+    "description": "Fix possible crash in OSD",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Using a try/catch to get current time as seconds long. If it fails, we manually generate the value as a long. Older Roku OS versions may not have this built in function.
- Stop the clock in the OSD from firing when we leave the video player. It's wasted computations since it's not shown.
