### PR TITLE
Fix inability to close Next Up display

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1021,9 +1021,9 @@ function getRemainingTime(videoSeekPosition = 0 as integer)
 end function
 
 sub onTrickPlayBarTextChange()
-    if m.nextupbuttonseconds <> 0 then m.nextupbuttonseconds = m.global.session.user.settings["playback.nextupbuttonseconds"].ToInt()
-
     if not m.top.trickPlayBar.visible then return
+
+    m.nextupbuttonseconds = m.global.session.user.settings["playback.nextupbuttonseconds"].ToInt()
 
     setVideoEndingTime(0)
 

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1021,7 +1021,7 @@ function getRemainingTime(videoSeekPosition = 0 as integer)
 end function
 
 sub onTrickPlayBarTextChange()
-    m.nextupbuttonseconds = m.global.session.user.settings["playback.nextupbuttonseconds"].ToInt()
+    if m.nextupbuttonseconds <> 0 then m.nextupbuttonseconds = m.global.session.user.settings["playback.nextupbuttonseconds"].ToInt()
 
     if not m.top.trickPlayBar.visible then return
 

--- a/source/static/whatsNew/3.0.12.json
+++ b/source/static/whatsNew/3.0.12.json
@@ -6,5 +6,9 @@
   {
     "description": "Add setting to limit maximum audio channels",
     "author": "brianpardy"
+  },
+  {
+    "description": "Fix bug preventing dismissal of Next Up display",
+    "author": "brianpardy"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
If Next Up display has been disabled by pressing the back key while on-screen, do not revert it back to the configured value in onTrickPlayBarTextChange().

## Issues
Fixes #578 
