### PR TITLE
Add option for subtitle burn

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -510,8 +510,10 @@ sub onVideoContentLoaded()
     end if
 
     m.isTranscoded = videoContent[0].isTranscoded
+    burnInSubtitles = chainLookupReturn(m.global, "session.user.settings.`playback.subs.burnin`", false)
 
-    if m.isTranscoded
+
+    if m.isTranscoded and burnInSubtitles
         videoContent[0].content.SubtitleTracks = []
     end if
 
@@ -583,8 +585,8 @@ sub onVideoContentLoaded()
         ' Disable trackplay bar for intro videos
         m.top.enableTrickPlay = false
     else
-        ' Allow custom captions for non intro videos as long as the video isn't transcoded
-        m.top.allowCaptions = not m.isTranscoded
+        ' Allow custom captions for non intro videos unless the video is being transcoded and burn subtitles are enabled
+        m.top.allowCaptions = not (m.isTranscoded and burnInSubtitles)
     end if
 
     ' Allow default subtitles
@@ -594,7 +596,7 @@ sub onVideoContentLoaded()
     selectedSubtitle = invalid
     updatedSubtitleData = []
     for each subtitle in m.top.fullSubtitleData
-        if m.isTranscoded
+        if m.isTranscoded and burnInSubtitles
             subtitle.IsEncoded = true
             updatedSubtitleData.push(subtitle)
         end if
@@ -605,7 +607,7 @@ sub onVideoContentLoaded()
         end if
     end for
 
-    if m.isTranscoded
+    if m.isTranscoded and burnInSubtitles
         m.top.fullSubtitleData = updatedSubtitleData
         m.top.globalCaptionMode = "Off"
     end if
@@ -624,7 +626,7 @@ sub onVideoContentLoaded()
         end if
     end if
 
-    if not m.isTranscoded
+    if not (m.isTranscoded and burnInSubtitles)
         m.top.selectedSubtitle = videoContent[0].selectedSubtitle
     end if
 

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2185,5 +2185,15 @@
             <source>Playback will automatically stop in 1 minute if no buttons are pressed.</source>
             <translation>Playback will automatically stop in 1 minute if no buttons are pressed.</translation>
         </message>
+        <message>
+            <source>Burn in subtitle when transcoding</source>
+            <translation>Burn in subtitle when transcoding</translation>
+            <extracomment>Settings Menu - Title for option</extracomment>
+        </message>
+        <message>
+            <source>Burn in all subtitles when transcoding is triggered. This ensures subtitle synchronization after transcoding at the cost of reduced transcoding speed.</source>
+            <translation>Burn in all subtitles when transcoding is triggered. This ensures subtitle synchronization after transcoding at the cost of reduced transcoding speed.</translation>
+            <extracomment>Settings Menu - Description for option</extracomment>
+        </message>
     </context>
 </TS>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -51,6 +51,13 @@
         ]
       },
       {
+        "title": "Burn in subtitle when transcoding",
+        "description": "Burn in all subtitles when transcoding is triggered. This ensures subtitle synchronization after transcoding at the cost of reduced transcoding speed.",
+        "settingName": "playback.subs.burnin",
+        "type": "bool",
+        "default": "false"
+      },
+      {
         "title": "Cinema Mode",
         "description": "Bring the theater experience straight to your living room with the ability to play custom intros before the main feature.",
         "settingName": "playback.cinemamode",

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -22,9 +22,10 @@ function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioT
         transcodeCodec = m.global.queueManager.callFunc("getTranscodeCodec")
     end if
 
+    burnInSubtitles = chainLookupReturn(m.global, "session.user.settings.`playback.subs.burnin`", false)
     body = {
         "DeviceProfile": getDeviceProfile(transcodeCodec),
-        "AlwaysBurnInSubtitleWhenTranscoding": true
+        "AlwaysBurnInSubtitleWhenTranscoding": burnInSubtitles
     }
     params = {
         "UserId": m.global.session.user.id,

--- a/source/static/whatsNew/3.0.12.json
+++ b/source/static/whatsNew/3.0.12.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "",
-    "author": ""
+    "description": "Add setting to enable burn in subtitles during transcoding",
+    "author": "michaelforgit"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->

- Adds a setting to enable subtitle burn in when transcoding.  
- It adds to [this pr](https://github.com/jellyfin/jellyfin-roku/pull/511) that says "Burn subtitles if video is transcoding. I may convert this to a setting in a later PR, but this change is already big enough."
- I used the above PR to look at where this setting is needed.

The reason I added this is one of my user's does not like the burned in subtitles font and prefers their tv settings.  I am open to feedback on anything in this PR.

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
