### PR TITLE
Create library image orientation setting

### DIFF
--- a/components/ItemGrid/GridItemSmall.bs
+++ b/components/ItemGrid/GridItemSmall.bs
@@ -1,3 +1,5 @@
+import "pkg:/source/enums/ImageLayout.bs"
+import "pkg:/source/enums/PosterLoadStatus.bs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/misc.bs"
 
@@ -78,7 +80,8 @@ sub itemContentChanged()
         unplayedCount: chainLookupReturn(itemData, "json.UserData.UnplayedItemCount", 0)
     }
 
-    m.itemPoster.uri = itemData.PosterUrl
+    m.itemPoster.uri = getPosterURL(itemData)
+
     if isValidAndNotEmpty(itemData.LookupCI("fullNameWithShowTitle"))
         m.posterText.text = itemData.LookupCI("fullNameWithShowTitle")
     else
@@ -93,6 +96,28 @@ sub itemContentChanged()
         m.posterText.visible = true
     end if
 end sub
+
+function getPosterURL(itemData) as string
+    posterURL = itemData.PosterUrl
+
+    posterOrientation = chainLookupReturn(m.global, "session.user.settings.libraryPosterOrientation", ImageLayout.DEFAULT)
+    if inArray([ImageLayout.DEFAULT, ImageLayout.PORTRAIT], posterOrientation)
+        posterURL = itemData.PosterUrl
+    else if isValidAndNotEmpty(itemData.landscapePosterURL)
+        posterURL = itemData.landscapePosterURL
+    else if isValidAndNotEmpty(itemData.backdropURL)
+        posterURL = itemData.backdropURL
+    end if
+
+    ' Adjust image dimensions as needed
+    posterURL = posterURL.replace("maxHeight=720", `maxHeight=${m.itemPoster.height}`)
+    posterURL = posterURL.replace("maxHeight=331", `maxHeight=${m.itemPoster.height}`)
+
+    posterURL = posterURL.replace("maxWidth=1280", `maxWidth=${m.itemPoster.width}`)
+    posterURL = posterURL.replace("maxWidth=464", `maxWidth=${m.itemPoster.width}`)
+
+    return posterURL
+end function
 
 sub focusChanged()
     if m.top.itemHasFocus = true
@@ -110,7 +135,19 @@ end sub
 
 'Hide backdrop and text when poster loaded
 sub onPosterLoadStatusChanged()
-    if m.itemPoster.loadStatus = "ready"
+    if isStringEqual(m.itemPoster.loadStatus, PosterLoadStatus.FAILED)
+        ' Image failed to load, try to fall back to default poster image
+        if not isStringEqual(m.itemPoster.uri, m.top.itemContent.PosterUrl)
+            m.itemPoster.uri = m.top.itemContent.PosterUrl
+            return
+        end if
+
+        ' No image loaded, ensure text is displayed
+        m.backdrop.visible = true
+        m.posterText.visible = true
+    end if
+
+    if isStringEqual(m.itemPoster.loadStatus, PosterLoadStatus.READY)
         m.backdrop.visible = false
         m.posterText.visible = false
     end if

--- a/components/Libraries/OtherLibrary.bs
+++ b/components/Libraries/OtherLibrary.bs
@@ -14,9 +14,9 @@ import "pkg:/source/utils/deviceCapabilities.bs"
 import "pkg:/source/utils/misc.bs"
 
 const ASPECT_RATIO_PORTRAIT_NO_TITLE = 1.52173
-const ASPECT_RATIO_LANDSCAPE_NO_TITLE = .825
+const ASPECT_RATIO_LANDSCAPE_NO_TITLE = .56307
 const ASPECT_RATIO_PORTRAIT_WITH_TITLE = 1.69565
-const ASPECT_RATIO_LANDSCAPE_WITH_TITLE = .925
+const ASPECT_RATIO_LANDSCAPE_WITH_TITLE = .66307
 
 sub init()
     m.top.imageDisplayMode = "scaleToZoom"
@@ -77,7 +77,13 @@ sub init()
     m.getFiltersTask = createObject("roSGNode", "GetFiltersTask")
     m.getPlaylistDataTask = createObject("roSGNode", "GetPlaylistDataTask")
 
-    setColumnSizes(ImageLayout.PORTRAIT)
+    posterOrientation = chainLookupReturn(m.global, "session.user.settings.libraryPosterOrientation", ImageLayout.DEFAULT)
+
+    if isStringEqual(posterOrientation, ImageLayout.DEFAULT)
+        setColumnSizes(ImageLayout.PORTRAIT)
+    else
+        setColumnSizes(posterOrientation)
+    end if
 
     'set inital counts for overhang before content is loaded.
     m.loadItemsTask.totalRecordCount = 0

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -15,9 +15,9 @@ import "pkg:/source/utils/deviceCapabilities.bs"
 import "pkg:/source/utils/misc.bs"
 
 const ASPECT_RATIO_PORTRAIT_NO_TITLE = 1.52173
-const ASPECT_RATIO_LANDSCAPE_NO_TITLE = .825
+const ASPECT_RATIO_LANDSCAPE_NO_TITLE = .56307
 const ASPECT_RATIO_PORTRAIT_WITH_TITLE = 1.69565
-const ASPECT_RATIO_LANDSCAPE_WITH_TITLE = .925
+const ASPECT_RATIO_LANDSCAPE_WITH_TITLE = .66307
 
 sub setupNodes()
     m.top.imageDisplayMode = "scaleToZoom"
@@ -556,12 +556,18 @@ sub loadInitialItems()
         end if
     end if
 
-    if inArray([ItemType.PHOTO, ItemType.PHOTOALBUM, ItemType.MUSICVIDEO, ItemType.MYLIST], m.top.mediaType)
-        setColumnSizes(ImageLayout.LANDSCAPE)
-    else if isStringEqual(m.view, "Episodes")
-        setColumnSizes(ImageLayout.LANDSCAPE)
+    posterOrientation = chainLookupReturn(m.global, "session.user.settings.libraryPosterOrientation", ImageLayout.DEFAULT)
+
+    if isStringEqual(posterOrientation, ImageLayout.DEFAULT)
+        if inArray([ItemType.PHOTO, ItemType.PHOTOALBUM, ItemType.MUSICVIDEO, ItemType.MYLIST], m.top.mediaType)
+            setColumnSizes(ImageLayout.LANDSCAPE)
+        else if isStringEqual(m.view, "Episodes")
+            setColumnSizes(ImageLayout.LANDSCAPE)
+        else
+            setColumnSizes(ImageLayout.PORTRAIT)
+        end if
     else
-        setColumnSizes(ImageLayout.PORTRAIT)
+        setColumnSizes(posterOrientation)
     end if
 
     m.loadItemsTask.observeField("content", "ItemDataLoaded")
@@ -583,7 +589,7 @@ sub setColumnSizes(layout = ImageLayout.PORTRAIT as string)
         imageWidthData = val(chainLookupReturn(m.global.session, "user.settings.numberOfColumnsPortraitData", "230"))
     else
         numberOfColumns = chainLookupReturn(m.global.session, "user.settings.numberOfColumnsLandscape", "4")
-        imageWidthData = val(chainLookupReturn(m.global.session, "user.settings.numberOfColumnsLandscapeData", "400"))
+        imageWidthData = val(chainLookupReturn(m.global.session, "user.settings.numberOfColumnsLandscapeData", "418"))
     end if
 
     if isStringEqual(m.top.showItemTitles, "hidealways")

--- a/components/data/JFContentItem.xml
+++ b/components/data/JFContentItem.xml
@@ -4,6 +4,7 @@
         <field id="favorite" type="boolean" />
         <field id="watched" type="boolean" />
         <field id="posterUrl" type="string" />
+        <field id="landscapePosterURL" type="string" />
         <field id="backdropUrl" type="string" />
         <field id="SubTitle" type="string" value="" />
         <field id="iconUrl" type="string" value="" />

--- a/components/data/MovieData.bs
+++ b/components/data/MovieData.bs
@@ -70,6 +70,11 @@ sub setPoster()
                 m.top.posterURL = ImageURL(m.top.json.ParentThumbItemId, "Thumb", imgParams)
             end if
 
+            if isChainValid(m.top.json, "ImageTags.Thumb")
+                imgParams = { "maxHeight": 331, "maxWidth": 464, "Tag": chainLookup(m.top.json, "ImageTags.Thumb") }
+                m.top.landscapePosterURL = ImageURL(m.top.json.id, "Thumb", imgParams)
+            end if
+
             ' Add Backdrop Image
             if isValid(m.top.json.BackdropImageTags) and isValid(m.top.json.BackdropImageTags[0])
                 imgParams = { "maxHeight": 720, "maxWidth": 1280, "Tag": m.top.json.BackdropImageTags[0] }

--- a/components/data/SeriesData.bs
+++ b/components/data/SeriesData.bs
@@ -68,6 +68,11 @@ sub setPoster()
             m.top.posterURL = ImageURL(m.top.json.id, "Backdrop", imgParams)
         end if
 
+        if isChainValid(m.top.json, "ImageTags.Thumb")
+            imgParams = { "maxHeight": 331, "maxWidth": 464, "Tag": chainLookup(m.top.json, "ImageTags.Thumb") }
+            m.top.landscapePosterURL = ImageURL(m.top.json.id, "Thumb", imgParams)
+        end if
+
         ' Add Backdrop Image
         if m.top.json.BackdropImageTags <> invalid
             imgParams = { "maxHeight": 720, "maxWidth": 1280, "Tag": m.top.json.BackdropImageTags[0] }

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1036,13 +1036,13 @@
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
         <message>
-            <source>Item Titles</source>
-            <translation>Item Titles</translation>
+            <source>Grid View Item Titles</source>
+            <translation>Grid View Item Titles</translation>
             <extracomment>Title of a setting - when should we show the title text of a grid item</extracomment>
         </message>
         <message>
-            <source>Select when to show titles.</source>
-            <translation>Select when to show titles.</translation>
+            <source>Select when to show titles in grid view.</source>
+            <translation>Select when to show titles in grid view.</translation>
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
         <message>
@@ -1521,11 +1521,6 @@
         <message>
             <source>Settings relating to the appearance of Library pages.</source>
             <translation>Settings relating to the appearance of Library pages.</translation>
-            <extracomment>Libraries Setting - Setting description</extracomment>
-        </message>
-        <message>
-            <source>Settings relating to the appearance of pages in all Libraries.</source>
-            <translation>Settings relating to the appearance of pages in all Libraries.</translation>
             <extracomment>Libraries Setting - Setting description</extracomment>
         </message>
         <message>
@@ -2209,6 +2204,26 @@
             <source>Burn in all subtitles when transcoding is triggered. This ensures subtitle synchronization after transcoding at the cost of reduced transcoding speed.</source>
             <translation>Burn in all subtitles when transcoding is triggered. This ensures subtitle synchronization after transcoding at the cost of reduced transcoding speed.</translation>
             <extracomment>Settings Menu - Description for option</extracomment>
+        </message>
+        <message>
+            <source>Library Image Orientation</source>
+            <translation>Library Image Orientation</translation>
+        </message>
+        <message>
+            <source>Select the poster image orientation for the library views.</source>
+            <translation>Select the poster image orientation for the library views.</translation>
+        </message>
+        <message>
+            <source>Default (Varies By Media Type)</source>
+            <translation>Default (Varies By Media Type)</translation>
+        </message>
+        <message>
+            <source>Landscape (Wide)</source>
+            <translation>Landscape (Wide)</translation>
+        </message>
+        <message>
+            <source>Portrait (Vertical)</source>
+            <translation>Portrait (Vertical)</translation>
         </message>
     </context>
 </TS>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1071,141 +1071,150 @@
         "description": "Settings relating to the appearance of Library pages.",
         "children": [
           {
-            "title": "General",
-            "description": "Settings relating to the appearance of pages in all Libraries.",
-            "children": [
+            "title": "Forget Filters",
+            "description": "Forget applied library filters when Jellyfin is closed.",
+            "settingName": "itemgrid.forgetFilters",
+            "type": "bool",
+            "default": "true"
+          },
+          {
+            "title": "Grid View Item Titles",
+            "description": "Select when to show titles in grid view.",
+            "settingName": "itemgrid.gridTitles",
+            "type": "radio",
+            "default": "showonhover",
+            "options": [
               {
-                "title": "Forget Filters",
-                "description": "Forget applied library filters when Jellyfin is closed.",
-                "settingName": "itemgrid.forgetFilters",
-                "type": "bool",
-                "default": "true"
+                "title": "Show On Hover",
+                "id": "showonhover"
               },
               {
-                "title": "Grid View Settings",
-                "description": "Settings that apply when Grid views are enabled.",
-                "children": [
-                  {
-                    "title": "Item Titles",
-                    "description": "Select when to show titles.",
-                    "settingName": "itemgrid.gridTitles",
-                    "type": "radio",
-                    "default": "showonhover",
-                    "options": [
-                      {
-                        "title": "Show On Hover",
-                        "id": "showonhover"
-                      },
-                      {
-                        "title": "Always Show",
-                        "id": "showalways"
-                      },
-                      {
-                        "title": "Always Hide",
-                        "id": "hidealways"
-                      }
-                    ]
-                  }
-                ]
+                "title": "Always Show",
+                "id": "showalways"
               },
               {
-                "title": "Library Landscape Column Count",
-                "description": "Number of columns in library view when showing landscape (wide) images",
-                "settingName": "numberOfColumnsLandscape",
-                "type": "slider",
-                "default": "4",
-                "options": [
-                  {
-                    "value": "3",
-                    "data": "550"
-                  },
-                  {
-                    "value": "4",
-                    "data": "400"
-                  },
-                  {
-                    "value": "5",
-                    "data": "313"
-                  },
-                  {
-                    "value": "6",
-                    "data": "255"
-                  },
-                  {
-                    "value": "7",
-                    "data": "212"
-                  },
-                  {
-                    "value": "8",
-                    "data": "181"
-                  }
-                ]
+                "title": "Always Hide",
+                "id": "hidealways"
+              }
+            ]
+          },
+          {
+            "title": "Library Image Orientation",
+            "description": "Select the poster image orientation for the library views.",
+            "settingName": "libraryPosterOrientation",
+            "type": "radio",
+            "default": "default",
+            "options": [
+              {
+                    "title": "Default (Varies By Media Type)",
+                    "id": "default"
               },
               {
-                "title": "Library Portrait Column Count",
-                "description": "Number of columns in library view when showing portrait (tall) images",
-                "settingName": "numberOfColumnsPortrait",
-                "type": "slider",
-                "default": "7",
-                "options": [
-                  {
-                    "value": "6",
-                    "data": "272"
-                  },
-                  {
-                    "value": "7",
-                    "data": "230"
-                  },
-                  {
-                    "value": "8",
-                    "data": "198"
-                  },
-                  {
-                    "value": "9",
-                    "data": "175"
-                  },
-                  {
-                    "value": "10",
-                    "data": "154"
-                  },
-                  {
-                    "value": "11",
-                    "data": "139"
-                  }
-                ]
+                    "title": "Landscape (Wide)",
+                    "id": "landscape"
               },
               {
-                "title": "Library Square Column Count",
-                "description": "Number of columns in library view when showing square images",
-                "settingName": "numberOfColumnsSquare",
-                "type": "slider",
-                "default": "6",
-                "options": [
-                  {
-                    "value": "5",
-                    "data": "330"
-                  },
-                  {
-                    "value": "6",
-                    "data": "272"
-                  },
-                  {
-                    "value": "7",
-                    "data": "230"
-                  },
-                  {
-                    "value": "8",
-                    "data": "198"
-                  },
-                  {
-                    "value": "9",
-                    "data": "175"
-                  },
-                  {
-                    "value": "10",
-                    "data": "154"
-                  }
-                ]
+                    "title": "Portrait (Vertical)",
+                    "id": "portrait"
+              }
+            ]
+          },
+          {
+            "title": "Library Landscape Column Count",
+            "description": "Number of columns in library view when showing landscape (wide) images",
+            "settingName": "numberOfColumnsLandscape",
+            "type": "slider",
+            "default": "4",
+            "options": [
+              {
+                "value": "3",
+                "data": "565"
+              },
+              {
+                "value": "4",
+                "data": "418"
+              },
+              {
+                "value": "5",
+                "data": "330"
+              },
+              {
+                "value": "6",
+                "data": "272"
+              },
+              {
+                "value": "7",
+                "data": "230"
+              },
+              {
+                "value": "8",
+                "data": "199"
+              }
+            ]
+          },
+          {
+            "title": "Library Portrait Column Count",
+            "description": "Number of columns in library view when showing portrait (tall) images",
+            "settingName": "numberOfColumnsPortrait",
+            "type": "slider",
+            "default": "7",
+            "options": [
+              {
+                "value": "6",
+                "data": "272"
+              },
+              {
+                "value": "7",
+                "data": "230"
+              },
+              {
+                "value": "8",
+                "data": "198"
+              },
+              {
+                "value": "9",
+                "data": "175"
+              },
+              {
+                "value": "10",
+                "data": "154"
+              },
+              {
+                "value": "11",
+                "data": "139"
+              }
+            ]
+          },
+          {
+            "title": "Library Square Column Count",
+            "description": "Number of columns in library view when showing square images",
+            "settingName": "numberOfColumnsSquare",
+            "type": "slider",
+            "default": "6",
+            "options": [
+              {
+                "value": "5",
+                "data": "330"
+              },
+              {
+                "value": "6",
+                "data": "272"
+              },
+              {
+                "value": "7",
+                "data": "230"
+              },
+              {
+                "value": "8",
+                "data": "198"
+              },
+              {
+                "value": "9",
+                "data": "175"
+              },
+              {
+                "value": "10",
+                "data": "154"
               }
             ]
           },

--- a/source/enums/ImageLayout.bs
+++ b/source/enums/ImageLayout.bs
@@ -1,4 +1,5 @@
 enum ImageLayout
+    DEFAULT = "default"
     LANDSCAPE = "landscape"
     PORTRAIT = "portrait"
 end enum


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Creates a new user setting allowing users to select the image orientation to use:
- - Default
- - Landscape
- - Portrait
- Moves User Interface / Libraries / General settings up 1 level
- Moves Grid View Item Titles to Libraries level
- Updates library pages to use new orientation setting 
- - Adjusts item sizes accordingly
- Updates GridItemSmall component to load poster image based on orientation.
- - If portrait, no change
- - If landscape, try loading thumb. If fails, try loading backdrop. If fails, fallback to portrait.

## Screenshots
### Before
![WIN_20251220_11_18_03_Pro](https://github.com/user-attachments/assets/6125a1b0-cf90-4807-9fee-fc31c89cb16f)

### After
![WIN_20251220_11_18_42_Pro](https://github.com/user-attachments/assets/e3bafb4b-3c8c-4f0e-9802-2ad4c4a36042)

### Next Steps
Once this PR is merged, I will add a library-level setting, allowing users to customize the image orientation library-by-library if they desire.

