### PR TITLE
Fix disable screensaver on audio player screen

### DIFF
--- a/components/music/LoadScreenSaverTimeoutTask.xml
+++ b/components/music/LoadScreenSaverTimeoutTask.xml
@@ -2,6 +2,6 @@
 
 <component name="LoadScreenSaverTimeoutTask" extends="Task">
   <interface>
-    <field id="content" type="integer" />
+    <field id="content" type="integer" value="300" />
   </interface>
 </component>

--- a/source/static/whatsNew/3.1.0.json
+++ b/source/static/whatsNew/3.1.0.json
@@ -9,10 +9,14 @@
   },
   {
     "description": "Allow translation of skip media segment buttons",
-    "author": "1hitsong"    
+    "author": "1hitsong"
   },
   {
     "description": "Add \"Go To Genre\" to Recently Added Music items",
+    "author": "1hitsong"
+  },
+  {
+    "description": "Fix disabling screensaver on audio player screen",
     "author": "1hitsong"
   }
 ]


### PR DESCRIPTION


<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Fixes bug that didn't honor the user's Roku setting to disable the screensaver on the audio player screen.

## Issues
Fixes #584
