### PR TITLE
Revert press check in option files

### DIFF
--- a/components/ItemGrid/ItemGridOptions.bs
+++ b/components/ItemGrid/ItemGridOptions.bs
@@ -282,8 +282,6 @@ sub saveFavoriteItemSelected(msg)
 end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean
-    if not press then return false
-
     if key = KeyCode.DOWN or (key = KeyCode.OK and m.buttons.hasFocus())
         m.buttons.setFocus(false)
         m.menus[m.selectedItem].setFocus(true)

--- a/components/movies/MovieOptions.bs
+++ b/components/movies/MovieOptions.bs
@@ -166,8 +166,6 @@ end sub
 
 
 function onKeyEvent(key as string, press as boolean) as boolean
-    if not press then return false
-
     if key = KeyCode.DOWN or (key = KeyCode.OK and m.top.findNode("buttons").hasFocus())
         m.top.findNode("buttons").setFocus(false)
         m.menus[m.selectedItem].setFocus(true)

--- a/components/search/SearchResults.bs
+++ b/components/search/SearchResults.bs
@@ -60,8 +60,6 @@ sub loadResults()
 end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean
-    if not press then return false
-
     m.searchAlphabox = m.top.findNode("search_Key")
     if m.searchAlphabox.textEditBox.hasFocus()
         m.searchAlphabox.textEditBox.translation = "[0, -150]"

--- a/components/tvshows/TVListOptions.bs
+++ b/components/tvshows/TVListOptions.bs
@@ -101,8 +101,6 @@ end sub
 
 
 function onKeyEvent(key as string, press as boolean) as boolean
-    if not press then return false
-
     if key = "down" or (key = "OK" and m.top.findNode("buttons").hasFocus())
         m.top.findNode("buttons").setFocus(false)
         m.menus[m.selectedItem].setFocus(true)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Reverts press check in onKeyEvent() in option files. Only working if press = true was causing issues with options not being properly applied when selected, such as force transcode not activating.
