### PR TITLE
Allow dismissing of skip segment buttons.

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -760,7 +760,7 @@ sub displaySegmentSkipButton(segmentType as string, endticks as double)
     m.currentSegmentEndTicks = endticks
     m.currentSegmentType = segmentType
 
-    if isValidAndNotEmpty(m.mediaSegmentDismissed) and m.mediaSegmentDismissed.DoesExist(m.currentSegmentType) and m.mediaSegmentDismissed[m.currentSegmentType] then return
+    if isValidAndNotEmpty(m.mediaSegmentDismissed) and m.mediaSegmentDismissed.DoesExist(m.currentSegmentType) then return
 
     ' Check if user has specific instructions for this media segment type
     userSetting = m.global.session.user.settings[`playback.mediasegments.${segmentType}`]

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -102,6 +102,10 @@ sub init()
     'Play Next Episode button
     m.nextupbuttonseconds = m.global.session.user.settings["playback.nextupbuttonseconds"].ToInt()
 
+    ' Skip segment tracking
+    m.mediaSegmentDismissed = {}
+    m.currentSegmentType = invalid
+
     m.checkedForNextEpisode = false
     m.getNextEpisodeTask = createObject("roSGNode", "GetNextEpisodeTask")
     m.getNextEpisodeTask.observeField("nextEpisodeData", "onNextEpisodeDataLoaded")
@@ -743,6 +747,7 @@ end sub
 
 sub hideSegmentSkipButton()
     m.currentSegmentEndTicks = 0
+    m.currentSegmentType = invalid
     m.skipSegmentButton.visible = false
     m.skipSegmentButton.text = string.EMPTY
     m.skipSegmentButton.setFocus(false)
@@ -753,6 +758,9 @@ end sub
 
 sub displaySegmentSkipButton(segmentType as string, endticks as double)
     m.currentSegmentEndTicks = endticks
+    m.currentSegmentType = segmentType
+
+    if isValidAndNotEmpty(m.mediaSegmentDismissed) and m.mediaSegmentDismissed.DoesExist(m.currentSegmentType) and m.mediaSegmentDismissed[m.currentSegmentType] then return
 
     ' Check if user has specific instructions for this media segment type
     userSetting = m.global.session.user.settings[`playback.mediasegments.${segmentType}`]
@@ -1320,13 +1328,13 @@ function onKeyEvent(key as string, press as boolean) as boolean
     end if
 
     if key = KeyCode.BACK
-        ' If user presses back when Skip Outro button is showing, hide button and disable it so it doesn't show again
+        ' If user presses back when any segment skip button is showing, hide button and disable it so it doesn't show again
         if m.skipSegmentButton.visible
-            if isStringEqual(m.skipSegmentButton.text, tr(`Skip ${MediaSegmentType.OUTRO}`))
-                m.nextupbuttonseconds = 0
-                hideSegmentSkipButton()
-                return true
+            if m.currentSegmentType <> invalid
+                m.mediaSegmentDismissed[m.currentSegmentType] = true
             end if
+            hideSegmentSkipButton()
+            return true
         end if
 
         m.PreloadTrickplayImagesTask.method = "REMOVE"

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1032,6 +1032,8 @@ sub onTrickPlayBarTextChange()
     if not m.top.trickPlayBar.visible then return
 
     m.nextupbuttonseconds = m.global.session.user.settings["playback.nextupbuttonseconds"].ToInt()
+    m.currentSegmentType = invalid
+    m.mediaSegmentDismissed = {}
 
     setVideoEndingTime(0)
 
@@ -1330,7 +1332,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
     if key = KeyCode.BACK
         ' If user presses back when any segment skip button is showing, hide button and disable it so it doesn't show again
         if m.skipSegmentButton.visible
-            if m.currentSegmentType <> invalid
+            if isValid(m.currentSegmentType)
                 m.mediaSegmentDismissed[m.currentSegmentType] = true
             end if
             hideSegmentSkipButton()

--- a/source/static/whatsNew/3.1.0.json
+++ b/source/static/whatsNew/3.1.0.json
@@ -46,5 +46,9 @@
   {
     "description": "Only show \"Shuffle Play Collection\" in option menu if on collection screen",
     "author": "1hitsong"
+  },
+  {
+    "description": "Allow dismissing of Skip Segment buttons",
+    "author": "jimdogx"
   }
 ]

--- a/source/static/whatsNew/3.1.0.json
+++ b/source/static/whatsNew/3.1.0.json
@@ -48,7 +48,7 @@
     "author": "1hitsong"
   },
   {
-    "description": "Allow dismissing of Skip Segment buttons",
+    "description": "Allow dismissing of all skip segment buttons",
     "author": "jimdogx"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
Lets the user hit the back button on any of the skip segment buttons (not just "Skip Outro").
<!-- markdownlint-disable MD041 first-line-heading -->
