### PR TITLE
Fix bug that caused resuming video from timestamp to not always work

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -121,7 +121,9 @@ sub onAvailableAudioTracksChanged()
             m.top.audioIndex = audioTrack.LookupCI("Track")
 
             ' Save the current video position
-            m.global.queueManager.callFunc("setTopStartingPoint", int(m.top.position) * 10000000&)
+            if m.top.position <> 0
+                m.global.queueManager.callFunc("setTopStartingPoint", int(m.top.position) * 10000000&)
+            end if
 
             m.top.control = VideoControl.STOP
 

--- a/source/static/whatsNew/3.0.10.json
+++ b/source/static/whatsNew/3.0.10.json
@@ -18,5 +18,9 @@
   {
     "description": "Create setting to display \"Are you still watching?\" popup after inactive for a set number of minutes",
     "author": "1hitsong"
+  },
+  {
+    "description": "Fix resuming video from timestamp",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Don't overwrite current video position if it's zero

## Issues
Fixes #528