### PR TITLE
Fix possible crash when server version can't be determined

### DIFF
--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -33,7 +33,10 @@ function LoginFlow()
         SaveServerList()
     end if
 
-    ServerVersionCheck(ServerInfo().LookupCI("version"))
+    serverVersion = ServerInfo().LookupCI("version")
+    if isValidAndNotEmpty(serverVersion)
+        ServerVersionCheck(serverVersion)
+    end if
 
     activeUser = get_setting("active_user")
     if activeUser = invalid

--- a/source/static/whatsNew/3.1.0.json
+++ b/source/static/whatsNew/3.1.0.json
@@ -62,5 +62,9 @@
   {
     "description": "Redesign TV series screen",
     "author": "1hitsong"
+  },
+  {
+    "description": "Fix possible crash when server version can't be determined",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
From Roku Crash Logs

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Checks server version is valid before passing it into function for use.
