### PR TITLE
Fix crash in video player when hide clock setting is enabled

### DIFF
--- a/components/Clock.bs
+++ b/components/Clock.bs
@@ -11,6 +11,8 @@ enum ClockFormat
 end enum
 
 sub init()
+    m.dateTimeObject = CreateObject("roDateTime")
+
 
     ' If hideclick setting is enabled, exit without setting any variables
     if m.global.session.user.settings["ui.design.hideclock"]
@@ -20,8 +22,6 @@ sub init()
     m.clockTime = m.top.findNode("clockTime")
 
     m.currentTimeTimer = m.top.findNode("currentTimeTimer")
-    m.dateTimeObject = CreateObject("roDateTime")
-
     m.currentTimeTimer.observeField("fire", "onCurrentTimeTimerFire")
     m.currentTimeTimer.control = TimerControl.START
 

--- a/source/static/whatsNew/3.0.10.json
+++ b/source/static/whatsNew/3.0.10.json
@@ -10,5 +10,9 @@
   {
     "description": "Fix slideshow function if quickplaying a photo",
     "author": "1hitsong"
+  },
+  {
+    "description": "Fix crash in video player when hide clock setting is enabled",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Create datetime component even when hideclock setting is enabled

## Issues
Fixes #525
