### PR TITLE
Fix slideshow function if quickplaying a photo

### DIFF
--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -2010,6 +2010,12 @@ function onKeyEvent(key as string, press as boolean) as boolean
         itemToPlay = getItemFocused()
 
         if isValid(itemToPlay)
+            ' If user presses play on a photo, load it normally instead of using quickplay so they can start a slideshow
+            if isStringEqual(ItemType.PHOTO, chainLookupReturn(itemToPlay, "type", string.EMPTY))
+                m.itemGrid.itemSelected = m.itemGrid.itemFocused
+                return true
+            end if
+
             m.top.quickPlayNode = itemToPlay
             return true
         end if

--- a/components/photos/PhotoDetails.bs
+++ b/components/photos/PhotoDetails.bs
@@ -147,8 +147,10 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 m.showStatusAnimation.control = "start"
             end if
             m.statusTimer.control = "start"
-            m.videoPlayer.disableScreenSaver = true
+            m.videoPlayer.disableScreenSaver = false
         else
+            if not isValidToContinue(m.top.itemIndex + 1) then return false
+
             ' start the slideshow if the user hits "play"
             m.status.text = tr("Slideshow Resumed")
             if m.textBackground.opacity = 0

--- a/source/static/whatsNew/3.0.10.json
+++ b/source/static/whatsNew/3.0.10.json
@@ -6,5 +6,9 @@
   {
     "description": "Fix voice search in live TV's TV guide view",
     "author": "1hitsong"
+  },
+  {
+    "description": "Fix slideshow function if quickplaying a photo",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Load slideshow data normally if user used quickplay so they can start a slideshow
- Don't show Slideshow Resumed if there are no more photos
- Re-enable screensaver if user pauses slideshow