### PR TITLE
Create library image orientation setting

### DIFF
--- a/components/ItemGrid/GridItemSmall.bs
+++ b/components/ItemGrid/GridItemSmall.bs
@@ -100,7 +100,14 @@ end sub
 function getPosterURL(itemData) as string
     posterURL = itemData.PosterUrl
 
-    posterOrientation = chainLookupReturn(m.global, "session.user.settings.libraryPosterOrientation", ImageLayout.DEFAULT)
+    ' If use has not set a library level setting, check the user level setting
+    if isChainValid(m.global.session, `user.settings.${itemData.json.passedData.libraryID}-useLandscapeImages`)
+        useLandscapeImages = chainLookupReturn(m.global.session, `user.settings.${itemData.json.passedData.libraryID}-useLandscapeImages`, false)
+        posterOrientation = useLandscapeImages ? ImageLayout.LANDSCAPE : ImageLayout.DEFAULT
+    else
+        posterOrientation = chainLookupReturn(m.global, "session.user.settings.libraryPosterOrientation", ImageLayout.DEFAULT)
+    end if
+
     if inArray([ImageLayout.DEFAULT, ImageLayout.PORTRAIT], posterOrientation)
         posterURL = itemData.PosterUrl
     else if isValidAndNotEmpty(itemData.landscapePosterURL)

--- a/components/ItemGrid/GridItemSmall.bs
+++ b/components/ItemGrid/GridItemSmall.bs
@@ -100,7 +100,7 @@ end sub
 function getPosterURL(itemData) as string
     posterURL = itemData.PosterUrl
 
-    ' If use has not set a library level setting, check the user level setting
+    ' If user has not set a library level setting, check the user level setting
     if isChainValid(m.global.session, `user.settings.${itemData.json.passedData.libraryID}-useLandscapeImages`)
         useLandscapeImages = chainLookupReturn(m.global.session, `user.settings.${itemData.json.passedData.libraryID}-useLandscapeImages`, false)
         posterOrientation = useLandscapeImages ? ImageLayout.LANDSCAPE : ImageLayout.DEFAULT

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -249,6 +249,26 @@ sub onItemDataLoaded()
 end sub
 
 sub redrawItems()
+    ' If use has not set a library level setting, check the user level setting
+    if isChainValid(m.global.session, `user.settings.${m.top.parentItem.id}-useLandscapeImages`)
+        useLandscapeImages = chainLookupReturn(m.global.session, `user.settings.${m.top.parentItem.id}-useLandscapeImages`, false)
+        posterOrientation = useLandscapeImages ? ImageLayout.LANDSCAPE : ImageLayout.DEFAULT
+    else
+        posterOrientation = chainLookupReturn(m.global, "session.user.settings.libraryPosterOrientation", ImageLayout.DEFAULT)
+    end if
+
+    if isStringEqual(posterOrientation, ImageLayout.DEFAULT)
+        if inArray([ItemType.PHOTO, ItemType.PHOTOALBUM, ItemType.MUSICVIDEO, ItemType.MYLIST], m.top.mediaType)
+            setColumnSizes(ImageLayout.LANDSCAPE)
+        else if isStringEqual(m.view, "Episodes")
+            setColumnSizes(ImageLayout.LANDSCAPE)
+        else
+            setColumnSizes(ImageLayout.PORTRAIT)
+        end if
+    else
+        setColumnSizes(posterOrientation)
+    end if
+
     itemGridContent = m.data.getChildren(-1, 0)
     m.data = CreateObject("roSGNode", "ContentNode")
     m.itemGrid.content = m.data
@@ -556,7 +576,13 @@ sub loadInitialItems()
         end if
     end if
 
-    posterOrientation = chainLookupReturn(m.global, "session.user.settings.libraryPosterOrientation", ImageLayout.DEFAULT)
+    ' If use has not set a library level setting, check the user level setting
+    if isChainValid(m.global.session, `user.settings.${m.top.parentItem.id}-useLandscapeImages`)
+        useLandscapeImages = chainLookupReturn(m.global.session, `user.settings.${m.top.parentItem.id}-useLandscapeImages`, false)
+        posterOrientation = useLandscapeImages ? ImageLayout.LANDSCAPE : ImageLayout.DEFAULT
+    else
+        posterOrientation = chainLookupReturn(m.global, "session.user.settings.libraryPosterOrientation", ImageLayout.DEFAULT)
+    end if
 
     if isStringEqual(posterOrientation, ImageLayout.DEFAULT)
         if inArray([ItemType.PHOTO, ItemType.PHOTOALBUM, ItemType.MUSICVIDEO, ItemType.MYLIST], m.top.mediaType)
@@ -583,7 +609,6 @@ sub loadInitialItems()
 end sub
 
 sub setColumnSizes(layout = ImageLayout.PORTRAIT as string)
-
     if isStringEqual(layout, ImageLayout.PORTRAIT)
         numberOfColumns = chainLookupReturn(m.global.session, "user.settings.numberOfColumnsPortrait", "7")
         imageWidthData = val(chainLookupReturn(m.global.session, "user.settings.numberOfColumnsPortraitData", "230"))

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -576,7 +576,7 @@ sub loadInitialItems()
         end if
     end if
 
-    ' If use has not set a library level setting, check the user level setting
+    ' If user has not set a library level setting, check the user level setting
     if isChainValid(m.global.session, `user.settings.${m.top.parentItem.id}-useLandscapeImages`)
         useLandscapeImages = chainLookupReturn(m.global.session, `user.settings.${m.top.parentItem.id}-useLandscapeImages`, false)
         posterOrientation = useLandscapeImages ? ImageLayout.LANDSCAPE : ImageLayout.DEFAULT

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -249,7 +249,7 @@ sub onItemDataLoaded()
 end sub
 
 sub redrawItems()
-    ' If use has not set a library level setting, check the user level setting
+    ' If user has not set a library level setting, check the user level setting
     if isChainValid(m.global.session, `user.settings.${m.top.parentItem.id}-useLandscapeImages`)
         useLandscapeImages = chainLookupReturn(m.global.session, `user.settings.${m.top.parentItem.id}-useLandscapeImages`, false)
         posterOrientation = useLandscapeImages ? ImageLayout.LANDSCAPE : ImageLayout.DEFAULT

--- a/components/SettingDialog.bs
+++ b/components/SettingDialog.bs
@@ -24,7 +24,7 @@ sub init()
             m.libraryID = m.group.parentItem.libraryID
         end if
 
-        ' If use has not set a library level setting, check the user level setting
+        ' If user has not set a library level setting, check the user level setting
         if isChainValid(m.global.session, `user.settings.${m.libraryID}-useLandscapeImages`)
             useLandscapeImages = chainLookupReturn(m.global.session, `user.settings.${m.libraryID}-useLandscapeImages`, false)
         else

--- a/components/SettingDialog.bs
+++ b/components/SettingDialog.bs
@@ -1,4 +1,5 @@
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/enums/ImageLayout.bs"
 import "pkg:/source/enums/KeyCode.bs"
 import "pkg:/source/utils/misc.bs"
 
@@ -23,8 +24,16 @@ sub init()
             m.libraryID = m.group.parentItem.libraryID
         end if
 
+        ' If use has not set a library level setting, check the user level setting
+        if isChainValid(m.global.session, `user.settings.${m.libraryID}-useLandscapeImages`)
+            useLandscapeImages = chainLookupReturn(m.global.session, `user.settings.${m.libraryID}-useLandscapeImages`, false)
+        else
+            posterOrientation = chainLookupReturn(m.global, "session.user.settings.libraryPosterOrientation", ImageLayout.DEFAULT)
+            useLandscapeImages = isStringEqual(posterOrientation, ImageLayout.LANDSCAPE)
+        end if
+
         showWatchedCheckmark = chainLookupReturn(m.global.session, `user.settings.${m.libraryID}-showWatchedCheckmark`, true)
-        m.watchedCheckmark.checkedState = [showWatchedCheckmark]
+        m.watchedCheckmark.checkedState = [showWatchedCheckmark, useLandscapeImages]
     end if
 end sub
 
@@ -32,6 +41,7 @@ sub onWatchedCheckmarkChange()
     if not isValid(m.libraryID) then return
 
     set_user_setting(`${m.libraryID}-showWatchedCheckmark`, m.watchedCheckmark.checkedState[0].toStr())
+    set_user_setting(`${m.libraryID}-useLandscapeImages`, m.watchedCheckmark.checkedState[1].toStr())
     m.group.callFunc("redrawItems")
 end sub
 

--- a/components/SettingDialog.xml
+++ b/components/SettingDialog.xml
@@ -4,7 +4,8 @@
     <StdDlgContentArea>
       <CheckList
         id="watchedCheckmark"
-        checkedState="[true]"
+        checkedState="[true,false]"
+        vertFocusAnimationStyle="floatingFocus"
         translation="[0, 0]"
         checkedIconUri="pkg:/images/icons/checkboxChecked.png"
         focusedCheckedIconUri="pkg:/images/icons/checkboxChecked.png"
@@ -14,6 +15,7 @@
         drawFocusFeedback="false">
         <ContentNode role="content">
           <ContentNode title="Display Watched Checkmark" />
+          <ContentNode title="Use Landscape (Wide) Images" />
         </ContentNode>
       </CheckList>
     </StdDlgContentArea>

--- a/source/static/whatsNew/3.1.0.json
+++ b/source/static/whatsNew/3.1.0.json
@@ -9,6 +9,14 @@
   },
   {
     "description": "Allow translation of skip media segment buttons",
-    "author": "1hitsong"    
+    "author": "1hitsong"
+  },
+  {
+    "description": "Create user setting to change poster orientation",
+    "author": "1hitsong"
+  },
+  {
+    "description": "Create library setting to change poster orientation",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Adds a new library setting allowing users to set per-library image orientation settings.

## Demo
https://github.com/user-attachments/assets/1640fda1-4da9-4875-9dd8-590876f1f62f