### PR TITLE
Create setting to display "Are you still watching?" popup

### DIFF
--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -326,7 +326,7 @@ sub onStateChange()
                     m.stillWatchingTimer.observeField("fire", "stillWatchingTimerComplete")
                     m.stillWatchingTimer.control = TimerControl.START
 
-                    m.global.sceneManager.callFunc("optionDialog", "stillwatching", tr("Are You Still Watching?"), [tr("Playback will automatically stop in 1 minute if no choice is made.")], [tr("Yes, continue"), tr("No, stop playback")], {})
+                    m.global.sceneManager.callFunc("optionDialog", "stillwatching", tr("Are You Still Watching?"), [tr("Playback will automatically stop in 1 minute if no buttons are pressed.")], [tr("Yes, continue"), tr("No, stop playback")], {})
                     return
                 end if
             end if

--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -1,6 +1,10 @@
 import "pkg:/source/enums/MediaPlaybackState.bs"
 import "pkg:/source/enums/TaskControl.bs"
+import "pkg:/source/enums/TimerControl.bs"
 import "pkg:/source/enums/VideoControl.bs"
+
+const STILL_WATCHING_POPUP_TIMER_SECONDS = 60
+
 
 ' Play Audio
 sub CreateAudioPlayerView()
@@ -310,6 +314,23 @@ sub onStateChange()
 
         ' If there is something next in the queue, play it
         if m.global.queueManager.callFunc("getPosition") < m.global.queueManager.callFunc("getCount") - 1
+            stillwatchingPopupInactivityTime = chainLookupReturn(m.global.session, "user.settings.stillwatchingPopupInactivityTime", "0")
+            if stillwatchingPopupInactivityTime <> "0"
+                stillwatchingPopupInactivityTime = stillwatchingPopupInactivityTime.ToInt()
+                m.deviceInfo = CreateObject("roDeviceInfo")
+
+                if m.deviceInfo.TimeSinceLastKeypress() >= (stillwatchingPopupInactivityTime * 60)
+                    m.stillWatchingTimer = createObject("roSGNode", "Timer")
+                    m.stillWatchingTimer.repeat = false
+                    m.stillWatchingTimer.duration = STILL_WATCHING_POPUP_TIMER_SECONDS
+                    m.stillWatchingTimer.observeField("fire", "stillWatchingTimerComplete")
+                    m.stillWatchingTimer.control = TimerControl.START
+
+                    m.global.sceneManager.callFunc("optionDialog", "stillwatching", tr("Are You Still Watching?"), [tr("Playback will automatically stop in 1 minute if no choice is made.")], [tr("Yes, continue"), tr("No, stop playback")], {})
+                    return
+                end if
+            end if
+
             m.global.sceneManager.callFunc("clearPreviousScene")
             m.global.queueManager.callFunc("moveForward")
             m.global.queueManager.callFunc("playQueue")
@@ -323,6 +344,21 @@ sub onStateChange()
         m.global.sceneManager.callFunc("popScene")
         m.global.audioPlayer.loopMode = ""
     end if
+end sub
+
+sub stillWatchingTimerComplete()
+    m.stillWatchingTimer.control = TimerControl.STOP
+
+    ' Check if user pressed a button before the timer fired
+    if m.deviceInfo.TimeSinceLastKeypress() <= STILL_WATCHING_POPUP_TIMER_SECONDS then return
+
+    if m.global.sceneManager.callFunc("isDialogOpen")
+        m.global.sceneManager.callFunc("dismissDialog")
+    end if
+
+    m.global.queueManager.callFunc("bypassNextPreferredAudioTrackIndexReset")
+    m.global.queueManager.callFunc("clear")
+    m.global.sceneManager.callFunc("popScene")
 end sub
 
 ' Roku translates the info provided in subtitleTracks into availableSubtitleTracks

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2161,5 +2161,29 @@
             <source>No channels found matching your search criteria</source>
             <translation>No channels found matching your search criteria</translation>
         </message>
+        <message>
+            <source>Are You Still Watching Popup</source>
+            <translation>Are You Still Watching Popup</translation>
+        </message>
+        <message>
+            <source>How many minutes of inactivity before playback is stopped between items and a popup is shown to continue? Set to 0 to disable.</source>
+            <translation>How many minutes of inactivity before playback is stopped between items and a popup is shown to continue? Set to 0 to disable.</translation>
+        </message>
+        <message>
+            <source>Are You Still Watching?</source>
+            <translation>Are You Still Watching?</translation>
+        </message>
+        <message>
+            <source>Yes, continue</source>
+            <translation>Yes, continue</translation>
+        </message>
+        <message>
+            <source>No, stop playback</source>
+            <translation>No, stop playback</translation>
+        </message>
+        <message>
+            <source>Playback will automatically stop in 1 minute if no choice is made.</source>
+            <translation>Playback will automatically stop in 1 minute if no choice is made.</translation>
+        </message>
     </context>
 </TS>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2183,7 +2183,7 @@
         </message>
         <message>
             <source>Playback will automatically stop in 1 minute if no choice is made.</source>
-            <translation>Playback will automatically stop in 1 minute if no choice is made.</translation>
+            <translation>Playback will automatically stop in 1 minute if no buttons are pressed.</translation>
         </message>
     </context>
 </TS>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2182,7 +2182,7 @@
             <translation>No, stop playback</translation>
         </message>
         <message>
-            <source>Playback will automatically stop in 1 minute if no choice is made.</source>
+            <source>Playback will automatically stop in 1 minute if no buttons are pressed.</source>
             <translation>Playback will automatically stop in 1 minute if no buttons are pressed.</translation>
         </message>
     </context>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -17,6 +17,13 @@
     "description": "Settings relating to playback and supported codec and media types.",
     "children": [
       {
+        "title": "Are You Still Watching Popup",
+        "description": "How many minutes of inactivity before playback is stopped between items and a popup is shown to continue? Set to 0 to disable.",
+        "settingName": "stillwatchingPopupInactivityTime",
+        "type": "integer",
+        "default": "0"
+      },
+      {
         "title": "Autoplay Episode Limit",
         "description": "The number of episodes that will play automatically after the selected episode. Requires 'Play next episode automatically' server setting to be enabled.",
         "settingName": "episodeQueueLimit",

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -1380,6 +1380,12 @@ sub onDataReturnedEvent(msg)
         return
     end if
 
+    if isStringEqual(selectedPopupID, "stillwatching")
+        if not isString(selectedPopupButton) then return
+        processStillWatchingPopup(selectedPopupButton)
+        return
+    end if
+
     if isStringEqual(selectedPopupID, "playlist")
         if not isValid(itemID) then return
         processPlaylistPopup(selectedPopupButton, itemID)
@@ -1426,6 +1432,19 @@ sub processPlaybackPopup(selectedPopupAction as integer, selectedItem as object)
     if selectedPopupAction = ResumePopupAction.GOTOEPISODE
         CreateMovieDetailsGroup(selectedItem[0])
         return
+    end if
+end sub
+
+sub processStillWatchingPopup(selectedPopupButton as string)
+    if isStringEqual(selectedPopupButton, tr("Yes, continue"))
+        m.global.sceneManager.callFunc("clearPreviousScene")
+        m.global.queueManager.callFunc("moveForward")
+        m.global.queueManager.callFunc("playQueue")
+    end if
+    if isStringEqual(selectedPopupButton, tr("No, stop playback"))
+        m.global.queueManager.callFunc("bypassNextPreferredAudioTrackIndexReset")
+        m.global.queueManager.callFunc("clear")
+        m.global.sceneManager.callFunc("popScene")
     end if
 end sub
 

--- a/source/static/whatsNew/3.0.10.json
+++ b/source/static/whatsNew/3.0.10.json
@@ -10,5 +10,9 @@
   {
     "description": "Fix slideshow function if quickplaying a photo",
     "author": "1hitsong"
+  },
+  {
+    "description": "Create setting to display \"Are you still watching?\" popup to cancel playback due to inactivity",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Create setting for number of inactive minutes before are you still watching popup can be shown
- Between item playback, check if we've passed inactive minutes setting
- If we have, display Are you still watching? popup
- If user chooses Yes, continue playback
- If user chooses No, stop playback
- If user chooses nothing after 60 seconds, close popup and stop playback

## Screenshot
![stillWatching](https://github.com/user-attachments/assets/9a444aa7-c122-4c61-bffb-196a1f54cb5a)

