### PR TITLE
Add basic project build in CI with Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build jellyfin-roku client project
+        run: npm run build
+
+      - name: Save build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jellyfin-roku-build
+          # This creates a zip of a zip, which is not ideal, but it means we're
+          # using the same output we'd get from a local build.
+          path: ./out/jellyfin-roku.zip
+          retention-days: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,3 @@ jobs:
 
       - name: Build jellyfin-roku client project
         run: npm run build
-
-      - name: Save build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: jellyfin-roku-build
-          # This creates a zip of a zip, which is not ideal, but it means we're
-          # using the same output we'd get from a local build.
-          path: ./out/jellyfin-roku.zip
-          retention-days: 30

--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -303,6 +303,9 @@ function parseVTT(lines)
             if isStringEqual(finalText, string.EMPTY)
                 entry.AddReplace("text", currentLine)
                 entries.push(entry)
+                ' This is a false positive in bslint due to
+                ' https://github.com/rokucommunity/bslint/issues/47
+                ' bs:disable-next-line
                 isNewLine = false
 
                 continue for


### PR DESCRIPTION
## Changes

This adds a Github Actions step so that on every commit to the main branch or pull request, Github Actions performs a build of the project in a clean environment. This helps identify compilation or linting errors early.

I configured it to keep the `jellyfin-roku.zip` as a build artifact, as it might be a convenient way to grab a PR version for testing, but we don't strictly need it. 

As noted in the comment, the build artifact step makes a zip of a zip. We could avoid the double-zip issue by instead specifying `build/staging/` as the build artifact directory, but it feels a little brittle to duplicate the logic of creating a build zip from `.bsconfig.json`.

## Issues

None