### PR TITLE
Add position cue support to custom subtitles

### DIFF
--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -188,6 +188,7 @@ function prepareStyles(styles as object, rect, lineCount = 1 as integer) as obje
     end if
 
     captionLine = chainLookupReturn(captionStyles, "line", string.EMPTY)
+    captionPosition = chainLookupReturn(captionStyles, "position", string.EMPTY)
 
     ' Line
     if not isStringEqual(captionLine, string.EMPTY)
@@ -195,9 +196,28 @@ function prepareStyles(styles as object, rect, lineCount = 1 as integer) as obje
         verticalPosition = processLineCue(captionLine, captionLineHeight)
     end if
 
+    ' Position
+    if not isStringEqual(captionPosition, string.EMPTY)
+        horizontalPositon = processPositionCue(captionPosition, rect.BoundingRect().width)
+    end if
+
     finalStyles.translation = [horizontalPositon, verticalPosition]
 
     return finalStyles
+end function
+
+function processPositionCue(captionPosition as string, captionLineWidth as float) as integer
+    calculatedPosition = 1920 * (val(captionPosition) / 100)
+
+    if calculatedPosition + captionLineWidth > 1920
+        calculatedPosition = 1920 - captionLineWidth
+    end if
+
+    if calculatedPosition < 0
+        calculatedPosition = 0
+    end if
+
+    return calculatedPosition
 end function
 
 function processLineCue(captionLine as string, captionLineHeight as float) as integer
@@ -260,7 +280,11 @@ function extractStyles(lineData as string) as object
 
     for each style in lineDataArray
         styleData = style.split(":")
-        returnData.styles.addreplace(styleData[0], styleData[1])
+
+        ' We don't support RTL text, so positionAlign properties must be removed
+        styleDataPositionAlign = styleData[1].split(",")
+
+        returnData.styles.addreplace(styleData[0], styleDataPositionAlign[0])
     end for
 
     return returnData

--- a/source/static/whatsNew/3.0.11.json
+++ b/source/static/whatsNew/3.0.11.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "",
-    "author": ""
+    "description": "Add position cue support to custom subtitles",
+    "author": "1hitsong"
   }
 ]

--- a/source/static/whatsNew/3.0.12.json
+++ b/source/static/whatsNew/3.0.12.json
@@ -8,7 +8,11 @@
     "author": "brianpardy"
   },
   {
-    "description": "Fix bug preventing dismissal of Next Up display",
+    "description": "Fix bug preventing dismissal of Skip Outro button",
     "author": "brianpardy"
+  },
+  {
+    "description": "Add position cue support to custom subtitles",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes

https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API/Web_Video_Text_Tracks_Format#position

- Adds custom subtitles support for the position cue. This is how you position lines of text horizontally.
- The value should always be treated as a percentage.
- It makes adjustments to try to prevent the text from going off screen.
- Overlap logic should still run to prevent subtitles from showing on top of each other

## Screenshots
![WIN_20250920_09_43_21_Pro](https://github.com/user-attachments/assets/b51a75b1-0806-4b58-b896-08cc668f3e5d)

![WIN_20250920_09_42_22_Pro](https://github.com/user-attachments/assets/6f35122e-d11a-4e19-a0e9-9b3e61830ae3)

![WIN_20250920_09_42_30_Pro](https://github.com/user-attachments/assets/82f52a4e-e391-44f3-92e2-471381ad78b1)


