### PR TITLE
Burn subtitles by default when transcoding

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -510,7 +510,7 @@ sub onVideoContentLoaded()
     end if
 
     m.isTranscoded = videoContent[0].isTranscoded
-    burnInSubtitles = chainLookupReturn(m.global, "session.user.settings.`playback.subs.burnin`", false)
+    burnInSubtitles = chainLookupReturn(m.global, "session.user.settings.`playback.subs.burnin`", true)
 
 
     if m.isTranscoded and burnInSubtitles

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -55,7 +55,7 @@
         "description": "Burn in all subtitles when transcoding is triggered. This ensures subtitle synchronization after transcoding at the cost of reduced transcoding speed.",
         "settingName": "playback.subs.burnin",
         "type": "bool",
-        "default": "false"
+        "default": "true"
       },
       {
         "title": "Cinema Mode",

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -22,7 +22,7 @@ function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioT
         transcodeCodec = m.global.queueManager.callFunc("getTranscodeCodec")
     end if
 
-    burnInSubtitles = chainLookupReturn(m.global, "session.user.settings.`playback.subs.burnin`", false)
+    burnInSubtitles = chainLookupReturn(m.global, "session.user.settings.`playback.subs.burnin`", true)
     body = {
         "DeviceProfile": getDeviceProfile(transcodeCodec),
         "AlwaysBurnInSubtitleWhenTranscoding": burnInSubtitles


### PR DESCRIPTION
## Changes
This option was added in #567, but defaulted to false, which is opposite of the previous behaviour of always burning in subtitles when transcoding. Without this, subtitles *will* desync from the content.

See https://github.com/jellyfin/jellyfin-roku/pull/567#issuecomment-3479233900 for context.
