### PR TITLE
Fix subtitles not displaying when burning into transcoded video

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -343,6 +343,14 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
             video.content = invalid
             return
         end if
+
+        ' If transcoding and burnInSubtitlesIfTrancoding is enabled, zero out SubtitleProfiles
+        if chainLookupReturn(m.global, "session.user.settings.`playback.subs.burnin`", true)
+            m.playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition, {
+                emptySubtitleProfiles: true
+            })
+        end if
+
         ' Get transcoding reason
         video.transcodeReasons = getTranscodeReasons(m.playbackInfo.MediaSources[0].TranscodingUrl)
         video.content.url = buildURL(m.playbackInfo.MediaSources[0].TranscodingUrl)

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2202,7 +2202,7 @@
         </message>
         <message>
             <source>Burn in subtitle when transcoding</source>
-            <translation>Burn in subtitle when transcoding</translation>
+            <translation>Burn In Subtitle When Transcoding</translation>
             <extracomment>Settings Menu - Title for option</extracomment>
         </message>
         <message>

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -14,7 +14,7 @@ function ItemGetPlaybackInfo(id as string, startTimeTicks = 0 as longinteger)
     return getJson(resp)
 end function
 
-function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioTrackIndex = -1 as integer, subtitleTrackIndex = SubtitleSelection.NONE as integer, startTimeTicks = 0 as longinteger)
+function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioTrackIndex = -1 as integer, subtitleTrackIndex = SubtitleSelection.NONE as integer, startTimeTicks = 0 as longinteger, options = {} as object)
 
     transcodeCodec = string.EMPTY
 
@@ -36,6 +36,10 @@ function ItemPostPlaybackInfo(id as string, mediaSourceId = "" as string, audioT
         "MaxStaticBitrate": "140000000",
         "SubtitleStreamIndex": subtitleTrackIndex
     }
+
+    if chainLookupReturn(options, "emptySubtitleProfiles", false)
+        body.DeviceProfile.SubtitleProfiles = []
+    end if
 
     ' Note: Jellyfin v10.9+ now remuxs LiveTV and does not allow DirectPlay anymore.
     ' Because of this, we need to tell the server "EnableDirectPlay = false" so that we receive the

--- a/source/static/whatsNew/3.0.13.json
+++ b/source/static/whatsNew/3.0.13.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "",
-    "author": ""
+    "description": "Fix subtitles not displaying when burning into transcoded video",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Fixes burning in subs when transcoding video. It does this by zeroing out the subtitle profile array. This is also how it is handled in the web client.

It seems without doing this the server believes Roku is handling subtitles and does not burn them into the video while the Roku believes the server is handling subtitles and does not display them - and the user is left with no subtitles since nothing handled them.
