### PR TITLE
Move Search and Setting links out of the user menu to the home screen

### DIFF
--- a/components/AudioMiniPlayer.bs
+++ b/components/AudioMiniPlayer.bs
@@ -287,6 +287,9 @@ sub removeFocus()
     group = m.global.sceneManager.callFunc("getActiveScene")
     if isChainValid(group, "lastFocus")
         group.lastFocus.setFocus(true)
+        if isStringEqual(group.lastFocus.subtype(), "TextButton")
+            group.lastFocus.focus = true
+        end if
     end if
 end sub
 

--- a/components/JFOverhang.bs
+++ b/components/JFOverhang.bs
@@ -91,6 +91,24 @@ end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean
     if press
+        if isStringEqual(key, KeyCode.LEFT)
+            buttons = m.top.getscene().findNode("buttons")
+            if isValid(buttons)
+                if buttons.getChildCount() = 0 then return false
+
+                lastButtonIndex = buttons.getChildCount() - 1
+                lastButton = buttons.getChild(lastButtonIndex)
+                if not isValid(lastButton) then return false
+
+                dehighlightUser()
+                lastButton.setfocus(true)
+                lastButton.focus = true
+                group = m.global.sceneManager.callFunc("getActiveScene")
+                group.lastFocus = lastButton
+                return true
+            end if
+        end if
+
         if key = KeyCode.DOWN
             homeRows = m.top.getscene().findNode("homeRows")
             if isValid(homeRows)

--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -1,5 +1,7 @@
 import "pkg:/source/api/baserequest.bs"
 import "pkg:/source/api/Image.bs"
+import "pkg:/source/enums/AnimationControl.bs"
+import "pkg:/source/enums/AnimationState.bs"
 import "pkg:/source/enums/ColorPalette.bs"
 import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/enums/KeyCode.bs"
@@ -26,11 +28,32 @@ sub init()
 
     m.homeRows = m.top.findNode("homeRows")
     m.homeRows.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+
+    m.buttons = m.top.findNode("buttons")
+    m.toggleButtonsAnimation = m.top.findNode("toggleButtonsAnimation")
+    m.buttonsFade = m.top.findNode("buttonsFade")
+    m.buttonsMove = m.top.findNode("buttonsMove")
+
+    setButtonColors()
 end sub
 
 sub refresh()
     m.homeRows.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.homeRows.callFunc("updateHomeRows")
+end sub
+
+sub setButtonColors()
+    m.searchButton = m.top.findNode("searchButton")
+    m.searchButton.textColor = ColorPalette.WHITE
+    m.searchButton.background = ColorPalette.DARKGREY
+    m.searchButton.focusTextColor = ColorPalette.WHITE
+    m.searchButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+
+    m.settingsButton = m.top.findNode("settingsButton")
+    m.settingsButton.textColor = ColorPalette.WHITE
+    m.settingsButton.background = ColorPalette.DARKGREY
+    m.settingsButton.focusTextColor = ColorPalette.WHITE
+    m.settingsButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 end sub
 
 sub loadLibraries()
@@ -91,6 +114,28 @@ end sub
 sub postFinished()
     m.postTask.unobserveField("responseCode")
     m.postTask.callFunc("empty")
+end sub
+
+sub onRowFocusedChange()
+    if m.top.rowFocused > 0
+        if m.buttons.opacity > 0
+            toggleButtonsVisibility()
+        end if
+        return
+    end if
+
+    if m.buttons.opacity < 1
+        toggleButtonsVisibility(true)
+    end if
+end sub
+
+sub toggleButtonsVisibility(runInReverse = false as boolean)
+    m.buttonsFade.reverse = runInReverse
+    m.buttonsMove.reverse = runInReverse
+
+    if not isStringEqual(m.toggleButtonsAnimation.state, AnimationState.RUNNING)
+        m.toggleButtonsAnimation.control = AnimationControl.START
+    end if
 end sub
 
 sub onMyListLoaded()
@@ -174,9 +219,95 @@ sub onMyListLoaded()
     m.global.sceneManager.callFunc("optionDialog", "libraryitem", focusedItem.LookupCI("title") ?? tr("Options"), [], dialogData, paramData)
 end sub
 
+sub setLastFocus(lastFocusElement)
+    group = m.global.sceneManager.callFunc("getActiveScene")
+
+    if isValid(group)
+        group.lastFocus = lastFocusElement
+    end if
+end sub
+
+function audioMiniPlayerIsVisible()
+    scene = m.top.getScene()
+    audioMiniPlayer = scene.findNode("audioMiniPlayer")
+
+    if not isValid(audioMiniPlayer) then return false
+
+    return audioMiniPlayer.callFunc("isVisible")
+end function
+
 ' Special handling for key presses on the home screen.
 function onKeyEvent(key as string, press as boolean) as boolean
     if not press then return false
+
+    if m.buttons.isInFocusChain()
+        if isStringEqual(key, KeyCode.REPLAY)
+            if not audioMiniPlayerIsVisible() then return true
+            m.searchButton.focus = false
+            m.settingsButton.focus = false
+        end if
+
+        if isStringEqual(key, KeyCode.OK)
+            if m.searchButton.hasFocus()
+                m.top.getScene().jumpTo = {
+                    selectionType: "search"
+                }
+                return true
+            end if
+
+            if m.settingsButton.hasFocus()
+                m.top.getScene().jumpTo = {
+                    selectionType: "settings"
+                }
+                return true
+            end if
+        end if
+
+        if isStringEqual(key, KeyCode.DOWN)
+            m.searchButton.focus = false
+            m.settingsButton.focus = false
+            m.homeRows.setfocus(true)
+            setLastFocus(m.homeRows)
+            return true
+        end if
+
+        if isStringEqual(key, KeyCode.RIGHT)
+            if m.searchButton.hasFocus()
+                m.searchButton.focus = false
+                m.settingsButton.focus = true
+                m.settingsButton.setfocus(true)
+                setLastFocus(m.settingsButton)
+                return true
+            end if
+
+            if m.settingsButton.hasFocus()
+                m.settingsButton.focus = false
+                scene = m.top.getScene()
+                if not isValid(scene) then return false
+
+                overhang = scene.findNode("overhang")
+                if not isValid(overhang) then return false
+
+                overhang.callFunc("highlightUser")
+                overhang.setfocus(true)
+                setLastFocus(overhang)
+                return true
+
+            end if
+        end if
+
+        if isStringEqual(key, KeyCode.LEFT)
+            if m.settingsButton.hasFocus()
+                m.searchButton.focus = true
+                m.settingsButton.focus = false
+                m.searchButton.setfocus(true)
+                setLastFocus(m.searchButton)
+                return true
+            end if
+        end if
+
+        return false
+    end if
 
     ' If the user hit back and is not on the first item of the row,
     ' assume they want to go to the first item of the row.
@@ -195,6 +326,13 @@ function onKeyEvent(key as string, press as boolean) as boolean
             m.loadMetaDataTask.control = TaskControl.RUN
             return true
         end if
+    end if
+
+    if isStringEqual(key, KeyCode.UP)
+        m.searchButton.focus = true
+        m.searchButton.setfocus(true)
+        setLastFocus(m.searchButton)
+        return true
     end if
 
     return false

--- a/components/home/Home.xml
+++ b/components/home/Home.xml
@@ -2,6 +2,30 @@
 <component name="Home" extends="JFScreen">
   <children>
     <Poster id="backdrop" loadDisplayMode="scaleToZoom" width="1920" height="1200" />
+
+    <LayoutGroup id="buttons" translation="[100, 100]" layoutDirection="horiz" horizAlignment="left" itemSpacings="[25]">
+      <TextButton
+        id="searchButton"
+        iconSide="left"
+        fontSize="25"
+        padding="20"
+        icon="pkg:/images/icons/search-light.png"
+        focusIcon="pkg:/images/icons/search-light.png"
+        text="Search"
+        height="50"
+        width="200" />
+      <TextButton
+        id="settingsButton"
+        iconSide="left"
+        fontSize="25"
+        padding="20"
+        icon="pkg:/images/icons/settings.png"
+        focusIcon="pkg:/images/icons/settings.png"
+        text="Settings"
+        height="50"
+        width="200" />
+    </LayoutGroup>
+
     <HomeRows
       id="homeRows"
       showRowLabel="true"
@@ -11,10 +35,17 @@
       numRows="2"
       rowLabelOffset="[[0,20]]" />
     <OptionsSlider id="options" />
+
+    <Animation id="toggleButtonsAnimation" duration=".7" repeat="false" easeFunction="linear">
+      <FloatFieldInterpolator id="buttonsFade" key="[0.0, .6]" keyValue="[1.00, 0.00]" fieldToInterp="buttons.opacity" />
+      <Vector2DFieldInterpolator id="buttonsMove" key="[0.1, .9]" keyValue="[[100, 100], [100, 0]]" fieldToInterp="buttons.translation" />
+    </Animation>
+
   </children>
   <interface>
     <field id="playlistData" type="array" />
     <field id="selectedItem" alias="homeRows.selectedItem" />
+    <field id="rowFocused" alias="homeRows.itemFocused" onchange="onRowFocusedChange" />
     <field id="quickPlayNode" alias="homeRows.quickPlayNode" />
     <function name="refresh" />
     <function name="loadLibraries" />

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -866,21 +866,6 @@ function onKeyEvent(key as string, press as boolean) as boolean
             end if
             return true
         end if
-
-        if key = KeyCode.UP
-            if m.top.rowItemFocused[0] = 0
-                m.overhang.callFunc("highlightUser")
-                m.overhang.setfocus(true)
-
-                group = m.global.sceneManager.callFunc("getActiveScene")
-                if isValid(group)
-                    group.lastFocus = m.overhang
-                end if
-
-                return true
-            end if
-        end if
-
     end if
 
     group = m.global.sceneManager.callFunc("getActiveScene")

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -171,23 +171,7 @@ sub Main (args as dynamic) as void
         else if isNodeEvent(msg, "userMenuOptionSelected")
             button = msg.getRoSGNode()
             group = sceneManager.callFunc("getActiveScene")
-            if isStringEqual(button.id, "goto_search") and isValid(group)
-                ' Exit out of the side panel
-                panel = group.findNode("options")
-                panel.visible = false
-                if isValid(group.lastFocus)
-                    group.lastFocus.setFocus(true)
-                else
-                    group.setFocus(true)
-                    group.lastFocus = group
-                end if
-                group = CreateSearchPage()
-                sceneManager.callFunc("pushScene", group)
-                group.findNode("SearchBox").findNode("search_Key").setFocus(true)
-                group = m.global.sceneManager.callFunc("getActiveScene")
-                group.lastFocus = group.findNode("SearchBox").findNode("search_Key")
-                group.findNode("SearchBox").findNode("search_Key").active = true
-            else if isStringEqual(button.id, "change_server")
+            if isStringEqual(button.id, "change_server")
                 unset_setting("server")
                 session.server.Delete()
                 SignOut(false)
@@ -205,16 +189,6 @@ sub Main (args as dynamic) as void
                 setUserColors()
                 sceneManager.callFunc("clearScenes")
                 goto app_start
-            else if isStringEqual(button.id, "settings")
-                ' Exit out of the side panel
-                panel = group.findNode("options")
-                panel.visible = false
-                if isValid(group) and isValid(group.lastFocus)
-                    group.lastFocus.setFocus(true)
-                else
-                    group.setFocus(true)
-                end if
-                sceneManager.callFunc("settings")
             end if
         else if isNodeEvent(msg, "state")
             onStateEvent(msg)

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -186,6 +186,28 @@ sub onJumpToEvent(msg)
         m.global.sceneManager.callFunc("clearPreviousScene")
     end if
 
+    if isStringEqual(jumpToData.selectiontype, "search")
+        startLoadingSpinner()
+
+        group = CreateSearchPage()
+        if not isValid(group)
+            stopLoadingSpinner()
+        end if
+
+        m.global.sceneManager.callFunc("pushScene", group)
+        group.findNode("SearchBox").findNode("search_Key").setFocus(true)
+        group = m.global.sceneManager.callFunc("getActiveScene")
+        group.lastFocus = group.findNode("SearchBox").findNode("search_Key")
+        group.findNode("SearchBox").findNode("search_Key").active = true
+        stopLoadingSpinner()
+    end if
+
+    if isStringEqual(jumpToData.selectiontype, "settings")
+        startLoadingSpinner()
+        m.global.sceneManager.callFunc("settings")
+        stopLoadingSpinner()
+    end if
+
     if isStringEqual(jumpToData.selectiontype, "nowplaying")
         JumpIntoAudioPlayerView()
     end if

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -629,8 +629,6 @@ function CreateHomeGroup()
     sidepanel.observeField("closeSidePanel", m.port)
     new_options = []
     options_buttons = [
-        { "title": "Search", "id": "goto_search" },
-        { "title": "Settings", "id": "settings" },
         { "title": "Change user", "id": "change_user" },
         { "title": "Change server", "id": "change_server" },
         { "title": "Sign out", "id": "sign_out" }

--- a/source/static/whatsNew/3.1.2.json
+++ b/source/static/whatsNew/3.1.2.json
@@ -18,5 +18,9 @@
   {
     "description": "Add Favorite and Playlist controls to music album screen under \"More\" button",
     "author": "1hitsong"
+  },
+  {
+    "description": "Move Search and Setting links out of the user menu to the home screen",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- On the home screen, moves the links to the Search screen and Settings screen out from the user menu and puts them above the home rows
- If the user scrolls down, the buttons are hidden
- If the user scrolls back up to the 1st row, the buttons are shown

## Screenshot
![WIN_20260122_21_43_19_Pro](https://github.com/user-attachments/assets/3ac1c4d0-dd69-4db8-a371-87d75666ede5)

