### PR TITLE
Add "Play Instant Mix" to recently added music items option menu

### DIFF
--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -151,6 +151,7 @@ sub onMyListLoaded()
     end if
 
     if inArray([ItemType.MUSICALBUM], focusedItem.LookupCI("type"))
+        dialogData.push(tr("Play Instant Mix"))
         dialogData.push(tr("Go To Artist"))
 
         genreData = focusedItem.json.LookupCI("Genre")
@@ -167,6 +168,7 @@ sub onMyListLoaded()
 
         paramData.ArtistId = focusedItem.json.LookupCI("AlbumArtistId")
         paramData.ArtistName = focusedItem.json.LookupCI("albumartist")
+        paramData.AlbumId = focusedItem.LookupCI("id")
     end if
 
     m.global.sceneManager.callFunc("optionDialog", "libraryitem", focusedItem.LookupCI("title") ?? tr("Options"), [], dialogData, paramData)

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2253,5 +2253,9 @@
             <source>Go To Genre</source>
             <translation>Go To Genre</translation>
         </message>
+        <message>
+            <source>Play Instant Mix</source>
+            <translation>Play Instant Mix</translation>
+        </message>
     </context>
 </TS>

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -1609,6 +1609,21 @@ sub processLibraryItemPopup(selectedPopupButton as string, itemID as string, par
         return
     end if
 
+    if isStringEqual(selectedPopupButton, tr("Play Instant Mix"))
+        ' Create instant mix based on selected artist
+
+        startLoadingSpinner()
+
+        instantMixList = CreateInstantMix(params.LookupCI("AlbumId"))
+        if isChainValid(instantMixList, "items")
+            MainAction.playItem(instantMixList.LookupCI("Items"), { method: "set", resetShuffle: true })
+        else
+            stopLoadingSpinner()
+        end if
+
+        return
+    end if
+
     if isStringEqual(selectedPopupButton, tr("Go To Artist"))
         CreateArtistView({
             name: params.LookupCI("artistname"),

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -497,13 +497,10 @@ end function
 
 ' Get Instant Mix based on item
 function CreateInstantMix(id as string)
-    url = Substitute("/Items/{0}/InstantMix", id)
-    resp = APIRequest(url, {
+    return api.items.GetInstantMix(id, {
         "UserId": m.global.session.user.id,
         "Limit": 201
     })
-
-    return getJson(resp)
 end function
 
 ' Get Instant Mix based on item

--- a/source/static/whatsNew/3.1.0.json
+++ b/source/static/whatsNew/3.1.0.json
@@ -9,10 +9,14 @@
   },
   {
     "description": "Allow translation of skip media segment buttons",
-    "author": "1hitsong"    
+    "author": "1hitsong"
   },
   {
-    "description": "Add \"Go To Genre\" to Recently Added Music items",
+    "description": "Add \"Go To Genre\" to recently added music items option menu",
+    "author": "1hitsong"
+  },
+  {
+    "description": "Add \"Play Instant Mix\" to recently added music items option menu",
     "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Adds an option to Play Instant Mix to the option menu for items in Recently Added Music row on home screen.

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
