### PR TITLE
Use SubtitleSelection enum instead of magic numbers

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -261,10 +261,10 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
     addSubtitlesToVideo(video, meta)
 
     ' Enable default subtitle track
-    if subtitle_idx = SubtitleSelection.notset
+    if subtitle_idx = SubtitleSelection.NOTSET
         defaultSubtitleIndex = defaultSubtitleTrackFromVid(video.id)
 
-        if defaultSubtitleIndex <> SubtitleSelection.none
+        if defaultSubtitleIndex <> SubtitleSelection.NONE
             video.SelectedSubtitle = defaultSubtitleIndex
             subtitle_idx = defaultSubtitleIndex
 
@@ -359,18 +359,18 @@ end sub
 ' defaultSubtitleTrackFromVid: Identifies the default subtitle track given video id
 '
 ' @param {dynamic} videoID - id of video user is playing
-' @return {integer} indicating the default track's server-side index. Defaults to {SubtitleSelection.none} is one is not found
+' @return {integer} indicating the default track's server-side index. Defaults to {SubtitleSelection.NONE} is one is not found
 function defaultSubtitleTrackFromVid(videoID) as integer
     if m.global.session.user.configuration.SubtitleMode = "None"
-        return SubtitleSelection.none ' No subtitles desired: return none
+        return SubtitleSelection.NONE ' No subtitles desired: return none
     end if
 
     meta = ItemMetaData(videoID)
 
-    if not isValid(meta) then return SubtitleSelection.none
-    if not isValid(meta.json) then return SubtitleSelection.none
-    if not isValidAndNotEmpty(meta.json.mediaSources) then return SubtitleSelection.none
-    if not isValidAndNotEmpty(meta.json.MediaSources[0].MediaStreams) then return SubtitleSelection.none
+    if not isValid(meta) then return SubtitleSelection.NONE
+    if not isValid(meta.json) then return SubtitleSelection.NONE
+    if not isValidAndNotEmpty(meta.json.mediaSources) then return SubtitleSelection.NONE
+    if not isValidAndNotEmpty(meta.json.MediaSources[0].MediaStreams) then return SubtitleSelection.NONE
 
     subtitles = sortSubtitles(meta.json.MediaSources[0].MediaStreams)
 
@@ -383,7 +383,7 @@ function defaultSubtitleTrackFromVid(videoID) as integer
     end if
 
     defaultTextSubs = defaultSubtitleTrack(subtitles["text"], selectedAudioLanguage, true) ' Find correct subtitle track (forced text)
-    if defaultTextSubs <> SubtitleSelection.none
+    if defaultTextSubs <> SubtitleSelection.NONE
         return defaultTextSubs
     end if
 
@@ -391,7 +391,7 @@ function defaultSubtitleTrackFromVid(videoID) as integer
         return defaultSubtitleTrack(subtitles["all"], selectedAudioLanguage) ' if no appropriate text subs exist, allow non-text
     end if
 
-    return SubtitleSelection.none
+    return SubtitleSelection.NONE
 end function
 
 ' defaultSubtitleTrack:
@@ -399,7 +399,7 @@ end function
 ' @param {dynamic} sortedSubtitles - array of subtitles sorted by type and language
 ' @param {string} selectedAudioLanguage - language for selected audio track
 ' @param {boolean} [requireText=false] - indicates if only text subtitles should be considered
-' @return {integer} indicating the default track's server-side index. Defaults to {SubtitleSelection.none} is one is not found
+' @return {integer} indicating the default track's server-side index. Defaults to {SubtitleSelection.NONE} is one is not found
 function defaultSubtitleTrack(sortedSubtitles, selectedAudioLanguage as string, requireText = false as boolean) as integer
     userConfig = m.global.session.user.configuration
 
@@ -455,7 +455,7 @@ function defaultSubtitleTrack(sortedSubtitles, selectedAudioLanguage as string, 
         end for
     end if
 
-    return SubtitleSelection.none ' Keep current default behavior of "None", if no correct subtitle is identified
+    return SubtitleSelection.NONE ' Keep current default behavior of "None", if no correct subtitle is identified
 end function
 
 sub addVideoContentURL(video, mediaSourceId, audio_stream_idx, fully_external)

--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -7,14 +7,10 @@ import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/enums/MediaSegmentType.bs"
 import "pkg:/source/enums/PlaybackMethod.bs"
 import "pkg:/source/enums/String.bs"
+import "pkg:/source/enums/SubtitleSelection.bs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/deviceCapabilities.bs"
 import "pkg:/source/utils/misc.bs"
-
-enum SubtitleSelection
-    notset = -2
-    none = -1
-end enum
 
 sub init()
     m.top.filter = "All"

--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -1,5 +1,6 @@
 import "pkg:/source/enums/MediaPlaybackState.bs"
 import "pkg:/source/enums/TaskControl.bs"
+import "pkg:/source/enums/SubtitleSelection.bs"
 import "pkg:/source/enums/TimerControl.bs"
 import "pkg:/source/enums/VideoControl.bs"
 
@@ -159,7 +160,7 @@ sub onSelectSubtitlePressed()
 
     ' Manually create the None option and place at top
     subtitleData.data.Unshift({
-        "Index": -1,
+        "Index": SubtitleSelection.none,
         "IsExternal": false,
         "Track": {
             "description": "None"

--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -127,7 +127,7 @@ sub onSelectSubtitlePressed()
     for each item in m.view.fullSubtitleData
         item.type = "subtitleselection"
 
-        if m.view.selectedSubtitle <> -1
+        if m.view.selectedSubtitle <> SubtitleSelection.none
             ' Subtitle is a track within the file
             if item.index = m.view.selectedSubtitle
                 item.selected = true
@@ -135,7 +135,7 @@ sub onSelectSubtitlePressed()
         else
             ' Subtitle is from an external source
             availableSubtitleTrackIndex = availSubtitleTrackIdx(item.track.TrackName)
-            if availableSubtitleTrackIndex <> -1
+            if availableSubtitleTrackIndex <> SubtitleSelection.none
 
                 ' Convert Jellyfin subtitle track name to Roku track name
                 subtitleFullTrackName = m.view.availableSubtitleTracks[availableSubtitleTrackIndex].TrackName
@@ -215,7 +215,7 @@ sub processSubtitleSelection()
     m.selectedSubtitle = m.global.sceneManager.returnData
 
     ' The selected encoded subtitle did not change.
-    if m.view.selectedSubtitle <> -1 or m.selectedSubtitle.index <> -1
+    if m.view.selectedSubtitle <> SubtitleSelection.none or m.selectedSubtitle.index <> SubtitleSelection.none
         if m.view.selectedSubtitle = m.selectedSubtitle.index then return
     end if
 
@@ -234,8 +234,8 @@ sub processSubtitleSelection()
         m.view.globalCaptionMode = "Off"
         m.view.subtitleTrack = ""
 
-        if m.view.selectedSubtitle <> -1
-            m.view.selectedSubtitle = -1
+        if m.view.selectedSubtitle <> SubtitleSelection.none
+            m.view.selectedSubtitle = SubtitleSelection.none
         end if
 
         m.global.queueManager.callFunc("setPreferredSubtitleTrack", m.selectedSubtitle)
@@ -251,7 +251,7 @@ sub processSubtitleSelection()
 
         ' Roku may rearrange subtitle tracks. Look up track based on name to ensure we get the correct index
         availableSubtitleTrackIndex = availSubtitleTrackIdx(m.selectedSubtitle.Track.TrackName)
-        if availableSubtitleTrackIndex = -1 then return
+        if availableSubtitleTrackIndex = SubtitleSelection.none then return
 
         m.view.subtitleTrack = m.view.availableSubtitleTracks[availableSubtitleTrackIndex].TrackName
     end if
@@ -376,7 +376,7 @@ function availSubtitleTrackIdx(tracknameToFind as string) as integer
         end if
         idx = idx + 1
     end for
-    return -1
+    return SubtitleSelection.none
 end function
 
 function audioMiniPlayerIsVisible(baseNode as dynamic) as boolean

--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -128,7 +128,7 @@ sub onSelectSubtitlePressed()
     for each item in m.view.fullSubtitleData
         item.type = "subtitleselection"
 
-        if m.view.selectedSubtitle <> SubtitleSelection.none
+        if m.view.selectedSubtitle <> SubtitleSelection.NONE
             ' Subtitle is a track within the file
             if item.index = m.view.selectedSubtitle
                 item.selected = true
@@ -136,7 +136,7 @@ sub onSelectSubtitlePressed()
         else
             ' Subtitle is from an external source
             availableSubtitleTrackIndex = availSubtitleTrackIdx(item.track.TrackName)
-            if availableSubtitleTrackIndex <> SubtitleSelection.none
+            if availableSubtitleTrackIndex <> SubtitleSelection.NONE
 
                 ' Convert Jellyfin subtitle track name to Roku track name
                 subtitleFullTrackName = m.view.availableSubtitleTracks[availableSubtitleTrackIndex].TrackName
@@ -160,7 +160,7 @@ sub onSelectSubtitlePressed()
 
     ' Manually create the None option and place at top
     subtitleData.data.Unshift({
-        "Index": SubtitleSelection.none,
+        "Index": SubtitleSelection.NONE,
         "IsExternal": false,
         "Track": {
             "description": "None"
@@ -216,7 +216,7 @@ sub processSubtitleSelection()
     m.selectedSubtitle = m.global.sceneManager.returnData
 
     ' The selected encoded subtitle did not change.
-    if m.view.selectedSubtitle <> SubtitleSelection.none or m.selectedSubtitle.index <> SubtitleSelection.none
+    if m.view.selectedSubtitle <> SubtitleSelection.NONE or m.selectedSubtitle.index <> SubtitleSelection.NONE
         if m.view.selectedSubtitle = m.selectedSubtitle.index then return
     end if
 
@@ -235,8 +235,8 @@ sub processSubtitleSelection()
         m.view.globalCaptionMode = "Off"
         m.view.subtitleTrack = ""
 
-        if m.view.selectedSubtitle <> SubtitleSelection.none
-            m.view.selectedSubtitle = SubtitleSelection.none
+        if m.view.selectedSubtitle <> SubtitleSelection.NONE
+            m.view.selectedSubtitle = SubtitleSelection.NONE
         end if
 
         m.global.queueManager.callFunc("setPreferredSubtitleTrack", m.selectedSubtitle)
@@ -252,7 +252,7 @@ sub processSubtitleSelection()
 
         ' Roku may rearrange subtitle tracks. Look up track based on name to ensure we get the correct index
         availableSubtitleTrackIndex = availSubtitleTrackIdx(m.selectedSubtitle.Track.TrackName)
-        if availableSubtitleTrackIndex = SubtitleSelection.none then return
+        if availableSubtitleTrackIndex = SubtitleSelection.NONE then return
 
         m.view.subtitleTrack = m.view.availableSubtitleTracks[availableSubtitleTrackIndex].TrackName
     end if
@@ -377,7 +377,7 @@ function availSubtitleTrackIdx(tracknameToFind as string) as integer
         end if
         idx = idx + 1
     end for
-    return SubtitleSelection.none
+    return SubtitleSelection.NONE
 end function
 
 function audioMiniPlayerIsVisible(baseNode as dynamic) as boolean

--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -607,7 +607,7 @@ sub SetUpAudioOptions(streams)
 
     audioTracks = []
     subtitleTracks = [{
-        "StreamIndex": -1,
+        "StreamIndex": SubtitleSelection.none,
         "json": {},
         "Title": "None",
         "Description": "None",

--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -11,6 +11,7 @@ import "pkg:/source/enums/MediaStreamType.bs"
 import "pkg:/source/enums/PersonType.bs"
 import "pkg:/source/enums/PlaybackMethod.bs"
 import "pkg:/source/enums/String.bs"
+import "pkg:/source/enums/SubtitleSelection.bs"
 import "pkg:/source/enums/TaskControl.bs"
 import "pkg:/source/enums/VideoType.bs"
 import "pkg:/source/enums/ViewLoadStatus.bs"
@@ -602,7 +603,7 @@ end sub
 
 sub SetUpAudioOptions(streams)
     preferredSubtitle = m.global.queueManager.callFunc("getPreferredSubtitleTrack")
-    selectedSubtitle = isChainValid(preferredSubtitle, "StreamIndex") ? preferredSubtitle.StreamIndex : -1
+    selectedSubtitle = isChainValid(preferredSubtitle, "StreamIndex") ? preferredSubtitle.StreamIndex : SubtitleSelection.none
 
     audioTracks = []
     subtitleTracks = [{
@@ -610,7 +611,7 @@ sub SetUpAudioOptions(streams)
         "json": {},
         "Title": "None",
         "Description": "None",
-        "Selected": selectedSubtitle = -1
+        "Selected": selectedSubtitle = SubtitleSelection.none
     }]
 
     audioStreamCount = 1

--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -603,15 +603,15 @@ end sub
 
 sub SetUpAudioOptions(streams)
     preferredSubtitle = m.global.queueManager.callFunc("getPreferredSubtitleTrack")
-    selectedSubtitle = isChainValid(preferredSubtitle, "StreamIndex") ? preferredSubtitle.StreamIndex : SubtitleSelection.none
+    selectedSubtitle = isChainValid(preferredSubtitle, "StreamIndex") ? preferredSubtitle.StreamIndex : SubtitleSelection.NONE
 
     audioTracks = []
     subtitleTracks = [{
-        "StreamIndex": SubtitleSelection.none,
+        "StreamIndex": SubtitleSelection.NONE,
         "json": {},
         "Title": "None",
         "Description": "None",
-        "Selected": selectedSubtitle = SubtitleSelection.none
+        "Selected": selectedSubtitle = SubtitleSelection.NONE
     }]
 
     audioStreamCount = 1

--- a/components/movies/MovieOptions.bs
+++ b/components/movies/MovieOptions.bs
@@ -3,6 +3,7 @@ import "pkg:/source/enums/ColorPalette.bs"
 import "pkg:/source/enums/KeyCode.bs"
 import "pkg:/source/enums/PlaybackMethod.bs"
 import "pkg:/source/enums/String.bs"
+import "pkg:/source/enums/SubtitleSelection.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
@@ -16,7 +17,7 @@ sub init()
     m.selectedItem = 0
     m.selectedAudioIndex = 0
     m.selectedVideoIndex = 0
-    m.selectedSubtitleIndex = -1
+    m.selectedSubtitleIndex = SubtitleSelection.none
 
     m.optionMenu = m.top.findNode("optionMenu")
     m.optionMenu.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)

--- a/components/movies/MovieOptions.bs
+++ b/components/movies/MovieOptions.bs
@@ -17,7 +17,7 @@ sub init()
     m.selectedItem = 0
     m.selectedAudioIndex = 0
     m.selectedVideoIndex = 0
-    m.selectedSubtitleIndex = SubtitleSelection.none
+    m.selectedSubtitleIndex = SubtitleSelection.NONE
 
     m.optionMenu = m.top.findNode("optionMenu")
     m.optionMenu.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -7,6 +7,7 @@ import "pkg:/source/enums/MediaPlaybackState.bs"
 import "pkg:/source/enums/MediaSegmentAction.bs"
 import "pkg:/source/enums/MediaSegmentType.bs"
 import "pkg:/source/enums/String.bs"
+import "pkg:/source/enums/SubtitleSelection.bs"
 import "pkg:/source/enums/TaskControl.bs"
 import "pkg:/source/enums/TimerControl.bs"
 import "pkg:/source/enums/VideoControl.bs"
@@ -31,7 +32,7 @@ sub init()
     }
 
     preferredSubtitle = m.global.queueManager.callFunc("getPreferredSubtitleTrack")
-    m.top.SelectedSubtitle = isChainValid(preferredSubtitle, "StreamIndex") ? preferredSubtitle.StreamIndex : -2
+    m.top.SelectedSubtitle = isChainValid(preferredSubtitle, "StreamIndex") ? preferredSubtitle.StreamIndex : SubtitleSelection.notset
     m.originalClosedCaptionState = invalid
 
     ' Load meta data
@@ -428,7 +429,7 @@ end sub
 sub onSubtitleChange()
     switchWithoutRefresh = true
 
-    if m.top.SelectedSubtitle <> -1
+    if m.top.SelectedSubtitle <> SubtitleSelection.none
         ' If the global caption mode is off, then Roku can't display the subtitles natively and needs a video stop/start
         if LCase(m.top.globalCaptionMode) <> "on" then switchWithoutRefresh = false
     end if
@@ -611,7 +612,7 @@ sub onVideoContentLoaded()
 
     if isValid(selectedSubtitle)
         availableSubtitleTrackIndex = availSubtitleTrackIdx(selectedSubtitle.Track.TrackName)
-        if availableSubtitleTrackIndex <> -1
+        if availableSubtitleTrackIndex <> SubtitleSelection.none
             if not selectedSubtitle.IsEncoded
                 if selectedSubtitle.IsForced
                     ' If IsForced, make sure to remember the Roku global setting so we can set it back when the video is done playing.
@@ -1128,7 +1129,7 @@ end function
 ' availSubtitleTrackIdx: Returns Roku's index for requested subtitle track
 '
 ' @param {string} tracknameToFind - TrackName for subtitle we're looking to match
-' @return {integer} indicating Roku's index for requested subtitle track. Returns -1 if not found
+' @return {integer} indicating Roku's index for requested subtitle track. Returns SubtitleSelection.none if not found
 function availSubtitleTrackIdx(tracknameToFind as string) as integer
     idx = 0
     for each availTrack in m.top.availableSubtitleTracks
@@ -1140,7 +1141,7 @@ function availSubtitleTrackIdx(tracknameToFind as string) as integer
         end if
         idx = idx + 1
     end for
-    return -1
+    return SubtitleSelection.none
 end function
 
 sub skipCurrentSegment()

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -32,7 +32,7 @@ sub init()
     }
 
     preferredSubtitle = m.global.queueManager.callFunc("getPreferredSubtitleTrack")
-    m.top.SelectedSubtitle = isChainValid(preferredSubtitle, "StreamIndex") ? preferredSubtitle.StreamIndex : SubtitleSelection.notset
+    m.top.SelectedSubtitle = isChainValid(preferredSubtitle, "StreamIndex") ? preferredSubtitle.StreamIndex : SubtitleSelection.NOTSET
     m.originalClosedCaptionState = invalid
 
     ' Load meta data
@@ -429,7 +429,7 @@ end sub
 sub onSubtitleChange()
     switchWithoutRefresh = true
 
-    if m.top.SelectedSubtitle <> SubtitleSelection.none
+    if m.top.SelectedSubtitle <> SubtitleSelection.NONE
         ' If the global caption mode is off, then Roku can't display the subtitles natively and needs a video stop/start
         if LCase(m.top.globalCaptionMode) <> "on" then switchWithoutRefresh = false
     end if
@@ -612,7 +612,7 @@ sub onVideoContentLoaded()
 
     if isValid(selectedSubtitle)
         availableSubtitleTrackIndex = availSubtitleTrackIdx(selectedSubtitle.Track.TrackName)
-        if availableSubtitleTrackIndex <> SubtitleSelection.none
+        if availableSubtitleTrackIndex <> SubtitleSelection.NONE
             if not selectedSubtitle.IsEncoded
                 if selectedSubtitle.IsForced
                     ' If IsForced, make sure to remember the Roku global setting so we can set it back when the video is done playing.
@@ -1129,7 +1129,7 @@ end function
 ' availSubtitleTrackIdx: Returns Roku's index for requested subtitle track
 '
 ' @param {string} tracknameToFind - TrackName for subtitle we're looking to match
-' @return {integer} indicating Roku's index for requested subtitle track. Returns SubtitleSelection.none if not found
+' @return {integer} indicating Roku's index for requested subtitle track. Returns SubtitleSelection.NONE if not found
 function availSubtitleTrackIdx(tracknameToFind as string) as integer
     idx = 0
     for each availTrack in m.top.availableSubtitleTracks
@@ -1141,7 +1141,7 @@ function availSubtitleTrackIdx(tracknameToFind as string) as integer
         end if
         idx = idx + 1
     end for
-    return SubtitleSelection.none
+    return SubtitleSelection.NONE
 end function
 
 sub skipCurrentSegment()

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -4,6 +4,7 @@ import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/enums/PlaybackMethod.bs"
 import "pkg:/source/enums/ResumePopupAction.bs"
 import "pkg:/source/enums/String.bs"
+import "pkg:/source/enums/SubtitleSelection.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub onQuickPlayEvent(msg)
@@ -1280,7 +1281,7 @@ sub onReturnDataEvent(msg)
 
             ' Search list of subtitles to see if we already have a downloading message for this item
             for each subtitle in subtitleListContent.getChildren(-1, 0)
-                if subtitle.LookupCI("index") = -1
+                if subtitle.LookupCI("index") = SubtitleSelection.none
                     if isStringEqual(subtitle.LookupCI("displaytitle"), popupNode.LookupCI("name"))
                         canAddSubtitle = false
                     end if
@@ -1291,7 +1292,7 @@ sub onReturnDataEvent(msg)
             if canAddSubtitle
                 mySubtitle = CreateObject("roSGNode", "SubtitleData")
                 mySubtitle.path = tr("Downloading - Refresh for updated status")
-                mySubtitle.index = -1
+                mySubtitle.index = SubtitleSelection.none
                 mySubtitle.displaytitle = popupNode.LookupCI("name")
                 mySubtitle.canDelete = false
 

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -1281,7 +1281,7 @@ sub onReturnDataEvent(msg)
 
             ' Search list of subtitles to see if we already have a downloading message for this item
             for each subtitle in subtitleListContent.getChildren(-1, 0)
-                if subtitle.LookupCI("index") = SubtitleSelection.none
+                if subtitle.LookupCI("index") = SubtitleSelection.NONE
                     if isStringEqual(subtitle.LookupCI("displaytitle"), popupNode.LookupCI("name"))
                         canAddSubtitle = false
                     end if
@@ -1292,7 +1292,7 @@ sub onReturnDataEvent(msg)
             if canAddSubtitle
                 mySubtitle = CreateObject("roSGNode", "SubtitleData")
                 mySubtitle.path = tr("Downloading - Refresh for updated status")
-                mySubtitle.index = SubtitleSelection.none
+                mySubtitle.index = SubtitleSelection.NONE
                 mySubtitle.displaytitle = popupNode.LookupCI("name")
                 mySubtitle.canDelete = false
 

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -14,7 +14,7 @@ function ItemGetPlaybackInfo(id as string, startTimeTicks = 0 as longinteger)
     return getJson(resp)
 end function
 
-function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioTrackIndex = -1 as integer, subtitleTrackIndex = SubtitleSelection.none as integer, startTimeTicks = 0 as longinteger)
+function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioTrackIndex = -1 as integer, subtitleTrackIndex = SubtitleSelection.NONE as integer, startTimeTicks = 0 as longinteger)
 
     transcodeCodec = string.EMPTY
 

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -1,5 +1,6 @@
 import "pkg:/source/api/sdk.bs"
 import "pkg:/source/enums/PlaybackMethod.bs"
+import "pkg:/source/enums/SubtitleSelection.bs"
 
 function ItemGetPlaybackInfo(id as string, startTimeTicks = 0 as longinteger)
     params = {
@@ -13,7 +14,7 @@ function ItemGetPlaybackInfo(id as string, startTimeTicks = 0 as longinteger)
     return getJson(resp)
 end function
 
-function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioTrackIndex = -1 as integer, subtitleTrackIndex = -1 as integer, startTimeTicks = 0 as longinteger)
+function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioTrackIndex = -1 as integer, subtitleTrackIndex = SubtitleSelection.none as integer, startTimeTicks = 0 as longinteger)
 
     transcodeCodec = string.EMPTY
 

--- a/source/enums/SubtitleSelection.bs
+++ b/source/enums/SubtitleSelection.bs
@@ -1,0 +1,4 @@
+enum SubtitleSelection
+    notset = -2
+    none = -1
+end enum

--- a/source/enums/SubtitleSelection.bs
+++ b/source/enums/SubtitleSelection.bs
@@ -1,4 +1,4 @@
 enum SubtitleSelection
-    notset = -2
-    none = -1
+    NOTSET = -2
+    NONE = -1
 end enum


### PR DESCRIPTION
## Changes

The codebase uses two sentinel values to represent special cases of subtitle indices, but there's inconsistency in how they're used. In some places, we use named constants as part of a `SubtitleSelection` enum and in other places we just use the raw values as magic numbers (`-1`, `-2`).

This change replaces the references to magic numbers with references to the appropriate `SubtitleSelection` enum.

This makes the code more readable because `SubtitleSelection.NONE` is more obvious than `-1`. It also ensures a single source of truth in defining these values and keeping them consistent across the codebase.

This is a non-functional change, as we're replacing magic numbers with named constants of the same value.

## Issues

Related: #526

I believe the root cause of #526 is that we're using these sentinel values inconsistently. This change has no impact on functionality, but I think it will make it easier to implement a fix for that issue in a subsequent change.