### PR TITLE
Fix possible crash with collections when userData is null

### DIFF
--- a/components/data/CollectionData.bs
+++ b/components/data/CollectionData.bs
@@ -13,8 +13,8 @@ sub setFields()
     m.top.Title = json.name
     m.top.overview = json.overview
     m.top.Description = json.overview
-    m.top.favorite = json.UserData.isFavorite
-    m.top.watched = chainLookup(json, "UserData.played")
+    m.top.favorite = chainLookupReturn(json, "UserData.isFavorite", false)
+    m.top.watched = chainLookupReturn(json, "UserData.played", false)
     m.top.Type = "Boxset"
 
     setPoster()

--- a/source/static/whatsNew/3.1.0.json
+++ b/source/static/whatsNew/3.1.0.json
@@ -62,5 +62,9 @@
   {
     "description": "Redesign TV series screen",
     "author": "1hitsong"
+  },
+  {
+    "description": "Fix possible crash with collections when user data is null",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
Roku Crash Log

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Uses chainlookupreturn instead of directly accessing object properties that may be null.