### PR TITLE
Burn subtitles if transcoding. Force Transcode option updated to disallow remux.

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -242,6 +242,25 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
         return
     end if
 
+    ' If forceTranscode setting is enabled, but we haven't set the transcode codec yet, set it now and update Playback Info
+    if chainLookupReturn(m.global.session, "user.settings.`playback.media.forceTranscode`", false)
+        if isStringEqual(m.global.queueManager.callFunc("getTranscodeCodec"), string.EMPTY)
+            for i = 0 to m.playbackInfo.MediaSources[0].MediaStreams.Count() - 1
+                if m.playbackInfo.MediaSources[0].MediaStreams[i].Type = "Video"
+                    m.global.queueManager.callFunc("setForceTranscode", true, m.playbackInfo.MediaSources[0].MediaStreams[i].Codec)
+                    exit for
+                end if
+            end for
+
+            m.playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition)
+            if not isValid(m.playbackInfo)
+                video.errorMsg = "Error loading playback info"
+                video.content = invalid
+                return
+            end if
+        end if
+    end if
+
     addSubtitlesToVideo(video, meta)
 
     ' Enable default subtitle track

--- a/components/manager/QueueManager.bs
+++ b/components/manager/QueueManager.bs
@@ -13,6 +13,7 @@ sub init()
     m.getLastKnownItemExtraType = ""
     m.bypassNextPreferredAudioTrackIndexReset = false
     m.forceTranscode = false
+    m.transcodeCodec = string.EMPTY
     m.hold = []
     m.queue = []
     m.originalQueue = []
@@ -288,12 +289,20 @@ function getForceTranscode() as boolean
     return m.forceTranscode
 end function
 
+' Gets the forceTranscode property
+function getTranscodeCodec() as string
+    return m.transcodeCodec
+end function
+
 ' Sets the forceTranscode property
-sub setForceTranscode(forceTranscode as boolean)
+sub setForceTranscode(forceTranscode as boolean, videoCodec = "" as string)
     m.forceTranscode = forceTranscode
 
+    if not forceTranscode then videoCodec = string.EMPTY
+    m.transcodeCodec = videoCodec
+
     postTask = createObject("roSGNode", "PostTask")
-    postTask.arrayData = getDeviceCapabilities()
+    postTask.arrayData = getDeviceCapabilities(videoCodec)
     postTask.apiUrl = "/Sessions/Capabilities/Full"
     postTask.control = "RUN"
 end sub

--- a/components/manager/QueueManager.xml
+++ b/components/manager/QueueManager.xml
@@ -29,6 +29,7 @@
     <function name="resetShuffle" />
     <function name="set" />
     <function name="bypassNextPreferredAudioTrackIndexReset" />
+    <function name="getTranscodeCodec" />
     <function name="getForceTranscode" />
     <function name="setForceTranscode" />
     <function name="getLastKnownItemID" />

--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -380,6 +380,16 @@ sub itemContentChanged()
 
     ' Set default video source if user hasn't selected one yet
     if m.top.selectedVideoStreamId = "" and isValid(itemData.MediaSources)
+        for i = 0 to itemData.mediaStreams.Count() - 1
+            if itemData.mediaStreams[i].Type = "Video"
+                m.options.codec = itemData.MediaStreams[i].Codec
+                if chainLookupReturn(m.global.session, "user.settings.`playback.media.forceTranscode`", false)
+                    m.global.queueManager.callFunc("setForceTranscode", true, m.options.codec)
+                    exit for
+                end if
+            end if
+        end for
+
         m.top.selectedVideoStreamId = itemData.MediaSources[0].id
     end if
 
@@ -538,6 +548,7 @@ sub SetUpVideoOptions(streams)
 
     for i = 0 to streams.Count() - 1
         if LCase(streams[i].VideoType) = VideoType.VIDEOFILE
+            videoCodecForDisplay = ""
             codec = ""
             if isValidAndNotEmpty(streams[i].mediaStreams)
 
@@ -561,7 +572,8 @@ sub SetUpVideoOptions(streams)
                     end if
                 end for
 
-                codec = streams[i].mediaStreams[0].displayTitle
+                videoCodecForDisplay = streams[i].mediaStreams[0].displayTitle
+                codec = streams[i].mediaStreams[0].Codec
             end if
 
             ' Create options for user to switch between video tracks
@@ -570,7 +582,8 @@ sub SetUpVideoOptions(streams)
                 "Description": tr("Video"),
                 "Selected": m.top.selectedVideoStreamId = streams[i].id,
                 "StreamID": streams[i].id,
-                "video_codec": codec
+                "video_codec": videoCodecForDisplay,
+                "codec": codec
             })
         end if
     end for

--- a/components/movies/MovieOptions.bs
+++ b/components/movies/MovieOptions.bs
@@ -119,6 +119,7 @@ sub optionsSet()
             entry.description = view.Description
             entry.streamId = view.streamId
             entry.video_codec = view.video_codec
+            entry.codec = view.codec
             m.videoNames.push(view.Name)
             if isValid(view.Selected) and view.Selected
                 selectedViewIndex = index
@@ -179,6 +180,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
                     m.selectedVideoIndex = selIndex
                     m.top.videoStreamId = newSelection.streamId
                     m.top.video_codec = newSelection.video_codec
+                    m.top.codec = newSelection.codec
                 end if
                 ' Then it is Audio options
             else if m.selectedItem = 1
@@ -203,7 +205,10 @@ function onKeyEvent(key as string, press as boolean) as boolean
                     m.global.queueManager.callFunc("setPreferredSubtitleTrack", newSelection)
                 end if
             else if m.selectedItem = 3 ' Options Menu
-                m.global.queueManager.callFunc("setForceTranscode", m.optionMenu.checkedItem = 1)
+                if chainLookupReturn(m.global.session, "user.settings.`playback.media.forceTranscode`", false)
+                    m.optionMenu.checkedItem = 1
+                end if
+                m.global.queueManager.callFunc("setForceTranscode", m.optionMenu.checkedItem = 1, m.top.codec)
             end if
 
         end if

--- a/components/movies/MovieOptions.xml
+++ b/components/movies/MovieOptions.xml
@@ -31,6 +31,7 @@
     <field id="options" type="assocarray" onChange="optionsSet" />
     <field id="videoStreamId" type="string" />
     <field id="video_codec" type="string" />
+    <field id="codec" type="string" />
     <field id="audioStreamIndex" type="integer" />
     <field id="audioStreamName" type="string" />
     <field id="subtitleStream" type="node" />

--- a/components/movies/VideoTrackListData.xml
+++ b/components/movies/VideoTrackListData.xml
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <component name="VideoTrackListData" extends="ContentNode">
   <interface>
     <field id="selected" type="boolean" value="false" />
     <field id="streamId" type="string" />
     <field id="video_codec" type="string" />
+    <field id="codec" type="string" />
   </interface>
 </component>

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -362,6 +362,10 @@ sub boolSettingChanged()
             ' save to user specific registry block
             set_user_setting(selectedSetting.settingName, "false")
         end if
+
+        if isStringEqual(selectedSetting.settingName, "playback.media.forceTranscode")
+            m.global.queueManager.callFunc("setForceTranscode", false)
+        end if
     end if
 
     if isStringEqual(selectedSetting.settingName, "ui.home.useWebSectionArrangement")

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -559,6 +559,12 @@ sub onVideoContentLoaded()
         return
     end if
 
+    m.isTranscoded = videoContent[0].isTranscoded
+
+    if m.isTranscoded
+        videoContent[0].content.SubtitleTracks = []
+    end if
+
     m.top.content = videoContent[0].content
     m.top.PlaySessionId = videoContent[0].PlaySessionId
     m.top.videoId = videoContent[0].id
@@ -627,8 +633,8 @@ sub onVideoContentLoaded()
         ' Disable trackplay bar for intro videos
         m.top.enableTrickPlay = false
     else
-        ' Allow custom captions for non intro videos
-        m.top.allowCaptions = true
+        ' Allow custom captions for non intro videos as long as the video isn't transcoded
+        m.top.allowCaptions = not m.isTranscoded
     end if
 
     ' Allow default subtitles
@@ -636,12 +642,23 @@ sub onVideoContentLoaded()
 
     ' Set subtitleTrack property if subs are natively supported by Roku
     selectedSubtitle = invalid
+    updatedSubtitleData = []
     for each subtitle in m.top.fullSubtitleData
+        if m.isTranscoded
+            subtitle.IsEncoded = true
+            updatedSubtitleData.push(subtitle)
+        end if
+
         if subtitle.Index = videoContent[0].selectedSubtitle
             selectedSubtitle = subtitle
             exit for
         end if
     end for
+
+    if m.isTranscoded
+        m.top.fullSubtitleData = updatedSubtitleData
+        m.top.globalCaptionMode = "Off"
+    end if
 
     if isValid(selectedSubtitle)
         availableSubtitleTrackIndex = availSubtitleTrackIdx(selectedSubtitle.Track.TrackName)
@@ -657,7 +674,9 @@ sub onVideoContentLoaded()
         end if
     end if
 
-    m.top.selectedSubtitle = videoContent[0].selectedSubtitle
+    if not m.isTranscoded
+        m.top.selectedSubtitle = videoContent[0].selectedSubtitle
+    end if
 
     m.top.observeField("selectedSubtitle", "onSubtitleChange")
 

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -14,7 +14,8 @@ end function
 
 function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioTrackIndex = -1 as integer, subtitleTrackIndex = -1 as integer, startTimeTicks = 0 as longinteger)
     body = {
-        "DeviceProfile": getDeviceProfile()
+        "DeviceProfile": getDeviceProfile(),
+        "AlwaysBurnInSubtitleWhenTranscoding": true
     }
     params = {
         "UserId": m.global.session.user.id,

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -13,8 +13,15 @@ function ItemGetPlaybackInfo(id as string, startTimeTicks = 0 as longinteger)
 end function
 
 function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioTrackIndex = -1 as integer, subtitleTrackIndex = -1 as integer, startTimeTicks = 0 as longinteger)
+
+    transcodeCodec = string.EMPTY
+
+    if m.global.queueManager.callFunc("getForceTranscode")
+        transcodeCodec = m.global.queueManager.callFunc("getTranscodeCodec")
+    end if
+
     body = {
-        "DeviceProfile": getDeviceProfile(),
+        "DeviceProfile": getDeviceProfile(transcodeCodec),
         "AlwaysBurnInSubtitleWhenTranscoding": true
     }
     params = {

--- a/source/static/whatsNew/3.0.9.json
+++ b/source/static/whatsNew/3.0.9.json
@@ -26,5 +26,13 @@
   {
     "description": "Add season and episode information to Roku's video player screen",
     "author": "1hitsong"
+  },
+  {
+    "description": "Update force transcode options to prevent remux",
+    "author": "1hitsong"
+  },
+  {
+    "description": "Burn subtitles if video is transcoding",
+    "author": "1hitsong"
   }
 ]

--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -1,8 +1,9 @@
 import "pkg:/source/api/baserequest.bs"
+import "pkg:/source/enums/String.bs"
 import "pkg:/source/utils/misc.bs"
 
 ' Returns the Device Capabilities for Roku.
-function getDeviceCapabilities() as object
+function getDeviceCapabilities(videoCodec = string.EMPTY as string) as object
     deviceProfile = {
         "PlayableMediaTypes": [
             "Audio",
@@ -14,13 +15,13 @@ function getDeviceCapabilities() as object
         "SupportsMediaControl": false,
         "SupportsContentUploading": false,
         "SupportsSync": false,
-        "DeviceProfile": getDeviceProfile()
+        "DeviceProfile": getDeviceProfile(videoCodec)
     }
 
     return deviceProfile
 end function
 
-function getDeviceProfile() as object
+function getDeviceProfile(videoCodec = string.EMPTY as string) as object
     globalDevice = m.global.device
     return {
         "Name": "Official Roku Client",
@@ -43,9 +44,9 @@ function getDeviceProfile() as object
         "MaxStaticBitrate": 100000000,
         "MusicStreamingTranscodingBitrate": 192000,
         "DirectPlayProfiles": GetDirectPlayProfiles(),
-        "TranscodingProfiles": getTranscodingProfiles(),
+        "TranscodingProfiles": getTranscodingProfiles(videoCodec),
         "ContainerProfiles": getContainerProfiles(),
-        "CodecProfiles": getCodecProfiles(),
+        "CodecProfiles": getCodecProfiles(videoCodec),
         "SubtitleProfiles": getSubtitleProfiles()
     }
 end function
@@ -179,7 +180,7 @@ function GetDirectPlayProfiles() as object
     return directPlayProfiles
 end function
 
-function getTranscodingProfiles() as object
+function getTranscodingProfiles(videoCodec = string.EMPTY as string) as object
     globalUserSettings = m.global.session.user.settings
     transcodingProfiles = []
 
@@ -188,9 +189,9 @@ function getTranscodingProfiles() as object
     transcodingContainers = ["mp4", "ts"]
     ' use strings to preserve order
     mp4AudioCodecs = "AC3"
-    mp4VideoCodecs = "h264"
+    mp4VideoCodecs = isStringEqual(videoCodec, "h264") ? string.EMPTY : "h264"
     tsAudioCodecs = "AC3"
-    tsVideoCodecs = "h264"
+    tsVideoCodecs = isStringEqual(videoCodec, "h264") ? string.EMPTY : "h264"
 
     ' does the users setup support surround sound?
     maxAudioChannels = "2" ' jellyfin expects this as a string
@@ -211,29 +212,33 @@ function getTranscodingProfiles() as object
     '
     ' AVC / h264 / MPEG4 AVC
     for each container in transcodingContainers
-        if di.CanDecodeVideo({ Codec: "h264", Container: container }).Result
-            if container = "mp4"
-                ' check for codec string before adding it
-                if mp4VideoCodecs.Instr(0, ",h264") = -1
-                    mp4VideoCodecs = mp4VideoCodecs + ",h264"
-                end if
-            else if container = "ts"
-                ' check for codec string before adding it
-                if tsVideoCodecs.Instr(0, ",h264") = -1
-                    tsVideoCodecs = tsVideoCodecs + ",h264"
+        if not isStringEqual(videoCodec, "h264")
+            if di.CanDecodeVideo({ Codec: "h264", Container: container }).Result
+                if container = "mp4"
+                    ' check for codec string before adding it
+                    if mp4VideoCodecs.Instr(0, ",h264") = -1
+                        mp4VideoCodecs = mp4VideoCodecs + ",h264"
+                    end if
+                else if container = "ts"
+                    ' check for codec string before adding it
+                    if tsVideoCodecs.Instr(0, ",h264") = -1
+                        tsVideoCodecs = tsVideoCodecs + ",h264"
+                    end if
                 end if
             end if
         end if
-        if di.CanDecodeVideo({ Codec: "mpeg4 avc", Container: container }).Result
-            if container = "mp4"
-                ' check for codec string before adding it
-                if mp4VideoCodecs.Instr(0, ",mpeg4 avc") = -1
-                    mp4VideoCodecs = mp4VideoCodecs + ",mpeg4 avc"
-                end if
-            else if container = "ts"
-                ' check for codec string before adding it
-                if tsVideoCodecs.Instr(0, ",mpeg4 avc") = -1
-                    tsVideoCodecs = tsVideoCodecs + ",mpeg4 avc"
+        if not isStringEqual(videoCodec, "mpeg4 avc")
+            if di.CanDecodeVideo({ Codec: "mpeg4 avc", Container: container }).Result
+                if container = "mp4"
+                    ' check for codec string before adding it
+                    if mp4VideoCodecs.Instr(0, ",mpeg4 avc") = -1
+                        mp4VideoCodecs = mp4VideoCodecs + ",mpeg4 avc"
+                    end if
+                else if container = "ts"
+                    ' check for codec string before adding it
+                    if tsVideoCodecs.Instr(0, ",mpeg4 avc") = -1
+                        tsVideoCodecs = tsVideoCodecs + ",mpeg4 avc"
+                    end if
                 end if
             end if
         end if
@@ -242,22 +247,24 @@ function getTranscodingProfiles() as object
     ' HEVC / h265
     if globalUserSettings["playback.compatibility.disablehevc"] = false
         for each container in transcodingContainers
-            if di.CanDecodeVideo({ Codec: "hevc", Container: container }).Result
-                if container = "mp4"
-                    ' check for codec string before adding it
-                    if mp4VideoCodecs.Instr(0, "h265,") = -1
-                        mp4VideoCodecs = "h265," + mp4VideoCodecs
-                    end if
-                    if mp4VideoCodecs.Instr(0, "hevc,") = -1
-                        mp4VideoCodecs = "hevc," + mp4VideoCodecs
-                    end if
-                else if container = "ts"
-                    ' check for codec string before adding it
-                    if tsVideoCodecs.Instr(0, "h265,") = -1
-                        tsVideoCodecs = "h265," + tsVideoCodecs
-                    end if
-                    if tsVideoCodecs.Instr(0, "hevc,") = -1
-                        tsVideoCodecs = "hevc," + tsVideoCodecs
+            if not isStringEqual(videoCodec, "hevc")
+                if di.CanDecodeVideo({ Codec: "hevc", Container: container }).Result
+                    if container = "mp4"
+                        ' check for codec string before adding it
+                        if mp4VideoCodecs.Instr(0, "h265,") = -1
+                            mp4VideoCodecs = "h265," + mp4VideoCodecs
+                        end if
+                        if mp4VideoCodecs.Instr(0, "hevc,") = -1
+                            mp4VideoCodecs = "hevc," + mp4VideoCodecs
+                        end if
+                    else if container = "ts"
+                        ' check for codec string before adding it
+                        if tsVideoCodecs.Instr(0, "h265,") = -1
+                            tsVideoCodecs = "h265," + tsVideoCodecs
+                        end if
+                        if tsVideoCodecs.Instr(0, "hevc,") = -1
+                            tsVideoCodecs = "hevc," + tsVideoCodecs
+                        end if
                     end if
                 end if
             end if
@@ -266,16 +273,18 @@ function getTranscodingProfiles() as object
 
     ' VP9
     for each container in transcodingContainers
-        if di.CanDecodeAudio({ Codec: "vp9", Container: container }).Result
-            if container = "mp4"
-                ' check for codec string before adding it
-                if mp4VideoCodecs.Instr(0, ",vp9") = -1
-                    mp4VideoCodecs = mp4VideoCodecs + ",vp9"
-                end if
-            else if container = "ts"
-                ' check for codec string before adding it
-                if tsVideoCodecs.Instr(0, ",vp9") = -1
-                    tsVideoCodecs = tsVideoCodecs + ",vp9"
+        if not isStringEqual(videoCodec, "vp9")
+            if di.CanDecodeVideo({ Codec: "vp9", Container: container }).Result
+                if container = "mp4"
+                    ' check for codec string before adding it
+                    if mp4VideoCodecs.Instr(0, ",vp9") = -1
+                        mp4VideoCodecs = mp4VideoCodecs + ",vp9"
+                    end if
+                else if container = "ts"
+                    ' check for codec string before adding it
+                    if tsVideoCodecs.Instr(0, ",vp9") = -1
+                        tsVideoCodecs = tsVideoCodecs + ",vp9"
+                    end if
                 end if
             end if
         end if
@@ -284,16 +293,18 @@ function getTranscodingProfiles() as object
     ' MPEG2
     if globalUserSettings["playback.mpeg2"]
         for each container in transcodingContainers
-            if di.CanDecodeVideo({ Codec: "mpeg2", Container: container }).Result
-                if container = "mp4"
-                    ' check for codec string before adding it
-                    if mp4VideoCodecs.Instr(0, ",mpeg2video") = -1
-                        mp4VideoCodecs = mp4VideoCodecs + ",mpeg2video"
-                    end if
-                else if container = "ts"
-                    ' check for codec string before adding it
-                    if tsVideoCodecs.Instr(0, ",mpeg2video") = -1
-                        tsVideoCodecs = tsVideoCodecs + ",mpeg2video"
+            if not isStringEqual(videoCodec, "mpeg2")
+                if di.CanDecodeVideo({ Codec: "mpeg2", Container: container }).Result
+                    if container = "mp4"
+                        ' check for codec string before adding it
+                        if mp4VideoCodecs.Instr(0, ",mpeg2video") = -1
+                            mp4VideoCodecs = mp4VideoCodecs + ",mpeg2video"
+                        end if
+                    else if container = "ts"
+                        ' check for codec string before adding it
+                        if tsVideoCodecs.Instr(0, ",mpeg2video") = -1
+                            tsVideoCodecs = tsVideoCodecs + ",mpeg2video"
+                        end if
                     end if
                 end if
             end if
@@ -302,16 +313,18 @@ function getTranscodingProfiles() as object
 
     ' AV1
     for each container in transcodingContainers
-        if di.CanDecodeVideo({ Codec: "av1", Container: container }).Result
-            if container = "mp4"
-                ' check for codec string before adding it
-                if mp4VideoCodecs.Instr(0, ",av1") = -1
-                    mp4VideoCodecs = mp4VideoCodecs + ",av1"
-                end if
-            else if container = "ts"
-                ' check for codec string before adding it
-                if tsVideoCodecs.Instr(0, ",av1") = -1
-                    tsVideoCodecs = tsVideoCodecs + ",av1"
+        if not isStringEqual(videoCodec, "av1")
+            if di.CanDecodeVideo({ Codec: "av1", Container: container }).Result
+                if container = "mp4"
+                    ' check for codec string before adding it
+                    if mp4VideoCodecs.Instr(0, ",av1") = -1
+                        mp4VideoCodecs = mp4VideoCodecs + ",av1"
+                    end if
+                else if container = "ts"
+                    ' check for codec string before adding it
+                    if tsVideoCodecs.Instr(0, ",av1") = -1
+                        tsVideoCodecs = tsVideoCodecs + ",av1"
+                    end if
                 end if
             end if
         end if
@@ -415,7 +428,7 @@ function getContainerProfiles() as object
     return containerProfiles
 end function
 
-function getCodecProfiles() as object
+function getCodecProfiles(videoCodec = string.EMPTY as string) as object
     globalUserSettings = m.global.session.user.settings
     codecProfiles = []
     profileSupport = {
@@ -427,6 +440,7 @@ function getCodecProfiles() as object
         "mpeg2": {},
         "av1": {}
     }
+
     maxResSetting = globalUserSettings["playback.resolution.max"]
     di = CreateObject("roDeviceInfo")
     maxHeightArray = getMaxHeightArray()
@@ -493,58 +507,74 @@ function getCodecProfiles() as object
     h264Levels = ["4.1", "4.2"]
     for each profile in h264Profiles
         for each level in h264Levels
-            if di.CanDecodeVideo({ Codec: "h264", Profile: profile, Level: level }).Result
-                profileSupport = updateProfileArray(profileSupport, "h264", profile, level)
+            if not isStringEqual(videoCodec, "h264")
+                if di.CanDecodeVideo({ Codec: "h264", Profile: profile, Level: level }).Result
+                    profileSupport = updateProfileArray(profileSupport, "h264", profile, level)
+                end if
             end if
-            if di.CanDecodeVideo({ Codec: "mpeg4 avc", Profile: profile, Level: level }).Result
-                profileSupport = updateProfileArray(profileSupport, "mpeg4 avc", profile, level)
+            if not isStringEqual(videoCodec, "mpeg4 avc")
+                if di.CanDecodeVideo({ Codec: "mpeg4 avc", Profile: profile, Level: level }).Result
+                    profileSupport = updateProfileArray(profileSupport, "mpeg4 avc", profile, level)
+                end if
             end if
         end for
     end for
 
     ' HEVC / h265
-    hevcProfiles = ["main", "main 10"]
-    hevcLevels = ["4.1", "5.0", "5.1"]
-    for each profile in hevcProfiles
-        for each level in hevcLevels
-            if di.CanDecodeVideo({ Codec: "hevc", Profile: profile, Level: level }).Result
-                profileSupport = updateProfileArray(profileSupport, "h265", profile, level)
-                profileSupport = updateProfileArray(profileSupport, "hevc", profile, level)
-            end if
+    if not isStringEqual(videoCodec, "hevc")
+        hevcProfiles = ["main", "main 10"]
+        hevcLevels = ["4.1", "5.0", "5.1"]
+        for each profile in hevcProfiles
+            for each level in hevcLevels
+                if di.CanDecodeVideo({ Codec: "hevc", Profile: profile, Level: level }).Result
+                    profileSupport = updateProfileArray(profileSupport, "h265", profile, level)
+                    profileSupport = updateProfileArray(profileSupport, "hevc", profile, level)
+                end if
+            end for
         end for
-    end for
+    end if
 
     ' VP9
-    vp9Profiles = ["profile 0", "profile 2"]
-    vp9Levels = ["4.1", "5.0", "5.1"]
-    for each profile in vp9Profiles
-        for each level in vp9Levels
-            if di.CanDecodeVideo({ Codec: "vp9", Profile: profile, Level: level }).Result
-                profileSupport = updateProfileArray(profileSupport, "vp9", profile, level)
-            end if
+    if not isStringEqual(videoCodec, "vp9")
+        vp9Profiles = ["profile 0", "profile 2"]
+        vp9Levels = ["4.1", "5.0", "5.1"]
+        for each profile in vp9Profiles
+            for each level in vp9Levels
+                if di.CanDecodeVideo({ Codec: "vp9", Profile: profile, Level: level }).Result
+                    profileSupport = updateProfileArray(profileSupport, "vp9", profile, level)
+                end if
+            end for
         end for
-    end for
+    end if
 
     ' MPEG2
     ' mpeg2 uses levels with no profiles. see https://developer.roku.com/en-ca/docs/references/brightscript/interfaces/ifdeviceinfo.md#candecodevideovideo_format-as-object-as-object
     ' NOTE: the mpeg2 levels are being saved in the profileSupport array as if they were profiles
-    mpeg2Levels = ["main", "high"]
-    for each level in mpeg2Levels
-        if di.CanDecodeVideo({ Codec: "mpeg2", Level: level }).Result
-            profileSupport = updateProfileArray(profileSupport, "mpeg2", level)
-        end if
-    end for
-
-    ' AV1
-    av1Profiles = ["main", "main 10"]
-    av1Levels = ["4.1", "5.0", "5.1"]
-    for each profile in av1Profiles
-        for each level in av1Levels
-            if di.CanDecodeVideo({ Codec: "av1", Profile: profile, Level: level }).Result
-                profileSupport = updateProfileArray(profileSupport, "av1", profile, level)
+    if not isStringEqual(videoCodec, "mpeg2")
+        mpeg2Levels = ["main", "high"]
+        for each level in mpeg2Levels
+            if di.CanDecodeVideo({ Codec: "mpeg2", Level: level }).Result
+                profileSupport = updateProfileArray(profileSupport, "mpeg2", level)
             end if
         end for
-    end for
+    end if
+
+    ' AV1
+    if not isStringEqual(videoCodec, "av1")
+        av1Profiles = ["main", "main 10"]
+        av1Levels = ["4.1", "5.0", "5.1"]
+        for each profile in av1Profiles
+            for each level in av1Levels
+                if di.CanDecodeVideo({ Codec: "av1", Profile: profile, Level: level }).Result
+                    profileSupport = updateProfileArray(profileSupport, "av1", profile, level)
+                end if
+            end for
+        end for
+    end if
+
+    if not isStringEqual(videoCodec, string.EMPTY)
+        profileSupport.addreplace(videoCodec, {})
+    end if
 
     ' HDR SUPPORT
     h264VideoRangeTypes = "SDR"
@@ -645,7 +675,9 @@ function getCodecProfiles() as object
         h264ProfileArray.Conditions.push(bitRateArray)
     end if
 
-    codecProfiles.push(h264ProfileArray)
+    if not isStringEqual(videoCodec, "h264")
+        codecProfiles.push(h264ProfileArray)
+    end if
 
     ' MPEG2
     ' NOTE: the mpeg2 levels are being saved in the profileSupport array as if they were profiles
@@ -682,7 +714,9 @@ function getCodecProfiles() as object
             mpeg2ProfileArray.Conditions.push(bitRateArray)
         end if
 
-        codecProfiles.push(mpeg2ProfileArray)
+        if not isStringEqual(videoCodec, "mpeg2")
+            codecProfiles.push(mpeg2ProfileArray)
+        end if
     end if
 
     if di.CanDecodeVideo({ Codec: "av1" }).Result
@@ -735,7 +769,9 @@ function getCodecProfiles() as object
             av1ProfileArray.Conditions.push(bitRateArray)
         end if
 
-        codecProfiles.push(av1ProfileArray)
+        if not isStringEqual(videoCodec, "av1")
+            codecProfiles.push(av1ProfileArray)
+        end if
     end if
 
     if not globalUserSettings["playback.compatibility.disablehevc"] and di.CanDecodeVideo({ Codec: "hevc" }).Result
@@ -804,7 +840,9 @@ function getCodecProfiles() as object
             hevcProfileArray.Conditions.push(bitRateArray)
         end if
 
-        codecProfiles.push(hevcProfileArray)
+        if not isStringEqual(videoCodec, "h265")
+            codecProfiles.push(hevcProfileArray)
+        end if
     end if
 
     if di.CanDecodeVideo({ Codec: "vp9" }).Result
@@ -863,7 +901,9 @@ function getCodecProfiles() as object
             vp9ProfileArray.Conditions.push(bitRateArray)
         end if
 
-        codecProfiles.push(vp9ProfileArray)
+        if not isStringEqual(videoCodec, "vp9")
+            codecProfiles.push(vp9ProfileArray)
+        end if
     end if
 
     return codecProfiles


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Update force transcode options to prevent remux. We want true transcoding!
  - I do this by passing the playing video's codec to the device capabilities and excluding that codec from all of the transcode profile and codec blocks. This prevents Jellyfin from simply remuxing the video and forces a full transcode since it now must change codecs.
- Burn subtitles if video is transcoding. I may convert this to a setting in a later PR, but this change is already big enough.

## Issues
Fixes #347
