### PR TITLE
Fix bug that caused video end time to climb

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -868,6 +868,10 @@ sub onPositionChanged()
     else
         m.osd.progressPercentage = m.top.position / m.top.duration
     end if
+
+    ' Ensure position text is accurate
+    m.positionText.text = secondsToHuman(m.top.position, true)
+
     m.osd.positionTime = m.top.position
     m.osd.remainingPositionTime = m.top.duration - m.top.position
 
@@ -1183,6 +1187,12 @@ sub onProgramDetailsLoaded()
     m.overview = m.LoadProgramDetailsTask.programDetails.json.CurrentProgram.Overview
 end sub
 
+sub showOSD()
+    m.osd.visible = true
+    m.osd.hasFocus = true
+    m.osd.setFocus(true)
+end sub
+
 sub refreshLiveOSDContent()
     if not m.top.content.live then return
     m.LoadProgramDetailsTask.programId = m.top.id
@@ -1245,9 +1255,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 hideSegmentSkipButton()
             end if
             refreshLiveOSDContent()
-            m.osd.visible = true
-            m.osd.hasFocus = true
-            m.osd.setFocus(true)
+            showOSD()
             return true
         end if
 
@@ -1261,9 +1269,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 hideSegmentSkipButton()
             end if
             refreshLiveOSDContent()
-            m.osd.visible = true
-            m.osd.hasFocus = true
-            m.osd.setFocus(true)
+            showOSD()
             return true
         end if
 
@@ -1278,9 +1284,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 hideSegmentSkipButton()
             end if
             refreshLiveOSDContent()
-            m.osd.visible = true
-            m.osd.hasFocus = true
-            m.osd.setFocus(true)
+            showOSD()
             return true
         end if
 
@@ -1307,9 +1311,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 hideSegmentSkipButton()
             end if
             refreshLiveOSDContent()
-            m.osd.visible = true
-            m.osd.hasFocus = true
-            m.osd.setFocus(true)
+            showOSD()
             return true
         end if
     end if

--- a/source/static/whatsNew/3.0.11.json
+++ b/source/static/whatsNew/3.0.11.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "",
-    "author": ""
+    "description": "Fix bug that caused video end time to climb",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Ensures position text stays current so video end time is always accurate

## Issues
Fixes #538
