### PR TITLE
Link release year on music album screen to music library filtered by year

### DIFF
--- a/components/Libraries/MusicLibraryView.bs
+++ b/components/Libraries/MusicLibraryView.bs
@@ -292,8 +292,8 @@ sub loadInitialItems()
         toggleDropdownOptions(true)
     end if
 
-    if isValidAndNotEmpty(m.top.parentItem.json.genreId)
-        m.settingID = "gotogenre"
+    if isValid(m.top.parentItem.json.jumpToFilter)
+        m.settingID = "jumpToFilter"
     else
         m.settingID = m.top.parentItem.Id
     end if

--- a/components/music/AlbumView.bs
+++ b/components/music/AlbumView.bs
@@ -702,6 +702,17 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 m.top.lastFocus = m.artistName
                 return true
             end if
+
+            if isStringEqual(key, KeyCode.OK)
+                releaseDate = chainLookup(m.top.pageContent, "json.ProductionYear")
+                if not isValid(releaseDate) then return false
+
+                m.top.getScene().jumpTo = {
+                    selectionType: "releaseDate",
+                    name: releaseDate
+                }
+                return true
+            end if
         end if
     end if
 

--- a/components/music/AlbumView.bs
+++ b/components/music/AlbumView.bs
@@ -17,8 +17,8 @@ sub init()
     m.zoomCover = m.top.findNode("zoomCover")
     m.zoomCoverBackground = m.top.findNode("zoomCoverBackground")
 
-    m.dscr = m.top.findNode("overview")
-    m.dscr.ellipsisText = tr("...")
+    m.overview = m.top.findNode("overview")
+    m.overview.ellipsisText = tr("...")
 
     m.artistName = m.top.findNode("artistName")
     m.albumCoverBackground = m.top.findNode("albumCoverBackground")
@@ -91,8 +91,8 @@ sub onBackdropImageLoaded()
 end sub
 
 sub setFontSizes()
-    if isValid(m.dscr)
-        m.dscr.font.size = 27
+    if isValid(m.overview)
+        m.overview.font.size = 27
     end if
 
     albumTitle = m.top.findNode("albumTitle")
@@ -528,7 +528,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
         if key = KeyCode.UP
             if m.buttonGrp.getChild(m.top.selectedButtonIndex).escape = "up"
                 ' If there is no overview content, go straight to genre link
-                if isStringEqual(m.dscr.text, string.EMPTY)
+                if isStringEqual(m.overview.text, string.EMPTY)
                     if focusGenres()
                         unfocusButton()
                         return true
@@ -543,9 +543,9 @@ function onKeyEvent(key as string, press as boolean) as boolean
                     m.top.lastFocus = m.artistName
                 else
                     unfocusButton()
-                    m.dscr.setFocus(true)
-                    m.dscr.color = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
-                    m.top.lastFocus = m.dscr
+                    m.overview.setFocus(true)
+                    m.overview.color = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+                    m.top.lastFocus = m.overview
                     return true
                 end if
             end if
@@ -681,15 +681,15 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 unfocusGenres()
 
                 ' If there is no overview content, go straight to buttons
-                if isStringEqual(m.dscr.text, string.EMPTY)
+                if isStringEqual(m.overview.text, string.EMPTY)
                     selectedButton = m.buttonGrp.getChild(m.top.selectedButtonIndex)
                     selectedButton.focus = true
                     selectedButton.setfocus(true)
                     return true
                 else
-                    m.dscr.setFocus(true)
-                    m.dscr.color = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
-                    m.top.lastFocus = m.dscr
+                    m.overview.setFocus(true)
+                    m.overview.color = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+                    m.top.lastFocus = m.overview
                     return true
                 end if
             end if
@@ -717,10 +717,10 @@ function onKeyEvent(key as string, press as boolean) as boolean
             end if
 
             ' We have no genres, if we have an overview, focus it
-            if not isStringEqual(m.dscr.text, string.EMPTY)
-                m.dscr.setFocus(true)
-                m.dscr.color = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
-                m.top.lastFocus = m.dscr
+            if not isStringEqual(m.overview.text, string.EMPTY)
+                m.overview.setFocus(true)
+                m.overview.color = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+                m.top.lastFocus = m.overview
                 return true
             end if
 
@@ -750,28 +750,28 @@ function onKeyEvent(key as string, press as boolean) as boolean
         end if
     end if
 
-    if m.dscr.hasFocus()
+    if m.overview.hasFocus()
         if key = KeyCode.OK
             createFullDscrDlg()
             return true
         end if
 
         if isStringEqual(key, KeyCode.RIGHT)
-            if highlightCover(m.dscr)
-                m.dscr.color = ColorPalette.WHITE
+            if highlightCover(m.overview)
+                m.overview.color = ColorPalette.WHITE
             end if
             return true
         end if
 
         if isStringEqual(key, KeyCode.UP)
             if focusGenres()
-                m.dscr.color = ColorPalette.WHITE
+                m.overview.color = ColorPalette.WHITE
                 return true
             end if
         end if
 
         if key = KeyCode.DOWN
-            m.dscr.color = ColorPalette.WHITE
+            m.overview.color = ColorPalette.WHITE
             selectedButton = m.buttonGrp.getChild(m.top.selectedButtonIndex)
             selectedButton.focus = true
             selectedButton.setfocus(true)
@@ -784,8 +784,8 @@ end function
 
 sub createFullDscrDlg()
     albumTitle = m.top.findNode("albumTitle")
-    if isAllValid([albumTitle.text, m.dscr.text])
-        m.global.sceneManager.callFunc("standardDialog", albumTitle.text, { data: ["<p>" + m.dscr.text + "</p>"] })
+    if isAllValid([albumTitle.text, m.overview.text])
+        m.global.sceneManager.callFunc("standardDialog", albumTitle.text, { data: ["<p>" + m.overview.text + "</p>"] })
     end if
 end sub
 

--- a/components/music/AlbumView.bs
+++ b/components/music/AlbumView.bs
@@ -342,6 +342,10 @@ sub setOnScreenTextValues(json)
 
         if type(json.ProductionYear) = "roInt"
             setFieldTextValue("released", `${json.ProductionYear}`)
+        else
+            releasedContainer = m.released.GetParent()
+            releasedContainer.GetParent().removeChild(releasedContainer)
+            m.released = invalid
         end if
 
         if isValidAndNotEmpty(json.genres)

--- a/components/music/AlbumView.bs
+++ b/components/music/AlbumView.bs
@@ -20,6 +20,8 @@ sub init()
     m.overview = m.top.findNode("overview")
     m.overview.ellipsisText = tr("...")
 
+    m.released = m.top.findNode("released")
+
     m.artistName = m.top.findNode("artistName")
     m.albumCoverBackground = m.top.findNode("albumCoverBackground")
     m.albumCoverBackground.color = ColorPalette.TRANSPARENT
@@ -114,9 +116,8 @@ sub setFontSizes()
         numberofsongs.font.size = 23
     end if
 
-    released = m.top.findNode("released")
-    if isValid(released)
-        released.font.size = 23
+    if isValid(m.released)
+        m.released.font.size = 23
     end if
 
     trackHeading = m.top.findNode("trackHeading")
@@ -405,6 +406,16 @@ sub onButtonSelectedChange()
     selectedButton.setfocus(true)
 end sub
 
+function focusReleaseDate() as boolean
+    if not isValid(m.released) then return false
+
+    m.released.setFocus(true)
+    m.released.color = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+    m.top.lastFocus = m.released
+
+    return true
+end function
+
 function focusGenres() as boolean
     if not isValid(m.genres) then return false
 
@@ -527,8 +538,13 @@ function onKeyEvent(key as string, press as boolean) as boolean
     if m.buttonGrp.isInFocusChain()
         if key = KeyCode.UP
             if m.buttonGrp.getChild(m.top.selectedButtonIndex).escape = "up"
-                ' If there is no overview content, go straight to genre link
+                ' If there is no overview content
                 if isStringEqual(m.overview.text, string.EMPTY)
+                    if focusReleaseDate()
+                        unfocusButton()
+                        return true
+                    end if
+
                     if focusGenres()
                         unfocusButton()
                         return true
@@ -645,10 +661,57 @@ function onKeyEvent(key as string, press as boolean) as boolean
         end if
     end if
 
+    if isValid(m.released)
+        if m.released.isInFocusChain()
+            if isStringEqual(key, KeyCode.RIGHT)
+                if focusGenres()
+                    m.released.color = ColorPalette.WHITE
+                    return true
+                end if
+            end if
+
+            if isStringEqual(key, KeyCode.DOWN)
+                m.released.color = ColorPalette.WHITE
+
+                ' If we have an overview, focus it
+                if not isStringEqual(m.overview.text, string.EMPTY)
+                    m.overview.setFocus(true)
+                    m.overview.color = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+                    m.top.lastFocus = m.overview
+                    return true
+                end if
+
+                ' We have no overview, focus buttons
+                selectedButton = m.buttonGrp.getChild(m.top.selectedButtonIndex)
+                selectedButton.focus = true
+                selectedButton.setfocus(true)
+                return true
+            end if
+
+            if isStringEqual(key, KeyCode.UP)
+                ' Check if we can go to the artistName
+                if not isValidAndNotEmpty(chainLookup(m.artistName, "text")) then return false
+
+                m.released.color = ColorPalette.WHITE
+                m.artistName.setFocus(true)
+                m.artistName.color = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+                m.top.lastFocus = m.artistName
+                return true
+            end if
+        end if
+    end if
+
     if isValid(m.genres)
         if m.genres.isInFocusChain()
             if isStringEqual(key, KeyCode.LEFT)
-                if m.highlightedGenre = 0 then return false
+                if m.highlightedGenre = 0
+                    if focusReleaseDate()
+                        unfocusGenres()
+                        return true
+                    end if
+                    return false
+                end if
+
                 dehighlightGenre()
                 m.highlightedGenre--
                 highlightGenre()
@@ -710,7 +773,13 @@ function onKeyEvent(key as string, press as boolean) as boolean
         if isStringEqual(key, KeyCode.DOWN)
             m.artistName.color = ColorPalette.WHITE
 
-            ' If we have genres, focus them
+            ' If we have release date, focus it, otherwise focus genres
+            if focusReleaseDate()
+                m.artistName.color = ColorPalette.WHITE
+                return true
+            end if
+
+            ' If we have release date, focus it, otherwise focus genres
             if focusGenres()
                 m.artistName.color = ColorPalette.WHITE
                 return true
@@ -764,6 +833,10 @@ function onKeyEvent(key as string, press as boolean) as boolean
         end if
 
         if isStringEqual(key, KeyCode.UP)
+            if focusReleaseDate()
+                m.overview.color = ColorPalette.WHITE
+                return true
+            end if
             if focusGenres()
                 m.overview.color = ColorPalette.WHITE
                 return true

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -209,15 +209,32 @@ sub onJumpToEvent(msg)
 
     if isStringEqual(jumpToData.selectiontype, "genre")
         ' Set filter settings so library loads with selected genre as selected filter
-        set_user_setting("display.gotogenre.landing", "albums")
-        set_user_setting("display.gotogenre.filter", "Genres")
-        set_user_setting("display.gotogenre.filterOptions", `{"Genres": "${jumpToData.LookupCI("Name")}"}`)
+        set_user_setting("display.jumpToFilter.landing", "albums")
+        set_user_setting("display.jumpToFilter.filter", "Genres")
+        set_user_setting("display.jumpToFilter.filterOptions", `{"Genres": "${jumpToData.LookupCI("Name")}"}`)
 
         libraryContent = CreateObject("roSGNode", "JFContentItem")
         libraryContent.type = "Music"
         libraryContent.json = {
             type: "collectionfolder",
-            genreId: jumpToData.LookupCI("Id")
+            jumpToFilter: true
+        }
+
+        group = CreateMusicLibraryView(libraryContent)
+        m.global.sceneManager.callFunc("pushScene", group)
+    end if
+
+    if isStringEqual(jumpToData.selectiontype, "releaseDate")
+        ' Set filter settings so library loads with selected releaseDate as selected filter
+        set_user_setting("display.jumpToFilter.landing", "albums")
+        set_user_setting("display.jumpToFilter.filter", "Years")
+        set_user_setting("display.jumpToFilter.filterOptions", `{"Years": "${jumpToData.LookupCI("Name")}"}`)
+
+        libraryContent = CreateObject("roSGNode", "JFContentItem")
+        libraryContent.type = "Music"
+        libraryContent.json = {
+            type: "collectionfolder",
+            jumpToFilter: true
         }
 
         group = CreateMusicLibraryView(libraryContent)
@@ -1715,9 +1732,9 @@ sub processLibraryItemPopup(selectedPopupButton as string, itemID as string, par
 
     if selectedPopupButton.Instr(tr("Go To Genre")) <> -1
         ' Set filter settings so library loads with selected genre as selected filter
-        set_user_setting("display.gotogenre.landing", "albums")
-        set_user_setting("display.gotogenre.filter", "Genres")
-        set_user_setting("display.gotogenre.filterOptions", `{"Genres": "${params.LookupCI("GenreName")}"}`)
+        set_user_setting("display.jumpToFilter.landing", "albums")
+        set_user_setting("display.jumpToFilter.filter", "Genres")
+        set_user_setting("display.jumpToFilter.filterOptions", `{"Genres": "${params.LookupCI("GenreName")}"}`)
 
         libraryContent = CreateObject("roSGNode", "JFContentItem")
         libraryContent.id = params.LookupCI("LibraryId")
@@ -1725,7 +1742,7 @@ sub processLibraryItemPopup(selectedPopupButton as string, itemID as string, par
         libraryContent.type = "Music"
         libraryContent.json = {
             type: "collectionfolder",
-            genreId: params.LookupCI("GenreId")
+            jumpToFilter: params.LookupCI("GenreId")
         }
 
         group = CreateMusicLibraryView(libraryContent)

--- a/source/static/whatsNew/3.1.2.json
+++ b/source/static/whatsNew/3.1.2.json
@@ -4,7 +4,11 @@
     "author": "1hitsong"
   },
   {
-    "description": "Bug Fix: Prevent moving cursor to album cover if no image loads on album screen",
+    "description": "Bug Fix: Prevent moving cursor to album cover if no image loads on music album screen",
+    "author": "1hitsong"
+  },
+  {
+    "description": "Link release year on music album screen to library filtered by year",
     "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- If API provides no album release year , remove element
- Allow user to navigate to and through release year
- If user presses OK while release year is highlighted, take them to a music library screen with albums filtered by the year that was clicked on