### PR TITLE
Try loading fallback images for tv series

### DIFF
--- a/components/tvshows/TVShowDetails.bs
+++ b/components/tvshows/TVShowDetails.bs
@@ -1,3 +1,4 @@
+import "pkg:/source/enums/PosterLoadStatus.bs"
 import "pkg:/source/enums/ViewLoadStatus.bs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/misc.bs"
@@ -13,9 +14,26 @@ sub init()
     m.seasons = m.top.findNode("seasons")
     m.overview = m.top.findNode("overview")
     m.playedIndicator = m.top.findNode("playedIndicator")
+    m.tvshowPoster = m.top.findNode("tvshowPoster")
 
     m.overview.ellipsisText = tr("... (Press * to read more)")
     m.loadStatus = ViewLoadStatus.INIT
+end sub
+
+sub onPosterLoadStatusChanged()
+    if isStringEqual(m.tvshowPoster.loadStatus, PosterLoadStatus.FAILED)
+        tryLoadingSeasonPoster()
+        m.tvshowPoster.unobserveFieldScoped("loadStatus")
+    end if
+end sub
+
+sub tryLoadingSeasonPoster()
+    for each season in m.seasons.TVSeasonData.Items
+        if isValidAndNotEmpty(season.posterURL)
+            m.tvshowPoster.uri = season.posterURL
+            exit for
+        end if
+    end for
 end sub
 
 sub itemContentChanged()
@@ -23,7 +41,9 @@ sub itemContentChanged()
     item = m.top.itemContent
     itemData = item.json
 
-    m.top.findNode("tvshowPoster").uri = m.top.itemContent.posterURL
+    ' Post image may change. We need to again watch load status
+    m.tvshowPoster.observeFieldscoped("loadStatus", "onPosterLoadStatusChanged")
+    m.tvshowPoster.uri = m.top.itemContent.posterURL
 
     m.playedIndicator.data = {
         played: chainLookupReturn(item, "json.UserData.Played", false),

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -596,13 +596,26 @@ function TVSeasons(id as string) as dynamic
 
     results = []
     for each item in data.Items
+        seasonImage = PosterImage(item.id)
+        if not isValidAndNotEmpty(seasonImage)
+            seasonImage = getFirstEpisodeImage(id, item.id)
+        end if
+
         tmp = CreateObject("roSGNode", "TVSeasonData")
-        tmp.image = PosterImage(item.id)
+        tmp.image = seasonImage
         tmp.json = item
         results.push(tmp)
     end for
     data.Items = results
     return data
+end function
+
+function getFirstEpisodeImage(showId as string, seasonId as string)
+    listOfEpisodes = TVEpisodes(showId, seasonId)
+    for each episode in listOfEpisodes.LookupCI("items")
+        if isValid(episode.image) then return episode.image
+    end for
+    return invalid
 end function
 
 ' Returns a list of TV Shows for a given TV Show and season

--- a/source/static/whatsNew/3.1.0.json
+++ b/source/static/whatsNew/3.1.0.json
@@ -1,6 +1,10 @@
 [
   {
-    "description": "",
-    "author": ""
+    "description": "Use 1st found episode image as season poster on TV series screen when no image available",
+    "author": "1hitsong"
+  },
+  {
+    "description": "Use 1st found season image as series poster on TV series screen when no image available",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- On TV Series screen, if a season has no poster image available, loop through episodes and use 1st found episode image
- On TV Series screen, if no poster image is available, loop through seasons and use 1st found season image

## Issues
Starts work on #360. There will be followup PRs to bring this fallback logic to other screens.

## Screenshots
Before:
![WIN_20251222_16_25_33_Pro](https://github.com/user-attachments/assets/eb615339-f8ba-4814-af5e-a8d0233863e1)

After:
![WIN_20251222_16_24_38_Pro](https://github.com/user-attachments/assets/8abe98c2-2c74-4677-98f8-b43a39e8f3d9)
