### PR TITLE
add option to display "next-up" episode when finishing a tv-show episode

### DIFF
--- a/components/GetNextUpTask.bs
+++ b/components/GetNextUpTask.bs
@@ -1,0 +1,29 @@
+import "pkg:/source/utils/config.bs"
+import "pkg:/source/api/sdk.bs"
+
+sub init()
+    m.top.functionName = "getNextUpTask"
+end sub
+
+sub getNextUpTask()
+    if not isValid(m.top.showID) or m.top.showID = ""
+        m.top.nextUpData = invalid
+        return
+    end if
+
+    params = {
+        "seriesId": m.top.showID,
+        "recursive": true,
+        "SortBy": "DatePlayed",
+        "SortOrder": "Descending",
+        "ImageTypeLimit": 1,
+        "UserId": m.global.session.user.id,
+        "EnableRewatching": m.global.session.user.settings["ui.details.enablerewatchingnextup"],
+        "DisableFirstEpisode": false,
+        "limit": 1,
+        "EnableTotalRecordCount": false
+    }
+
+    m.top.nextUpData = api.shows.GetNextUp(params)
+end sub
+

--- a/components/GetNextUpTask.xml
+++ b/components/GetNextUpTask.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<component name="GetNextUpTask" extends="Task">
+    <interface>
+        <field id="showID" type="string" />
+        <field id="nextUpData" type="assocarray" />
+    </interface>
+</component>

--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -295,14 +295,20 @@ sub onNextUpDataLoaded()
 
     nextUpData = m.getNextUpTask.nextUpData
 
+    ' Check if video player is still the active scene (might have been popped by scene manager)
+    currentView = m.global.sceneManager.callFunc("getActiveScene")
+    videoPlayerStillActive = (isValid(currentView) and currentView.isSubType("VideoPlayerView"))
+
     ' If we found a next up episode, navigate to its details page
     if isValid(nextUpData) and isValidAndNotEmpty(nextUpData.Items) and nextUpData.Items.Count() > 0
         nextEpisode = nextUpData.Items[0]
         nextEpisodeId = nextEpisode.Id
         ' Only navigate if it's a different episode
         if nextEpisodeId <> m.currentEpisodeId
-            ' Pop the video player scene first
-            m.global.sceneManager.callFunc("popScene")
+            ' Pop the video player scene first (only if it's still active)
+            if videoPlayerStillActive
+                m.global.sceneManager.callFunc("popScene")
+            end if
             ' Trigger navigation through main event loop using jumpTo
             ' This ensures CreateMovieDetailsGroup is called from Main.bs context where m.port exists
             episodeNode = {
@@ -318,7 +324,10 @@ sub onNextUpDataLoaded()
     end if
 
     ' No next up episode found or it's the same episode, return to previous screen
-    m.global.sceneManager.callFunc("popScene")
+    ' Only pop if video player is still active (scene manager may have already popped it)
+    if videoPlayerStillActive
+        m.global.sceneManager.callFunc("popScene")
+    end if
     m.global.audioPlayer.loopMode = ""
     m.currentEpisodeId = invalid
 end sub
@@ -331,7 +340,10 @@ sub onStateChange()
         return
     end if
 
-    if LCase(m.view.state) = "finished"
+    currentState = LCase(m.view.state)
+
+    ' Handle "finished" state (always means playback completed)
+    if currentState = "finished"
         if isValid(m.view.returnOnStop)
             if m.view.returnOnStop then return
         end if
@@ -403,6 +415,35 @@ sub onStateChange()
         ' Playback completed, return user to previous screen
         m.global.sceneManager.callFunc("popScene")
         m.global.audioPlayer.loopMode = ""
+    else if currentState = "stopped" and isValid(m.view.content) and isValid(m.view.duration) and m.view.duration > 0
+        ' Handle "stopped" state only if playback has actually started
+        ' (to avoid triggering during player initialization)
+        ' For "stopped", handle next-up logic if enabled
+        ' Server determines completion status, so we check for next-up even when stopped
+        ' Note: Don't pop scene here - let scene manager handle it when back button bubbles up
+        ' onNextUpDataLoaded() will handle navigation if next episode is found
+        m.global.queueManager.callFunc("bypassNextPreferredAudioTrackIndexReset")
+        m.global.queueManager.callFunc("clear")
+
+        ' Check if setting is enabled to show next up episode after finish
+        showNextUpAfterFinish = m.global.session.user.settings["playback.showNextUpAfterFinish"]
+        if showNextUpAfterFinish = true
+            ' Check if this was an episode and we have a showID
+            if isValid(m.view.showID) and m.view.showID <> string.EMPTY
+                ' Check if content type is episode (4 = Episode)
+                if isValid(m.view.content) and isValid(m.view.content.contenttype) and m.view.content.contenttype = 4
+                    ' Store current episode ID for comparison when task completes
+                    m.currentEpisodeId = m.view.id
+                    ' Start async task to get next up episode
+                    m.getNextUpTask.showID = m.view.showID
+                    m.getNextUpTask.control = TaskControl.RUN
+                    ' Don't pop scene - scene manager will pop when back button bubbles up
+                    ' onNextUpDataLoaded() will handle navigation if next episode found
+                    return
+                end if
+            end if
+        end if
+        ' If no next-up logic needed, let scene manager handle the pop normally
     end if
 end sub
 

--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -1,8 +1,11 @@
+import "pkg:/source/api/sdk.bs"
+import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/enums/MediaPlaybackState.bs"
-import "pkg:/source/enums/TaskControl.bs"
 import "pkg:/source/enums/SubtitleSelection.bs"
+import "pkg:/source/enums/TaskControl.bs"
 import "pkg:/source/enums/TimerControl.bs"
 import "pkg:/source/enums/VideoControl.bs"
+import "pkg:/source/ShowScenes.bs"
 
 const STILL_WATCHING_POPUP_TIMER_SECONDS = 60
 
@@ -73,6 +76,10 @@ sub CreateVideoPlayerView()
     m.getPlaybackInfoTask = createObject("roSGNode", "GetPlaybackInfoTask")
     m.getPlaybackInfoTask.videoID = mediaSourceId
     m.getPlaybackInfoTask.observeField("data", "onPlaybackInfoLoaded")
+
+    ' Create task for getting next up episode after playback finishes
+    m.getNextUpTask = createObject("roSGNode", "GetNextUpTask")
+    m.getNextUpTask.observeField("nextUpData", "onNextUpDataLoaded")
 
     m.global.sceneManager.callFunc("pushScene", m.view)
 end sub
@@ -282,6 +289,40 @@ sub onPlaybackInfoLoaded()
     end if
 end sub
 
+' The next up task has returned data
+sub onNextUpDataLoaded()
+    m.getNextUpTask.unobserveField("nextUpData")
+
+    nextUpData = m.getNextUpTask.nextUpData
+
+    ' If we found a next up episode, navigate to its details page
+    if isValid(nextUpData) and isValidAndNotEmpty(nextUpData.Items) and nextUpData.Items.Count() > 0
+        nextEpisode = nextUpData.Items[0]
+        nextEpisodeId = nextEpisode.Id
+        ' Only navigate if it's a different episode
+        if nextEpisodeId <> m.currentEpisodeId
+            ' Pop the video player scene first
+            m.global.sceneManager.callFunc("popScene")
+            ' Trigger navigation through main event loop using jumpTo
+            ' This ensures CreateMovieDetailsGroup is called from Main.bs context where m.port exists
+            episodeNode = {
+                selectiontype: "episode",
+                id: nextEpisodeId,
+                title: nextEpisode.Name
+            }
+            m.global.jumpTo = episodeNode
+            m.global.audioPlayer.loopMode = ""
+            m.currentEpisodeId = invalid
+            return
+        end if
+    end if
+
+    ' No next up episode found or it's the same episode, return to previous screen
+    m.global.sceneManager.callFunc("popScene")
+    m.global.audioPlayer.loopMode = ""
+    m.currentEpisodeId = invalid
+end sub
+
 ' Playback state change event handlers
 sub onStateChange()
     ' If the state changed due to an error, we don't want to continue the queue
@@ -340,6 +381,24 @@ sub onStateChange()
 
         m.global.queueManager.callFunc("bypassNextPreferredAudioTrackIndexReset")
         m.global.queueManager.callFunc("clear")
+
+        ' Check if setting is enabled to show next up episode after finish
+        showNextUpAfterFinish = m.global.session.user.settings["playback.showNextUpAfterFinish"]
+        if showNextUpAfterFinish = true
+            ' Check if this was an episode and we have a showID
+            if isValid(m.view.showID) and m.view.showID <> string.EMPTY
+                ' Check if content type is episode (4 = Episode)
+                if isValid(m.view.content) and isValid(m.view.content.contenttype) and m.view.content.contenttype = 4
+                    ' Store current episode ID for comparison when task completes
+                    m.currentEpisodeId = m.view.id
+                    ' Start async task to get next up episode
+                    m.getNextUpTask.showID = m.view.showID
+                    m.getNextUpTask.control = TaskControl.RUN
+                    ' Don't pop scene yet - wait for task to complete
+                    return
+                end if
+            end if
+        end if
 
         ' Playback completed, return user to previous screen
         m.global.sceneManager.callFunc("popScene")

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1210,6 +1210,16 @@
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
         <message>
+            <source>Show Next Up After Finish</source>
+            <translation>Show Next Up After Finish</translation>
+            <extracomment>Settings Menu - Title for option</extracomment>
+        </message>
+        <message>
+            <source>Display the next up episode's details page after an episode finishes playing. If no next up episode is found, return to the just-played episode's page.</source>
+            <translation>Display the next up episode's details page after an episode finishes playing. If no next up episode is found, return to the just-played episode's page.</translation>
+            <extracomment>Settings Menu - Description for option</extracomment>
+        </message>
+        <message>
             <source>Preferred Audio Codec</source>
             <translation>Preferred Audio Codec</translation>
             <extracomment>Settings Menu - Title of option</extracomment>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -320,6 +320,13 @@
         "default": "30"
       },
       {
+        "title": "Show Next Up After Finish",
+        "description": "Display the next up episode's details page after an episode finishes playing. If no next up episode is found, return to the just-played episode's page.",
+        "settingName": "playback.showNextUpAfterFinish",
+        "type": "bool",
+        "default": "false"
+      },
+      {
         "title": "Preferred Audio Codec",
         "description": "Use the selected audio codec for transcodes. If the device or stream does not support it, a fallback codec will be used.",
         "settingName": "playback.preferredAudioCodec",

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -206,6 +206,20 @@ sub onJumpToEvent(msg)
             stopLoadingSpinner()
         end if
     end if
+
+    if isStringEqual(jumpToData.selectiontype, "episode")
+        ' If current scene is also a MovieDetails scene, remove it from stack
+        ' This prevents having two episode detail pages in the stack
+        ' After popping the video player, the old episode detail page is now the current scene
+        ' We need to remove it before pushing the new episode detail page
+        if isValid(currentView) and currentView.isSubType("MovieDetails")
+            ' Pop the current scene (old episode detail) to remove it from the stack
+            ' This will restore whatever was before it, or exit if stack is empty
+            m.global.sceneManager.callFunc("popScene")
+        end if
+        startLoadingSpinner()
+        CreateMovieDetailsGroup(jumpToData)
+    end if
 end sub
 
 sub onDeepLinkingEvent(args)

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -1,3 +1,4 @@
+import "pkg:/source/enums/ColorPalette.bs"
 import "pkg:/source/enums/ImageType.bs"
 import "pkg:/source/utils/misc.bs"
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
New field in playback  settings to change the screen after finishing a TV show episode. Default is disabled, but when enabled the episode info screen for the "next-up" episode is shown (based on watched status returned by server). This makes it easy to binge episodes at your own pace without needing to enable auto-play server-wide. If no next-up episode is found for the show, it shows the normal screen for the episode just watched.

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes https://github.com/jellyfin/jellyfin-roku/issues/356
