### PR TITLE
Try playing non-specials first when clicking Play on tv show details

### DIFF
--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -831,7 +831,18 @@ sub onPlaySeriesFromStartEvent(msg)
     if not isChainValid(series, "seasonData.items") then return
     if not isValidAndNotEmpty(series.seasonData.items) then return
 
-    firstSeasonData = series.seasonData.items[0]
+    ' Fall back to playing specials if that's all that is available
+    firstSeasonIndex = 0
+
+    ' Loop through the season data and find the first season with a season number greater than 0
+    for i = 0 to series.seasonData.items.count() - 1
+        if series.seasonData.items[i].json.IndexNumber > 0
+            firstSeasonIndex = i
+            exit for
+        end if
+    end for
+
+    firstSeasonData = series.seasonData.items[firstSeasonIndex]
 
     if not isValidAndNotEmpty(firstSeasonData.LookupCI("id")) then return
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
When the user clicks the Play button on the TV Show detail screen, first try to load an episode outside of the specials folder. If nothing is found, fall back to playing the first found special.