### PR TITLE
Fix URL parsing issues

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -469,12 +469,12 @@ end function
 sub addVideoContentURL(video, mediaSourceId, audio_stream_idx, fully_external)
     protocol = LCase(m.playbackInfo.MediaSources[0].Protocol)
     if protocol <> "file"
-        uri = parseUrl(m.playbackInfo.MediaSources[0].Path)
-        if isLocalhost(uri[2])
+        uri = ParsedUrl(m.playbackInfo.MediaSources[0].Path)
+        if isLocalhost(uri.host)
             ' if the domain of the URI is local to the server,
             ' create a new URI by appending the received path to the server URL
             ' later we will substitute the users provided URL for this case
-            video.content.url = buildURL(uri[4])
+            video.content.url = buildURL(uri.path)
         else
             fully_external = true
             video.content.url = m.playbackInfo.MediaSources[0].Path

--- a/package-lock.json
+++ b/package-lock.json
@@ -607,7 +607,6 @@
       "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.70.3.tgz",
       "integrity": "sha512-R9r/AWvxDZioTfDvRZT50yO+PAHl/nElKA3SO9eWfmF43J88CBEtLT1dpLfFPfmPfdtxjcF58ZW87rmcqqYVyA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rokucommunity/bslib": "^0.1.1",
         "@rokucommunity/logger": "^0.3.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -504,6 +504,7 @@
       "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.70.3.tgz",
       "integrity": "sha512-R9r/AWvxDZioTfDvRZT50yO+PAHl/nElKA3SO9eWfmF43J88CBEtLT1dpLfFPfmPfdtxjcF58ZW87rmcqqYVyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rokucommunity/bslib": "^0.1.1",
         "@rokucommunity/logger": "^0.3.11",

--- a/source/api/baserequest.bs
+++ b/source/api/baserequest.bs
@@ -51,17 +51,26 @@ function buildURL(path as string, params = {} as object) as dynamic
     full_url += realPath.startswith("/") ? realPath : `/${realPath}`
 
     ' append query string values
-    if parsed_url.query <> "" or pathQuery <> "" or params.count() > 0
+    if isValidAndNotEmpty(parsed_url.query) or isValidAndNotEmpty(pathQuery) or isValidAndNotEmpty(params)
         full_url += "?"
-        if parsed_url.query <> ""
+
+        if isValidAndNotEmpty(parsed_url.query)
             full_url += parsed_url.query
-            if pathQuery <> "" or params.count() > 0 then full_url += "&"
+            if isValidAndNotEmpty(pathQuery) or isValidAndNotEmpty(params)
+                full_url += "&"
+            end if
         end if
-        if pathQuery <> ""
+
+        if isValidAndNotEmpty(pathQuery)
             full_url += pathQuery
-            if params.count() > 0 then full_url += "&"
+            if isValidAndNotEmpty(params)
+                full_url += "&"
+            end if
         end if
-        if params.count() > 0 then full_url += buildParams(params)
+
+        if isValidAndNotEmpty(params)
+            full_url += buildParams(params)
+        end if
     end if
 
     return full_url

--- a/source/api/baserequest.bs
+++ b/source/api/baserequest.bs
@@ -39,15 +39,29 @@ function buildURL(path as string, params = {} as object) as dynamic
     serverURL = get_url()
     if serverURL = invalid then return invalid
 
-    ' Add intial '/' if path does not start with one
-    if path.Left(1) = "/"
-        full_url = serverURL + path
-    else
-        full_url = serverURL + "/" + path
-    end if
+    parsed_url = ParsedUrl(serverURL)
+    full_url = `${parsed_url.proto}://${parsed_url.host}${parsed_url.port = "" ? "" : `:${parsed_url.port}`}${parsed_url.path}`
 
-    if params.count() > 0
-        full_url = full_url + "?" + buildParams(params)
+    ' some parts of the code include a query string with the path, so split it
+    pathParts = path.split("?")
+    realPath = pathParts[0]
+    pathQuery = pathParts.count() > 1 ? pathParts[1] : ""
+
+    ' Add intial '/' if path does not start with one
+    full_url += realPath.startswith("/") ? realPath : `/${realPath}`
+
+    ' append query string values
+    if parsed_url.query <> "" or pathQuery <> "" or params.count() > 0
+        full_url += "?"
+        if parsed_url.query <> ""
+            full_url += parsed_url.query
+            if pathQuery <> "" or params.count() > 0 then full_url += "&"
+        end if
+        if pathQuery <> ""
+            full_url += pathQuery
+            if params.count() > 0 then full_url += "&"
+        end if
+        if params.count() > 0 then full_url += buildParams(params)
     end if
 
     return full_url

--- a/source/api/baserequest.bs
+++ b/source/api/baserequest.bs
@@ -51,24 +51,28 @@ function buildURL(path as string, params = {} as object) as dynamic
     full_url += realPath.startswith("/") ? realPath : `/${realPath}`
 
     ' append query string values
-    if isValidAndNotEmpty(parsed_url.query) or isValidAndNotEmpty(pathQuery) or isValidAndNotEmpty(params)
+    hasQueryValue = isValidAndNotEmpty(parsed_url.query)
+    hasPathQueryValue = isValidAndNotEmpty(pathQuery)
+    hasParamsValue = isValidAndNotEmpty(params)
+
+    if hasQueryValue or hasPathQueryValue or hasParamsValue
         full_url += "?"
 
-        if isValidAndNotEmpty(parsed_url.query)
+        if hasQueryValue
             full_url += parsed_url.query
-            if isValidAndNotEmpty(pathQuery) or isValidAndNotEmpty(params)
+            if hasPathQueryValue or hasParamsValue
                 full_url += "&"
             end if
         end if
 
-        if isValidAndNotEmpty(pathQuery)
+        if hasPathQueryValue
             full_url += pathQuery
-            if isValidAndNotEmpty(params)
+            if hasParamsValue
                 full_url += "&"
             end if
         end if
 
-        if isValidAndNotEmpty(params)
+        if hasParamsValue
             full_url += buildParams(params)
         end if
     end if

--- a/source/static/whatsNew/3.0.13.json
+++ b/source/static/whatsNew/3.0.13.json
@@ -2,5 +2,9 @@
   {
     "description": "Fix subtitles not displaying when burning into transcoded video",
     "author": "1hitsong"
+  },
+  {
+    "description": "Add support for querystring values in server address",
+    "author": "GeekJosh"
   }
 ]

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -269,7 +269,7 @@ end function
 function urlCandidates(input as string)
     url = ParsedUrl(input)
     ' if the parsed url is invalid then the string is not a valid url
-    if url = invalid then return []
+    if not isValid(url) then return []
     supportedProtos = ["http", "https"]
     protoCandidates = isValidAndNotEmpty(url.proto) ? [url.proto] : supportedProtos ' if no proto was declared, try all supported
     finalCandidates = []

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -1,4 +1,5 @@
 import "pkg:/source/utils/config.bs"
+import "pkg:/source/utils/parsedUrl.bs"
 
 function isNodeEvent(msg, field as string) as boolean
     return type(msg) = "roSGNodeEvent" and msg.getField() = field
@@ -224,12 +225,11 @@ function inferServerUrl(url as string) as string
     for each endpoint in candidates
         req = CreateObject("roUrlTransfer")
         reqs.push(req) ' keep in scope outside of loop, else -10001
-        req.seturl(endpoint + "/system/info/public")
+        finalUrl = `${endpoint.proto}://${endpoint.host}${endpoint.port = "" ? "" : `:${endpoint.port}`}${endpoint.path}`
+        req.seturl(`${finalUrl}/system/info/public${endpoint.query = "" ? "" : `?${endpoint.query}`}`)
         req.setMessagePort(port)
-        hosts.addreplace(req.getidentity().ToStr(), endpoint)
-        if endpoint.Left(8) = "https://"
-            req.setCertificatesFile("common:/certs/ca-bundle.crt")
-        end if
+        hosts.addreplace(req.getidentity().ToStr(), `${finalUrl}${endpoint.query = "" ? "" : `?${endpoint.query}`}`)
+        if endpoint.proto = "https" then req.setCertificatesFile("common:/certs/ca-bundle.crt")
         req.AsyncGetToString()
     end for
     handled = 0
@@ -265,45 +265,23 @@ end function
 ' for the tests in inferServerUrl. takes an incomplete url as an arg and returns a list of extrapolated
 ' full urls.
 function urlCandidates(input as string)
-    if input.endswith("/") then input = input.Left(len(input) - 1)
-    url = parseUrl(input)
-    if url[1] = invalid
-        ' a proto wasn't declared
-        url = parseUrl("none://" + input)
-    end if
-    ' if the proto is still invalid then the string is not valid
-    if url[1] = invalid then return []
-    proto = url[1]
-    host = url[2]
-    port = url[3]
-    path = url[4]
-    protoCandidates = []
-    supportedProtos = ["http:", "https:"] ' appending colons because the regex does
-    if proto = "none:" ' the user did not declare a protocol
-        ' try every supported proto
-        for each supportedProto in supportedProtos
-            protoCandidates.push(supportedProto + "//" + host)
-        end for
-    else
-        protoCandidates.push(proto + "//" + host) ' but still allow arbitrary protocols if they are declared
-    end if
+    url = ParsedUrl(input)
+    ' if the parsed url is invalid then the string is not a valid url
+    if url = invalid then return []
+    supportedProtos = ["http", "https"]
+    protoCandidates = isValid(url.proto) and url.proto <> "" ? [url.proto] : supportedProtos ' if no proto was declared, try all supported
     finalCandidates = []
-    if isValid(port) and port <> "" ' if the port is defined just use that
-        for each candidate in protoCandidates
-            finalCandidates.push(candidate + port + path)
-        end for
-    else ' the port wasnt declared so use default jellyfin and proto ports
-        for each candidate in protoCandidates:
-            ' proto default
-            finalCandidates.push(candidate + path)
+    for each proto in protoCandidates:
+        finalCandidates.push(url.withProto(proto))
+        if isValid(url.port) = false or url.port = "" ' if the port isn't defined, use default jellyfin and proto ports
             ' jellyfin defaults
-            if candidate.startswith("https")
-                finalCandidates.push(candidate + ":8920" + path)
-            else if candidate.startswith("http")
-                finalCandidates.push(candidate + ":8096" + path)
+            if proto = "https"
+                finalCandidates.push(url.withPort("8920"))
+            else if proto = "http"
+                finalCandidates.push(url.withPort("8096"))
             end if
-        end for
-    end if
+        end if
+    end for
     return finalCandidates
 end function
 
@@ -456,14 +434,6 @@ function isValidAndNotEmpty(input as dynamic) as boolean
         print "Called isValidAndNotEmpty() with invalid type: ", inputType
         return false
     end if
-end function
-
-' Returns an array from a url = [ url, proto, host, port, subdir+params ]
-' If port or subdir are not found, an empty string will be added to the array
-' Proto must be declared or array will be empty
-function parseUrl(url as string) as object
-    rgx = CreateObject("roRegex", "^(.*:)//([A-Za-z0-9\-\.]+)(:[0-9]+)?(.*)$", "")
-    return rgx.Match(url)
 end function
 
 ' Returns true if the string is a loopback, such as 'localhost' or '127.0.0.1'

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -279,7 +279,7 @@ function urlCandidates(input as string)
             ' jellyfin defaults
             if isStringEqual(proto, "https")
                 finalCandidates.push(url.withPort("8920"))
-            else if proto = "http"
+            else if isStringEqual(proto, "http")
                 finalCandidates.push(url.withPort("8096"))
             end if
         end if

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -277,7 +277,7 @@ function urlCandidates(input as string)
         finalCandidates.push(url.withProto(proto))
         if not isValidAndNotEmpty(url.port) ' if the port isn't defined, use default jellyfin and proto ports
             ' jellyfin defaults
-            if proto = "https"
+            if isStringEqual(proto, "https")
                 finalCandidates.push(url.withPort("8920"))
             else if proto = "http"
                 finalCandidates.push(url.withPort("8096"))

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -229,7 +229,9 @@ function inferServerUrl(url as string) as string
         req.seturl(`${finalUrl}/system/info/public${endpoint.query = "" ? "" : `?${endpoint.query}`}`)
         req.setMessagePort(port)
         hosts.addreplace(req.getidentity().ToStr(), `${finalUrl}${endpoint.query = "" ? "" : `?${endpoint.query}`}`)
-        if endpoint.proto = "https" then req.setCertificatesFile("common:/certs/ca-bundle.crt")
+        if isStringEqual(endpoint.proto, "https")
+            req.setCertificatesFile("common:/certs/ca-bundle.crt")
+        end if
         req.AsyncGetToString()
     end for
     handled = 0

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -269,7 +269,7 @@ function urlCandidates(input as string)
     ' if the parsed url is invalid then the string is not a valid url
     if url = invalid then return []
     supportedProtos = ["http", "https"]
-    protoCandidates = isValid(url.proto) and url.proto <> "" ? [url.proto] : supportedProtos ' if no proto was declared, try all supported
+    protoCandidates = isValidAndNotEmpty(url.proto) ? [url.proto] : supportedProtos ' if no proto was declared, try all supported
     finalCandidates = []
     for each proto in protoCandidates:
         finalCandidates.push(url.withProto(proto))

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -273,7 +273,7 @@ function urlCandidates(input as string)
     finalCandidates = []
     for each proto in protoCandidates:
         finalCandidates.push(url.withProto(proto))
-        if isValid(url.port) = false or url.port = "" ' if the port isn't defined, use default jellyfin and proto ports
+        if not isValidAndNotEmpty(url.port) ' if the port isn't defined, use default jellyfin and proto ports
             ' jellyfin defaults
             if proto = "https"
                 finalCandidates.push(url.withPort("8920"))

--- a/source/utils/parsedUrl.bs
+++ b/source/utils/parsedUrl.bs
@@ -1,0 +1,70 @@
+'
+' Returns an object from a URL with its URI components as properties = { proto, host, port, path, query }
+' If any of those URI components are missing, they will be set as empty strings = ""
+' If the url param provided cannot be parsed, then invalid will be returned
+'
+' @param url a URL string which will be parsed into URI components
+function ParsedUrl(url as string) as object
+    rgx = CreateObject("roRegex", "^(?:(.*):\/\/)?([^\/:?]+)(?::(\d+))?(\/[^\r\n?]+)?(?:\?(.*))?$", "")
+    match = rgx.Match(url)
+    if match = invalid then return invalid
+
+    return {
+        proto: match[1] = invalid ? "" : match[1],
+        host: match[2] = invalid ? "" : match[2],
+        port: match[3] = invalid ? "" : match[3],
+        path: match[4] = invalid ? "" : match[4].endswith("/") ? match[4].left(len(match[4]) - 1) : match[4],
+        query: match[5] = invalid ? "" : match[5],
+        toString: __ParsedUrl_ToString,
+        withProto: __ParsedUrl_WithProto,
+        withHost: __ParsedUrl_WithHost,
+        withPort: __ParsedUrl_WithPort,
+        withPath: __ParsedUrl_WithPath,
+        withQuery: __ParsedUrl_WithQuery
+    }
+end function
+
+' Returns the parsed URL as a complete URL string
+function __ParsedUrl_ToString() as string
+    return `${m.proto = "" ? "" : `://${m.proto}`}${m.host}${m.port = "" ? "" : `:${m.port}`}${m.path}${m.query = "" ? "" : `?${m.query}`}`
+end function
+
+' Returns a copy of the parsed URL with the proto changed to the provided proto
+function __ParsedUrl_WithProto(proto as string) as object
+    newCopy = CreateObject("roUtils").DeepCopy(m)
+    newCopy.proto = proto
+    return newCopy
+end function
+
+' Returns a copy of the parsed URL with the host changed to the provided host
+function __ParsedUrl_WithHost(host as string) as object
+    newCopy = CreateObject("roUtils").DeepCopy(m)
+    newCopy.host = host
+    return newCopy
+end function
+
+' Returns a copy of the parsed URL with the port changed to the provided port
+function __ParsedUrl_WithPort(port as string) as object
+    newCopy = CreateObject("roUtils").DeepCopy(m)
+    newCopy.port = port.startsWith(":") ? port.right(len(port) - 1) : port
+    return newCopy
+end function
+
+' Returns a copy of the parsed URL with the provided path appended to the original path,
+' or with the path replaced by the provided path if replace = true
+function __ParsedUrl_WithPath(path as string, replace = false as boolean) as object
+    newCopy = CreateObject("roUtils").DeepCopy(m)
+    newCopy.path = `${replace ? "" : m.path}/${path.endsWith("/") ? path.left(len(path) - 1) : path}`
+    return newCopy
+end function
+
+' Returns a copy of the parsed URL with the provided query appended to the original query,
+' or with the query replaced by the provided query if replace = true
+function __ParsedUrl_WithQuery(query as string, replace = false as boolean) as object
+    newCopy = CreateObject("roUtils").DeepCopy(m)
+    newQuery = "?"
+    if replace = false and m.query <> "" then newQuery += `${m.query}&`
+    newQuery += query.startswith("?") ? query.right(len(query) - 1) : query
+    newCopy.query = newQuery
+    return newCopy
+end function

--- a/source/utils/parsedUrl.bs
+++ b/source/utils/parsedUrl.bs
@@ -63,7 +63,9 @@ end function
 function __ParsedUrl_WithQuery(query as string, replace = false as boolean) as object
     newCopy = CreateObject("roUtils").DeepCopy(m)
     newQuery = "?"
-    if replace = false and m.query <> "" then newQuery += `${m.query}&`
+    if not replace and isValidAndNotEmpty(m.query) 
+        newQuery += `${m.query}&`
+    end if
     newQuery += query.startswith("?") ? query.right(len(query) - 1) : query
     newCopy.query = newQuery
     return newCopy

--- a/source/utils/parsedUrl.bs
+++ b/source/utils/parsedUrl.bs
@@ -7,7 +7,7 @@
 function ParsedUrl(url as string) as object
     rgx = CreateObject("roRegex", "^(?:(.*):\/\/)?([^\/:?]+)(?::(\d+))?(\/[^\r\n?]+)?(?:\?(.*))?$", "")
     match = rgx.Match(url)
-    if match = invalid then return invalid
+    if not isValid(match) then return invalid
 
     return {
         proto: match[1] = invalid ? "" : match[1],

--- a/source/utils/parsedUrl.bs
+++ b/source/utils/parsedUrl.bs
@@ -10,11 +10,11 @@ function ParsedUrl(url as string) as object
     if not isValid(match) then return invalid
 
     return {
-        proto: match[1] = invalid ? "" : match[1],
-        host: match[2] = invalid ? "" : match[2],
-        port: match[3] = invalid ? "" : match[3],
-        path: match[4] = invalid ? "" : match[4].endswith("/") ? match[4].left(len(match[4]) - 1) : match[4],
-        query: match[5] = invalid ? "" : match[5],
+        proto: isValid(match[1]) ? match[1] : string.EMPTY,
+        host: isValid(match[2]) ? match[2] : string.EMPTY,
+        port: isValid(match[3]) ? match[3] : string.EMPTY,
+        path: isValid(match[4]) ? match[4].endswith("/") ? match[4].left(len(match[4]) - 1) : match[4] : string.EMPTY,
+        query: isValid(match[5]) ? match[5] : string.EMPTY,
         toString: __ParsedUrl_ToString,
         withProto: __ParsedUrl_WithProto,
         withHost: __ParsedUrl_WithHost,


### PR DESCRIPTION
I recently had an issue connecting my Roku device to my Jellyfin server as my server is setup to expect certain query string values in the URL. When I looked into the code, I found that this was due to the URL parsing logic during server selection not accounting for the presence of a query string and appending the API path to the end of the URL, making it invalid.

<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
 - update the logic in `misc.inferServerUrl`, `misc.urlCandidates` and `baserequest.buildURL` to properly handle query string values present in the given URL
 - fix an issue in `baserequest.buildURL` when certain functions include the query params in `path` rather than `params`
 - replace `misc.parseUrl` with new `ParsedUrl` function (defined in `parsedUrl.bs`), which returns an associative array of URI components parsed from the given URL and defines helper functions for manipulating it safely
<!-- Describe your changes here in 1-5 sentences. -->

## Issues
#601 
