### PR TITLE
Remember if user unchecks Save Credentials on login screen

### DIFF
--- a/components/config/SigninScene.bs
+++ b/components/config/SigninScene.bs
@@ -72,6 +72,10 @@ sub init()
     saveCredentials.font.size = 30
     saveCredentials.focusedFont.size = 30
 
+    if not isStringEqual(get_setting("saveCredentials", "true"), "true")
+        saveCredentials.checkedState = "[false]"
+    end if
+
     items = [username_field, password_field]
     m.config.configItems = items
 

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -559,6 +559,8 @@ function CreateSigninGroup(user = "", profileImageUri = "")
                 ' Validate credentials
                 activeUser = get_token(username.value, password.value)
                 if isValid(activeUser)
+                    set_setting("saveCredentials", saveCredentials.checkedState[0].toStr())
+
                     if saveCredentials.checkedState[0] = true
                         ' save credentials
                         session.user.Login(activeUser, true)

--- a/source/static/whatsNew/3.0.14.json
+++ b/source/static/whatsNew/3.0.14.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "",
-    "author": ""
+    "description": "Remember if user unchecks Save Credentials on login screen",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
If user unchecks the Save Credentials checkbox on the login screen, the next time the login screen is shown, the Save Credentials checkbox will remain unchecked.

The default state remains checked until the user unchecks it, then the default state is changed to unchecked.

## Issues
Fixes #609
