### PR TITLE
Add setting to goto next episode's details after current episode ends

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -209,11 +209,18 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
         end for
     end if
 
-    if m.global.session.user.Configuration.EnableNextEpisodeAutoPlay and isValid(video.showID)
-        episodeQueueLimit = chainLookupReturn(m.global.session, "user.settings.episodeQueueLimit", "50")
-        episodeQueueLimit = episodeQueueLimit.ToInt()
+    if isValid(video.showID)
+        if m.global.session.user.Configuration.EnableNextEpisodeAutoPlay
+            episodeQueueLimit = chainLookupReturn(m.global.session, "user.settings.episodeQueueLimit", "50")
+            episodeQueueLimit = episodeQueueLimit.ToInt()
 
-        addNextEpisodesToQueue(video.showID, additionalPartsCount, episodeQueueLimit)
+            addNextEpisodesToQueue(video.showID, additionalPartsCount, episodeQueueLimit)
+        else
+            gotoNextEpisodeAfterCurrentEnds = chainLookupReturn(m.global.session, "user.settings.`playback.showNextUpAfterFinish`", false)
+            if gotoNextEpisodeAfterCurrentEnds
+                addEpisodeToShowAtFinish(video.showID)
+            end if
+        end if
     end if
 
     playbackPosition = 0!
@@ -639,7 +646,38 @@ sub addNextEpisodesToQueue(showID, additionalPartsCount as integer, queueLimit a
             m.global.queueManager.callFunc("push", data.Items[i])
         end for
     end if
+end sub
 
+' Add episode to show at finish of current episode
+sub addEpisodeToShowAtFinish(showID)
+    videoID = m.top.itemId
+
+    ' If first item is an intro video, use the next item in the queue
+    if m.top.isIntro
+        currentVideo = m.global.queueManager.callFunc("getItemByIndex", 1)
+
+        if isValid(currentVideo) and isValid(currentVideo.id)
+            videoID = currentVideo.id
+
+            ' Override showID value since it's for the intro video
+            meta = ItemMetaData(videoID)
+            if isValid(meta)
+                showID = meta.showID
+            end if
+        end if
+    end if
+
+    url = Substitute("Shows/{0}/Episodes", showID)
+    urlParams = { "UserId": m.global.session.user.id }
+    urlParams.Append({ "StartItemId": videoID })
+    urlParams.Append({ "Limit": 2 })
+    urlParams.Append({ "isMissing": false })
+    resp = APIRequest(url, urlParams)
+    data = getJson(resp)
+
+    if isValid(data) and data.Items.Count() > 1
+        m.global.queueManager.callFunc("setEpisodeToShowAtFinish", data.Items[1])
+    end if
 end sub
 
 'Checks available subtitle tracks and puts subtitles in forced, default, and non-default/forced but preferred language at the top

--- a/components/manager/QueueManager.bs
+++ b/components/manager/QueueManager.bs
@@ -25,12 +25,14 @@ sub init()
     m.position = 0
     m.preferredAudioTrackIndex = -1
     m.preferredAudioTrackName = string.EMPTY
+    m.episodeToShowAtFinish = string.EMPTY
     m.preferredSubtitleTrack = {}
     m.shuffleEnabled = false
 end sub
 
 ' Clear all content from play queue
 sub clear()
+    m.episodeToShowAtFinish = string.EMPTY
     m.isPlaying = false
     m.queue = []
     m.queueTypes = []
@@ -438,6 +440,16 @@ sub set(items)
         m.queue.push(item)
         m.queueTypes.push(getItemType(item))
     end for
+end sub
+
+' Get episode ID to show when current episode ends
+function getEpisodeToShowAtFinish()
+    return m.episodeToShowAtFinish
+end function
+
+' Set episode ID to show when current episode ends
+sub setEpisodeToShowAtFinish(episodeID)
+    m.episodeToShowAtFinish = episodeID
 end sub
 
 ' Set starting point for top item in the queue

--- a/components/manager/QueueManager.xml
+++ b/components/manager/QueueManager.xml
@@ -29,6 +29,8 @@
     <function name="resetShuffle" />
     <function name="setShuffle" />
     <function name="set" />
+    <function name="getEpisodeToShowAtFinish" />
+    <function name="setEpisodeToShowAtFinish" />
     <function name="bypassNextPreferredAudioTrackIndexReset" />
     <function name="getTranscodeCodec" />
     <function name="getForceTranscode" />

--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -1,6 +1,6 @@
 import "pkg:/source/enums/MediaPlaybackState.bs"
-import "pkg:/source/enums/TaskControl.bs"
 import "pkg:/source/enums/SubtitleSelection.bs"
+import "pkg:/source/enums/TaskControl.bs"
 import "pkg:/source/enums/TimerControl.bs"
 import "pkg:/source/enums/VideoControl.bs"
 
@@ -338,8 +338,18 @@ sub onStateChange()
             return
         end if
 
+        episodeToShowAtFinish = string.EMPTY
+        gotoNextEpisodeAfterCurrentEnds = chainLookupReturn(m.global.session, "user.settings.`playback.showNextUpAfterFinish`", false)
+        if gotoNextEpisodeAfterCurrentEnds
+            episodeToShowAtFinish = m.global.queueManager.callFunc("getEpisodeToShowAtFinish")
+        end if
+
         m.global.queueManager.callFunc("bypassNextPreferredAudioTrackIndexReset")
         m.global.queueManager.callFunc("clear")
+
+        if isValidAndNotEmpty(episodeToShowAtFinish)
+            m.global.queueManager.callFunc("setLastKnownItemID", episodeToShowAtFinish.LookupCI("id"))
+        end if
 
         ' Playback completed, return user to previous screen
         m.global.sceneManager.callFunc("popScene")

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2257,5 +2257,13 @@
             <source>Play Instant Mix</source>
             <translation>Play Instant Mix</translation>
         </message>
+        <message>
+            <source>Show Next Episode Details After Finish</source>
+            <translation>Show Next Episode Details After Finish</translation>
+        </message>
+        <message>
+            <source>If auto play next episode is disabled, display the next episode's detail screen after an episode finishes playing. If no next up episode is found, return to the just-played episode's page.</source>
+            <translation>If auto play next episode is disabled, display the next episode's detail screen after an episode finishes playing. If no next up episode is found, return to the just-played episode's page.</translation>
+        </message>
     </context>
 </TS>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -349,6 +349,13 @@
         ]
       },
       {
+        "title": "Show Next Episode Details After Finish",
+        "description": "If auto play next episode is disabled, display the next episode's detail screen after an episode finishes playing. If no next up episode is found, return to the just-played episode's page.",
+        "settingName": "playback.showNextUpAfterFinish",
+        "type": "bool",
+        "default": "false"
+      },
+      {
         "title": "Text Subtitles Only",
         "description": "Only display text subtitles to minimize transcoding.",
         "settingName": "playback.subs.onlytext",

--- a/source/static/whatsNew/3.1.0.json
+++ b/source/static/whatsNew/3.1.0.json
@@ -70,5 +70,9 @@
   {
     "description": "Fix possible crash with collections when user data is null",
     "author": "1hitsong"
+  },
+  {
+    "description": "Add setting to return to next episode's detail screen after current episode ends",
+    "author": "williamkray"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Creates new user setting that if auto play next episode is disabled will take them to the next episode's detail screen after the current episode ends.
