### PR TITLE
Fix subtitles showing when not selected and transcode burn in is disbled

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -409,11 +409,14 @@ function defaultSubtitleTrack(sortedSubtitles, selectedAudioLanguage as string, 
 
     subtitleMode = isValid(userConfig.SubtitleMode) ? LCase(userConfig.SubtitleMode) : ""
 
+    audioLanguagePreference = chainLookupReturn(userConfig, "AudioLanguagePreference", string.EMPTY)
+
     allowSmartMode = false
 
-    ' Only evaluate selected audio language if we have a value
-    if selectedAudioLanguage <> ""
-        allowSmartMode = selectedAudioLanguage <> userConfig.SubtitleLanguagePreference
+    ' Confirm the selected audio track has a language
+    if not isStringEqual(selectedAudioLanguage, string.EMPTY)
+        ' Confirm the selected audio track does not match the user's preferred audio language
+        allowSmartMode = selectedAudioLanguage <> audioLanguagePreference
     end if
 
     for each item in sortedSubtitles

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -436,6 +436,15 @@ sub onSubtitleChange()
     ' If previous sustitle was encoded, then we need to a video stop/start to change subtitle content
     if m.top.previousSubtitleWasEncoded then switchWithoutRefresh = false
 
+    ' If we are transcoding and the user wants subtitles burned, force a refresh
+    if isValid(m.isTranscoded)
+        if m.isTranscoded
+            if chainLookupReturn(m.global.session, "user.settings.`playback.media.burnsubtitlestranscoding`", true)
+                switchWithoutRefresh = false
+            end if
+        end if
+    end if
+
     if switchWithoutRefresh then return
 
     ' Save the current video position

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2185,5 +2185,13 @@
             <source>Playback will automatically stop in 1 minute if no buttons are pressed.</source>
             <translation>Playback will automatically stop in 1 minute if no buttons are pressed.</translation>
         </message>
+        <message>
+            <source>Burn In Subtitles When Transcoding</source>
+            <translation>Burn In Subtitles When Transcoding</translation>
+        </message>
+        <message>
+            <source>Burn in all subtitles when transcoding is triggered. This ensures subtitle synchronization after transcoding at the cost of reduced transcoding speed.</source>
+            <translation>Burn in all subtitles when transcoding is triggered. This ensures subtitle synchronization after transcoding at the cost of reduced transcoding speed.</translation>
+        </message>
     </context>
 </TS>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -51,6 +51,13 @@
         ]
       },
       {
+        "title": "Burn In Subtitles When Transcoding",
+        "description": "Burn in all subtitles when transcoding is triggered. This ensures subtitle synchronization after transcoding at the cost of reduced transcoding speed.",
+        "settingName": "playback.media.burnsubtitlestranscoding",
+        "type": "bool",
+        "default": "false"
+      },
+      {
         "title": "Cinema Mode",
         "description": "Bring the theater experience straight to your living room with the ability to play custom intros before the main feature.",
         "settingName": "playback.cinemamode",

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -21,9 +21,16 @@ function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioT
         transcodeCodec = m.global.queueManager.callFunc("getTranscodeCodec")
     end if
 
+    burnsubtitlestranscoding = false
+
+    ' If a subtitle track was selected, check the user's burnsubtitlestranscoding setting
+    if subtitleTrackIndex >= 0
+        burnsubtitlestranscoding = chainLookupReturn(m.global.session, "user.settings.`playback.media.burnsubtitlestranscoding`", true)
+    end if
+
     body = {
         "DeviceProfile": getDeviceProfile(transcodeCodec),
-        "AlwaysBurnInSubtitleWhenTranscoding": true
+        "AlwaysBurnInSubtitleWhenTranscoding": burnsubtitlestranscoding
     }
     params = {
         "UserId": m.global.session.user.id,

--- a/source/static/whatsNew/3.0.11.json
+++ b/source/static/whatsNew/3.0.11.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "",
-    "author": ""
+    "description": "Fix subtitles showing when not selected and transcode burn in is disabled",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Add Burn In Subtitles When Transcoding setting allowing users to enable/disable feature
- If no subtitle has been selected, ensure AlwaysBurnInSubtitleWhenTranscoding is false

## Issues
Fixes #526

## Build for Testing
[roku-deploy-1.0.1.zip](https://github.com/user-attachments/files/22574298/roku-deploy-1.0.1.zip)
