### PR TITLE
Add setting to start episode list from first unwatched episode

### DIFF
--- a/components/tvshows/TVEpisodeRow.bs
+++ b/components/tvshows/TVEpisodeRow.bs
@@ -1,6 +1,13 @@
+import "pkg:/source/utils/misc.bs"
+
 sub init()
+    m.firstUnwatched = 0
     m.top.itemComponentName = "TVListDetails"
     m.top.content = setData()
+
+    if chainLookupReturn(m.global.session, "user.settings.`ui.tvshows.startListFromUnwatched`", false)
+        m.top.jumpToItem = m.firstUnwatched
+    end if
 
     m.top.vertFocusAnimationStyle = "fixedFocusWrap"
 
@@ -36,6 +43,10 @@ sub setupRows()
     objects = m.top.objects
     m.top.numRows = objects.items.count()
     m.top.content = setData()
+
+    if chainLookupReturn(m.global.session, "user.settings.`ui.tvshows.startListFromUnwatched`", false)
+        m.top.jumpToItem = m.firstUnwatched
+    end if
 end sub
 
 function setData()
@@ -45,9 +56,18 @@ function setData()
         return data
     end if
 
+    i = 0
+    m.firstUnwatched = -1
     for each item in m.top.objects.items
+        if m.firstUnwatched = -1
+            if not chainLookupReturn(item, "watched", false)
+                m.firstUnwatched = i
+            end if
+        end if
+
         row = data.CreateChild("ContentNode")
         row.appendChild(item)
+        i++
     end for
 
     m.top.doneLoading = true

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2121,5 +2121,13 @@
             <source>Note: Force transcode option automatically enabled due to video rotation</source>
             <translation>Note: Force transcode option automatically enabled due to video rotation</translation>
         </message>
+        <message>
+            <source>Start Episode List From First Unwatched Episode</source>
+            <translation>Start Episode List From First Unwatched Episode</translation>
+        </message>
+        <message>
+            <source>When opening a season\'s list of episodes, automatically scroll down and start the cursor on the first unwatched episode.</source>
+            <translation>When opening a season\'s list of episodes, automatically scroll down and start the cursor on the first unwatched episode.</translation>
+        </message>
     </context>
 </TS>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1173,6 +1173,13 @@
                 "settingName": "ui.tvshows.goStraightToEpisodeListing",
                 "type": "bool",
                 "default": "false"
+              },
+              {
+                "title": "Start Episode List From First Unwatched Episode",
+                "description": "When opening a season's list of episodes, automatically scroll down and start the cursor on the first unwatched episode.",
+                "settingName": "ui.tvshows.startListFromUnwatched",
+                "type": "bool",
+                "default": "false"
               }
             ]
           }

--- a/source/static/whatsNew/3.0.9.json
+++ b/source/static/whatsNew/3.0.9.json
@@ -26,5 +26,9 @@
   {
     "description": "Add season and episode information to Roku's video player screen",
     "author": "1hitsong"
+  },
+  {
+    "description": "Add setting to start episode list from first unwatched episode",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Adds new setting that causes the episode list screen to automatically scroll down and start the cursor on the first unwatched episode
- This episode may be resumable (meaning you've watched part of it)

## Issues
Fixes #357

## Screenshot
![WIN_20250830_09_29_38_Pro](https://github.com/user-attachments/assets/bd76fbfc-0b2a-4be6-9686-fd2373f64005)

