### PR TITLE
Fix display of next up info if episode has no episode number

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -815,10 +815,13 @@ sub displayNextItem()
 
     nextItemEpisodeTitle = m.top.findNode("nextItemEpisodeTitle")
     if isValid(nextItemEpisodeTitle)
-        seasonName = nextItem.lookupCI("SeasonName") ?? ""
+        seasonName = nextItem.lookupCI("SeasonName") ?? string.EMPTY
         seasonName = seasonName.Replace("Season ", "S")
+
+        episodeNumber = isValid(nextItem.lookupCI("IndexNumber")) ? `E${nextItem.lookupCI("IndexNumber")}` : string.EMPTY
+
         nextItemEpisodeTitle.font.size = 22
-        nextItemEpisodeTitle.text = `${seasonName}E${nextItem.lookupCI("IndexNumber")} - ${nextItem.lookupCI("name")}`
+        nextItemEpisodeTitle.text = `${seasonName}${episodeNumber} - ${nextItem.lookupCI("name")}`
     end if
 
     m.nextUp.visible = true

--- a/source/static/whatsNew/3.0.10.json
+++ b/source/static/whatsNew/3.0.10.json
@@ -18,5 +18,9 @@
   {
     "description": "Create setting to display \"Are you still watching?\" popup after inactive for a set number of minutes",
     "author": "1hitsong"
+  },
+  {
+    "description": "Fix display of next up info if episode has no episode number",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Checks for episode number before using value

## Screenshots
Before
![WIN_20250907_15_50_07_Pro](https://github.com/user-attachments/assets/bb36a481-6da6-49c8-9c7c-1c1d83502b01)

After
![WIN_20250907_15_52_30_Pro](https://github.com/user-attachments/assets/37834b41-3100-4256-b446-a4997ab5a52e)
