### PR TITLE
Add "Go To Genre" to the option menu for music items in Recently Added rows on home screen

### DIFF
--- a/components/Libraries/MusicLibraryView.bs
+++ b/components/Libraries/MusicLibraryView.bs
@@ -180,7 +180,7 @@ sub onSortChange()
 
     m.sortAscending = true
 
-    set_user_setting("display." + m.top.parentItem.Id + ".sortField", m.sortField)
+    set_user_setting("display." + m.settingID + ".sortField", m.sortField)
 
     m.loadedRows = 0
     m.loadedItems = 0
@@ -202,7 +202,7 @@ sub onViewChange()
     m.view = viewChoice.LookupCI("name")
     m.viewButton.text = tr(viewChoice.LookupCI("title"))
 
-    set_user_setting("display." + m.top.parentItem.Id + ".landing", m.view)
+    set_user_setting("display." + m.settingID + ".landing", m.view)
 
     ' Reset any filtering or search terms
     m.bypassSearchEvent = true
@@ -216,10 +216,10 @@ sub onViewChange()
     m.sortAscending = true
 
     ' Reset view to defaults
-    set_user_setting("display." + m.top.parentItem.Id + ".sortField", m.sortField)
-    set_user_setting("display." + m.top.parentItem.Id + ".sortAscending", "true")
-    set_user_setting("display." + m.top.parentItem.Id + ".filter", m.filter)
-    set_user_setting("display." + m.top.parentItem.Id + ".filterOptions", FormatJson(m.filterOptions))
+    set_user_setting("display." + m.settingID + ".sortField", m.sortField)
+    set_user_setting("display." + m.settingID + ".sortAscending", "true")
+    set_user_setting("display." + m.settingID + ".filter", m.filter)
+    set_user_setting("display." + m.settingID + ".filterOptions", FormatJson(m.filterOptions))
 
     m.getFiltersTask.control = "RUN"
 
@@ -243,7 +243,7 @@ sub onSortOrderChange()
     m.sortAscending = isStringEqual(sortOrderChoice.LookupCI("name"), "Ascending")
     m.sortOrderButton.text = tr(sortOrderChoice.LookupCI("title"))
 
-    set_user_setting("display." + m.top.parentItem.Id + ".sortAscending", m.sortAscending.toStr())
+    set_user_setting("display." + m.settingID + ".sortAscending", m.sortAscending.toStr())
 
     m.loadedRows = 0
     m.loadedItems = 0
@@ -292,11 +292,17 @@ sub loadInitialItems()
         toggleDropdownOptions(true)
     end if
 
-    m.sortField = m.global.session.user.settings["display." + m.top.parentItem.Id + ".sortField"]
-    m.sortAscending = m.global.session.user.settings["display." + m.top.parentItem.Id + ".sortAscending"]
-    m.filter = m.global.session.user.settings["display." + m.top.parentItem.Id + ".filter"]
-    m.filterOptions = m.global.session.user.settings["display." + m.top.parentItem.Id + ".filterOptions"]
-    m.view = m.global.session.user.settings["display." + m.top.parentItem.Id + ".landing"]
+    if isValidAndNotEmpty(m.top.parentItem.json.genreId)
+        m.settingID = "gotogenre"
+    else
+        m.settingID = m.top.parentItem.Id
+    end if
+
+    m.sortField = m.global.session.user.settings["display." + m.settingID + ".sortField"]
+    m.sortAscending = m.global.session.user.settings["display." + m.settingID + ".sortAscending"]
+    m.filter = m.global.session.user.settings["display." + m.settingID + ".filter"]
+    m.filterOptions = m.global.session.user.settings["display." + m.settingID + ".filterOptions"]
+    m.view = m.global.session.user.settings["display." + m.settingID + ".landing"]
 
     if not isValidAndNotEmpty(m.sortField) then m.sortField = "SortName"
     if not isValidAndNotEmpty(m.filter) then m.filter = "All"
@@ -441,7 +447,7 @@ sub onOptionsVisibleChange()
     if m.options.filter <> m.filter
         m.filter = m.options.filter
         reload = true
-        set_user_setting("display." + m.top.parentItem.Id + ".filter", m.options.filter)
+        set_user_setting("display." + m.settingID + ".filter", m.options.filter)
     end if
 
     if not isValid(m.options.filterOptions)
@@ -451,7 +457,7 @@ sub onOptionsVisibleChange()
     if not AssocArrayEqual(m.options.filterOptions, m.filterOptions)
         m.filterOptions = m.options.filterOptions
         reload = true
-        set_user_setting("display." + m.top.parentItem.Id + ".filterOptions", FormatJson(m.options.filterOptions))
+        set_user_setting("display." + m.settingID + ".filterOptions", FormatJson(m.options.filterOptions))
     end if
 
     if reload
@@ -1029,10 +1035,10 @@ sub resetDropdownsToDefaultState()
     m.sortAscending = true
 
     ' Reset view to defaults
-    set_user_setting("display." + m.top.parentItem.Id + ".sortField", m.sortField)
-    set_user_setting("display." + m.top.parentItem.Id + ".sortAscending", "true")
-    set_user_setting("display." + m.top.parentItem.Id + ".filter", m.filter)
-    set_user_setting("display." + m.top.parentItem.Id + ".filterOptions", FormatJson(m.filterOptions))
+    set_user_setting("display." + m.settingID + ".sortField", m.sortField)
+    set_user_setting("display." + m.settingID + ".sortAscending", "true")
+    set_user_setting("display." + m.settingID + ".filter", m.filter)
+    set_user_setting("display." + m.settingID + ".filterOptions", FormatJson(m.filterOptions))
 
     if not isStringEqual(m.view, "Genres")
         set_user_setting(`display.${m.top.mediaType}library.defaultview`, m.view)

--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -152,6 +152,19 @@ sub onMyListLoaded()
 
     if inArray([ItemType.MUSICALBUM], focusedItem.LookupCI("type"))
         dialogData.push(tr("Go To Artist"))
+
+        genreData = focusedItem.json.LookupCI("Genre")
+        if isValidAndNotEmpty(genreData)
+            if isValidAndNotEmpty(genreData[0])
+                if isValidAndNotEmpty(genreData[0].Name)
+                    dialogData.push(tr("Go To Genre") + `: ${genreData[0].LookupCI("Name")}`)
+                    paramData.GenreName = genreData[0].LookupCI("Name")
+                    paramData.GenreId = genreData[0].LookupCI("Id")
+                    paramData.LibraryId = chainLookup(focusedItem, "json.LibraryId")
+                end if
+            end if
+        end if
+
         paramData.ArtistId = focusedItem.json.LookupCI("AlbumArtistId")
         paramData.ArtistName = focusedItem.json.LookupCI("albumartist")
     end if

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -61,7 +61,8 @@ function loadLatestMedia() as object
         parentId: m.top.itemId,
         enableImageTypes: `${ImageType.PRIMARY}, ${ImageType.BACKDROP}, ${ImageType.THUMB}`,
         imageTypeLimit: 1,
-        enableTotalRecordCount: false
+        enableTotalRecordCount: false,
+        fields: "Genres"
     }
 
     data = api.items.GetLatest(params)
@@ -71,12 +72,6 @@ function loadLatestMedia() as object
     for each item in data
         if not isStringEqual(item.Type, ItemType.BOOK)
             tmp = CreateObject("roSGNode", "HomeData")
-
-            albumArtistID = invalid
-
-            if isValidAndNotEmpty(item.AlbumArtists)
-                albumArtistID = item.AlbumArtists[0].LookupCI("id")
-            end if
 
             tmp.json = {
                 id: item.LookupCI("Id"),
@@ -98,7 +93,8 @@ function loadLatestMedia() as object
                 IndexNumber: item.LookupCI("IndexNumber"),
                 IndexNumberEnd: item.LookupCI("IndexNumberEnd"),
                 AlbumArtist: item.LookupCI("AlbumArtist"),
-                AlbumArtistId: albumArtistID,
+                AlbumArtistId: isValidAndNotEmpty(item.AlbumArtists) ? item.AlbumArtists[0].LookupCI("id") : invalid,
+                Genre: isValidAndNotEmpty(item.GenreItems) ? item.GenreItems : invalid,
                 Status: item.LookupCI("Status"),
                 ImageTags: item.LookupCI("ImageTags"),
                 UserData: item.LookupCI("UserData"),
@@ -106,7 +102,8 @@ function loadLatestMedia() as object
                 ParentBackdropImageTags: item.LookupCI("ParentBackdropImageTags"),
                 ParentBackdropItemId: item.LookupCI("ParentBackdropItemId"),
                 SeriesPrimaryImageTag: item.LookupCI("SeriesPrimaryImageTag"),
-                BackdropImageTags: item.LookupCI("BackdropImageTags")
+                BackdropImageTags: item.LookupCI("BackdropImageTags"),
+                LibraryId: m.top.itemId
             }
             results.push(tmp)
         end if

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2249,5 +2249,9 @@
             <source>Skip Intro</source>
             <translation>Skip Intro</translation>
         </message>
+        <message>
+            <source>Go To Genre</source>
+            <translation>Go To Genre</translation>
+        </message>
     </context>
 </TS>

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -1617,6 +1617,27 @@ sub processLibraryItemPopup(selectedPopupButton as string, itemID as string, par
         return
     end if
 
+    if selectedPopupButton.Instr(tr("Go To Genre")) <> -1
+
+        ' Set filter settings so library loads with selected genre as selected filter
+        set_user_setting("display.gotogenre.landing", "albums")
+        set_user_setting("display.gotogenre.filter", "Genres")
+        set_user_setting("display.gotogenre.filterOptions", `{"Genres": "${params.LookupCI("GenreName")}"}`)
+
+        libraryContent = CreateObject("roSGNode", "JFContentItem")
+        libraryContent.id = params.LookupCI("LibraryId")
+        libraryContent.parentFolder = params.LookupCI("LibraryId")
+        libraryContent.type = "Music"
+        libraryContent.json = {
+            type: "collectionfolder",
+            genreId: params.LookupCI("GenreId")
+        }
+
+        group = CreateMusicLibraryView(libraryContent)
+        m.global.sceneManager.callFunc("pushScene", group)
+        return
+    end if
+
     ' Mark item as played
     if isStringEqual(selectedPopupButton, tr("Mark As Played"))
         MainAction.setPlayed(itemID, true)

--- a/source/static/whatsNew/3.1.0.json
+++ b/source/static/whatsNew/3.1.0.json
@@ -10,5 +10,9 @@
   {
     "description": "Allow translation of skip media segment buttons",
     "author": "1hitsong"    
+  },
+  {
+    "description": "Add \"Go To Genre\" to Recently Added Music items",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Adds "Go To Genre" to the option menu for music items in Recently Added rows on home screen
- If clicked on, user is taken to library pre-filtered to selected genre

## Demo Video
https://github.com/user-attachments/assets/be51b368-5b9f-4455-a0a9-c6f0d42a2b7f


