### PR TITLE
Allow translation of skip segment buttons

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -769,7 +769,7 @@ sub displaySegmentSkipButton(segmentType as string, endticks as double)
     end if
 
     ' Check if button is already showing
-    if isStringEqual(m.skipSegmentButton.text, `${tr("Skip")} ${segmentType}`) then return
+    if isStringEqual(m.skipSegmentButton.text, tr(`Skip ${segmentType}`)) then return
 
     if m.osd.visible then return ' Don't show if OSD is visible
 
@@ -779,7 +779,7 @@ sub displaySegmentSkipButton(segmentType as string, endticks as double)
     end if
 
     m.skipSegmentButton.visible = true
-    m.skipSegmentButton.text = `${tr("Skip")} ${segmentType}`
+    m.skipSegmentButton.text = tr(`Skip ${segmentType}`)
     m.skipSegmentButton.setFocus(true)
     m.skipSegmentButton.focus = true
 end sub
@@ -1322,7 +1322,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
     if key = KeyCode.BACK
         ' If user presses back when Skip Outro button is showing, hide button and disable it so it doesn't show again
         if m.skipSegmentButton.visible
-            if isStringEqual(m.skipSegmentButton.text, `${tr("Skip")} ${MediaSegmentType.OUTRO}`)
+            if isStringEqual(m.skipSegmentButton.text, tr(`Skip ${MediaSegmentType.OUTRO}`))
                 m.nextupbuttonseconds = 0
                 hideSegmentSkipButton()
                 return true

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2210,5 +2210,29 @@
             <translation>Burn in all subtitles when transcoding is triggered. This ensures subtitle synchronization after transcoding at the cost of reduced transcoding speed.</translation>
             <extracomment>Settings Menu - Description for option</extracomment>
         </message>
+        <message>
+            <source>Skip Unknown</source>
+            <translation>Skip Segment</translation>
+        </message>
+        <message>
+            <source>Skip Commercial</source>
+            <translation>Skip Commercial</translation>
+        </message>
+        <message>
+            <source>Skip Preview</source>
+            <translation>Skip Preview</translation>
+        </message>
+        <message>
+            <source>Skip Recap</source>
+            <translation>Skip Recap</translation>
+        </message>
+        <message>
+            <source>Skip Outro</source>
+            <translation>Skip Outro</translation>
+        </message>
+        <message>
+            <source>Skip Intro</source>
+            <translation>Skip Intro</translation>
+        </message>
     </context>
 </TS>

--- a/source/static/whatsNew/3.1.0.json
+++ b/source/static/whatsNew/3.1.0.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "",
-    "author": ""
+    "description": "Allow translation of skip media segment buttons",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Changes how text is placed in the skip media segment button so the full text can be translated as one.

## Issues
Fixes #564
