### PR TITLE
Fix 10.11.0 transcode issue when username has spaces in it

### DIFF
--- a/source/static/whatsNew/3.0.11.json
+++ b/source/static/whatsNew/3.0.11.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "",
-    "author": ""
+    "description": "Fix 10.11.0 transcode issue when username has spaces in it",
+    "author": "1hitsong"
   }
 ]

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -2,6 +2,7 @@
 import "pkg:/source/api/baserequest.bs"
 import "pkg:/source/api/userauth.bs"
 import "pkg:/source/enums/LiveTVScreen.bs"
+import "pkg:/source/enums/String.bs"
 import "pkg:/source/utils/misc.bs"
 
 namespace session
@@ -123,8 +124,8 @@ namespace session
 
             ' keep friendlyName in sync
             if LCase(key) = "name"
-                regex = CreateObject("roRegex", "[^a-zA-Z0-9\ \-\_]", "")
-                tmpSessionUser["friendlyName"] = regex.ReplaceAll(value, "")
+                regex = CreateObject("roRegex", "[^a-zA-Z0-9\-\_]", string.EMPTY)
+                tmpSessionUser["friendlyName"] = regex.ReplaceAll(value, string.EMPTY)
             end if
 
             ' update global user session using the temp array
@@ -155,8 +156,8 @@ namespace session
                 tmpSession.user.AddReplace("authToken", userData.json.AccessToken)
             end if
             ' remove special characters from name
-            regex = CreateObject("roRegex", "[^a-zA-Z0-9\ \-\_]", "")
-            friendlyName = regex.ReplaceAll(tmpSession.user.name, "")
+            regex = CreateObject("roRegex", "[^a-zA-Z0-9\-\_]", string.EMPTY)
+            friendlyName = regex.ReplaceAll(tmpSession.user.name, string.EMPTY)
             tmpSession.user.AddReplace("friendlyName", friendlyName)
 
             tmpSession.user.AddReplace("settings", oldUserSettings)
@@ -205,7 +206,8 @@ namespace session
 
             ' default device name is the unique id for the device
             deviceName = localGlobal.device.id
-            if isValid(localGlobal.session.user) and isValid(localGlobal.session.user.friendlyName)
+
+            if isChainValid(localGlobal, "session.user.friendlyName")
                 deviceName = deviceName + localGlobal.session.user.friendlyName
             end if
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Removes spaces from device name field. It appears this causes issues with server version 10.11.0 that did not occur under 10.10.0

## Issues
Fixes #568