### PR TITLE
Refresh Subtitle Timing UI

### DIFF
--- a/components/RadioDialog.bs
+++ b/components/RadioDialog.bs
@@ -19,6 +19,17 @@ end sub
 sub onButtonSelected()
     if m.top.buttonSelected = 0
         m.global.sceneManager.returnData = m.top.contentData.data[m.radioOptions.selectedIndex]
+        return
+    end if
+
+    if isStringEqual(m.top.buttons[m.top.buttonSelected], tr("Adjust Subtitle Timing"))
+        activeScene = m.global.sceneManager.callFunc("getActiveScene")
+        if not isValid(activeScene) then return
+
+        osd = activeScene.findNode("osd")
+        if not isValid(osd) then return
+
+        osd.action = "showsyncmenu"
     end if
 end sub
 

--- a/components/StandardButton.bs
+++ b/components/StandardButton.bs
@@ -1,3 +1,5 @@
+import "pkg:/source/utils/misc.bs"
+
 sub init()
     m.buttonBackground = m.top.findNode("buttonBackground")
     m.buttonText = m.top.findNode("buttonText")
@@ -8,6 +10,13 @@ sub init()
     m.top.observeField("height", "onHeightChanged")
     m.top.observeField("width", "onWidthChanged")
     m.top.observeField("focus", "onFocusChanged")
+    m.top.observeField("fontSize", "onFontSizeChanged")
+end sub
+
+sub onFontSizeChanged()
+    if m.top.fontSize > 0
+        m.buttonText.font.size = m.top.fontSize
+    end if
 end sub
 
 sub onFocusChanged()
@@ -15,10 +24,16 @@ sub onFocusChanged()
         m.buttonBackground.blendColor = m.top.focusBackground
         m.buttonText.color = m.top.focusColor
         m.buttonText.font = "font:SmallBoldSystemFont"
+        if m.top.fontSize > 0
+            m.buttonText.font.size = m.top.fontSize
+        end if
     else
         m.buttonBackground.blendColor = m.top.background
         m.buttonText.color = m.top.color
         m.buttonText.font = "font:SmallSystemFont"
+        if m.top.fontSize > 0
+            m.buttonText.font.size = m.top.fontSize
+        end if
     end if
 end sub
 

--- a/components/StandardButton.xml
+++ b/components/StandardButton.xml
@@ -12,6 +12,7 @@
     <field id="text" type="string" value="" />
     <field id="height" type="integer" value="" />
     <field id="width" type="integer" value="" />
+    <field id="fontSize" type="integer" value="0" />
     <field id="selected" type="boolean" value="false" />
     <field id="focus" type="boolean" />
     <field id="escape" type="string" value="" />

--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -180,7 +180,7 @@ function prepareStyles(styles as object, rect, lineCount = 1 as integer) as obje
     captionStyles = styles
     finalStyles = { translation: [960, 1020] }
 
-    verticalPosition = 120
+    verticalPosition = 1020
     horizontalPositon = 960 - (rect.BoundingRect().width / 2)
 
     if not isValidAndNotEmpty(captionStyles)

--- a/components/data/SceneManager.bs
+++ b/components/data/SceneManager.bs
@@ -328,7 +328,7 @@ end sub
 
 '
 ' Display dialog to user with an OK button
-sub radioDialog(title, message)
+sub radioDialog(title, message, buttons = [tr("OK")])
     m.itemID = string.EMPTY
     m.userselection = false
 
@@ -347,7 +347,7 @@ sub radioDialog(title, message)
     dialog.observeField("wasClosed", "optionClosed")
     dialog.title = title
     dialog.contentData = message
-    dialog.buttons = [tr("OK")]
+    dialog.buttons = buttons
 
     m.scene.dialog = dialog
 end sub

--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -168,7 +168,13 @@ sub onSelectSubtitlePressed()
         "Type": "subtitleselection"
     })
 
-    m.global.sceneManager.callFunc("radioDialog", tr("Select Subtitles"), subtitleData)
+    buttons = [tr("OK")]
+
+    if chainLookupReturn(m.global, "session.user.settings.`playback.subs.custom`", false)
+        buttons.push(tr("Adjust Subtitle Timing"))
+    end if
+
+    m.global.sceneManager.callFunc("radioDialog", tr("Select Subtitles"), subtitleData, buttons)
     m.global.sceneManager.observeField("returnData", "onSelectionMade")
 end sub
 

--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -124,6 +124,7 @@ sub onSelectSubtitlePressed()
     subtitleData = {
         data: []
     }
+    selectedSubtitleIsExternal = false
 
     for each item in m.view.fullSubtitleData
         item.type = "subtitleselection"
@@ -132,6 +133,7 @@ sub onSelectSubtitlePressed()
             ' Subtitle is a track within the file
             if item.index = m.view.selectedSubtitle
                 item.selected = true
+                selectedSubtitleIsExternal = item.LookupCI("IsExternal")
             end if
         else
             ' Subtitle is from an external source
@@ -143,6 +145,7 @@ sub onSelectSubtitlePressed()
 
                 if subtitleFullTrackName = m.view.subtitleTrack
                     item.selected = true
+                    selectedSubtitleIsExternal = item.LookupCI("IsExternal")
                 end if
 
             end if
@@ -170,8 +173,10 @@ sub onSelectSubtitlePressed()
 
     buttons = [tr("OK")]
 
-    if chainLookupReturn(m.global, "session.user.settings.`playback.subs.custom`", false)
-        buttons.push(tr("Adjust Subtitle Timing"))
+    if selectedSubtitleIsExternal
+        if chainLookupReturn(m.global, "session.user.settings.`playback.subs.custom`", false)
+            buttons.push(tr("Adjust Subtitle Timing"))
+        end if
     end if
 
     m.global.sceneManager.callFunc("radioDialog", tr("Select Subtitles"), subtitleData, buttons)

--- a/components/video/OSD.xml
+++ b/components/video/OSD.xml
@@ -20,7 +20,6 @@
       <IconButton id="chapterList" padding="16" icon="pkg:/images/icons/numberList.png" height="65" width="100" />
       <IconButton id="showSubtitleMenu" padding="0" icon="pkg:/images/icons/subtitle.png" height="65" width="100" />
       <IconButton id="showAudioMenu" padding="27" icon="pkg:/images/icons/musicNote.png" height="65" width="100" />
-      <IconButton id="showSyncMenu" padding="16" icon="pkg:/images/icons/settings.png" height="65" width="100" />
     </ButtonGroup>
 
     <ButtonGroup id="videoControls" itemSpacings="[20]" layoutDirection="horiz" horizAlignment="center" translation="[960,875]">

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -92,6 +92,47 @@ sub init()
 
     m.videoEndingTime = m.top.findNode("videoEndingTime")
 
+    m.subtitleSyncValue = m.top.findNode("subtitleSyncValue")
+    m.subtitleSyncValue.font.size = 26
+
+    m.subtitleTimingButtons = m.top.findNode("subtitleTimingButtons")
+    m.subtitleTimingButtons.color = ColorPalette.BLACK90
+
+    m.subtitleSyncPlus100 = m.top.findNode("subtitleSyncPlus100")
+    m.subtitleSyncPlus100.fontSize = 25
+    m.subtitleSyncPlus100.background = ColorPalette.DARKGREY
+    m.subtitleSyncPlus100.color = ColorPalette.WHITE
+    m.subtitleSyncPlus100.focusBackground = ColorPalette.HIGHLIGHT
+    m.subtitleSyncPlus100.focusColor = ColorPalette.WHITE
+
+    m.subtitleSyncPlus500 = m.top.findNode("subtitleSyncPlus500")
+    m.subtitleSyncPlus500.fontSize = 25
+    m.subtitleSyncPlus500.background = ColorPalette.DARKGREY
+    m.subtitleSyncPlus500.color = ColorPalette.WHITE
+    m.subtitleSyncPlus500.focusBackground = ColorPalette.HIGHLIGHT
+    m.subtitleSyncPlus500.focusColor = ColorPalette.WHITE
+
+    m.subtitleSyncMinus100 = m.top.findNode("subtitleSyncMinus100")
+    m.subtitleSyncMinus100.fontSize = 25
+    m.subtitleSyncMinus100.background = ColorPalette.DARKGREY
+    m.subtitleSyncMinus100.color = ColorPalette.WHITE
+    m.subtitleSyncMinus100.focusBackground = ColorPalette.HIGHLIGHT
+    m.subtitleSyncMinus100.focusColor = ColorPalette.WHITE
+
+    m.subtitleSyncMinus500 = m.top.findNode("subtitleSyncMinus500")
+    m.subtitleSyncMinus500.fontSize = 25
+    m.subtitleSyncMinus500.background = ColorPalette.DARKGREY
+    m.subtitleSyncMinus500.color = ColorPalette.WHITE
+    m.subtitleSyncMinus500.focusBackground = ColorPalette.HIGHLIGHT
+    m.subtitleSyncMinus500.focusColor = ColorPalette.WHITE
+
+    m.subtitleSyncReset = m.top.findNode("subtitleSyncReset")
+    m.subtitleSyncReset.fontSize = 25
+    m.subtitleSyncReset.background = ColorPalette.DARKGREY
+    m.subtitleSyncReset.color = ColorPalette.WHITE
+    m.subtitleSyncReset.focusBackground = ColorPalette.HIGHLIGHT
+    m.subtitleSyncReset.focusColor = ColorPalette.WHITE
+
     m.nextUp = m.top.findNode("nextUp")
     m.nextUpInfoLoaded = false
 
@@ -387,14 +428,39 @@ sub onOSDAction()
     end if
 
     if action = "showsyncmenu"
-        dialog = createObject("roSGNode", "StandardDialog")
-        dialog.title = "Subtitle Sync"
-        dialog.message = ["Current Offset: " + m.subtitleOffset.toStr() + " ms"]
-        dialog.buttons = ["-500ms", "-100ms", "Reset (0ms)", "+100ms", "+500ms", "Close"]
-        dialog.observeField("buttonSelected", "onSyncButtonSelected")
-        m.top.getScene().dialog = dialog
+        handleShowsyncmenuAction()
         return
     end if
+end sub
+
+sub handleShowsyncmenuAction()
+    ' Hide the OSD
+    handleHideAction(false)
+
+    m.subtitleTimingButtons.visible = true
+    m.subtitleSyncPlus100.focus = true
+    m.subtitleSyncPlus100.setfocus(true)
+end sub
+
+sub hidesyncmenuAction()
+    m.subtitleSyncPlus100.setFocus(false)
+    m.subtitleSyncPlus100.focus = false
+
+    m.subtitleSyncPlus500.setFocus(false)
+    m.subtitleSyncPlus500.focus = false
+
+    m.subtitleSyncMinus100.setFocus(false)
+    m.subtitleSyncMinus100.focus = false
+
+    m.subtitleSyncMinus500.setFocus(false)
+    m.subtitleSyncMinus500.focus = false
+
+    m.subtitleSyncReset.setFocus(false)
+    m.subtitleSyncReset.focus = false
+
+    m.top.setFocus(true)
+
+    m.subtitleTimingButtons.visible = false
 end sub
 
 ' Only setup caption items if captions are allowed
@@ -513,6 +579,8 @@ sub onVideoContentLoaded()
     m.LoadMetaDataTask.content = []
 
     stopLoadingSpinner()
+
+    hidesyncmenuAction()
 
     ' If we have nothing to play, return to previous screen
     if not isValid(videoContent)
@@ -1228,32 +1296,111 @@ sub refreshLiveOSDContent()
     m.LoadProgramDetailsTask.control = TaskControl.RUN
 end sub
 
-sub onSyncButtonSelected(event)
-    dialog = event.getRoSGNode()
-    index = event.getData()
+sub changeSubtitleTimeOffset(offsetAmount as integer)
+    ' If the subtitles are 60+ seconds off, the user needs to get better subtitles
+    if abs(m.subtitleOffset + offsetAmount) >= 60000 then return
 
-    ' Button index mapping:
-    ' 0: -500 ms | 1: -100 ms | 2: Reset | 3: +100 ms | 4: +500 ms | 5: Close
-
-    if index = 0
-        m.subtitleOffset -= 500
-    else if index = 1
-        m.subtitleOffset -= 100
-    else if index = 2
-        m.subtitleOffset = 0
-    else if index = 3
-        m.subtitleOffset += 100
-    else if index = 4
-        m.subtitleOffset += 500
-    else if index = 5
-        dialog.close = true
-        return
-    end if
-
-    dialog.message = ["Current Offset: " + m.subtitleOffset.toStr() + " ms"]
+    m.subtitleOffset += offsetAmount
+    m.subtitleSyncValue.text = `${tr("Current Offset")}: ${m.subtitleOffset.toStr()} ms`
 end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean
+    if m.subtitleTimingButtons.visible
+        if m.subtitleTimingButtons.isInFocusChain()
+            if not press then return false
+
+            if isStringEqual(key, KeyCode.RIGHT)
+                if m.subtitleSyncMinus500.hasfocus()
+                    m.subtitleSyncMinus500.focus = false
+                    m.subtitleSyncMinus100.focus = true
+                    m.subtitleSyncMinus100.setfocus(true)
+                    return true
+                end if
+
+                if m.subtitleSyncMinus100.hasfocus()
+                    m.subtitleSyncMinus100.focus = false
+                    m.subtitleSyncPlus100.focus = true
+                    m.subtitleSyncPlus100.setfocus(true)
+                    return true
+                end if
+
+                if m.subtitleSyncPlus100.hasfocus()
+                    m.subtitleSyncPlus100.focus = false
+                    m.subtitleSyncPlus500.focus = true
+                    m.subtitleSyncPlus500.setfocus(true)
+                    return true
+                end if
+
+                if m.subtitleSyncPlus500.hasfocus()
+                    m.subtitleSyncPlus500.focus = false
+                    m.subtitleSyncReset.focus = true
+                    m.subtitleSyncReset.setfocus(true)
+                    return true
+                end if
+            end if
+
+            if isStringEqual(key, KeyCode.LEFT)
+                if m.subtitleSyncMinus100.hasfocus()
+                    m.subtitleSyncMinus100.focus = false
+                    m.subtitleSyncMinus500.focus = true
+                    m.subtitleSyncMinus500.setfocus(true)
+                    return true
+                end if
+
+                if m.subtitleSyncPlus100.hasfocus()
+                    m.subtitleSyncPlus100.focus = false
+                    m.subtitleSyncminus100.focus = true
+                    m.subtitleSyncMinus100.setfocus(true)
+                    return true
+                end if
+
+                if m.subtitleSyncPlus500.hasfocus()
+                    m.subtitleSyncPlus500.focus = false
+                    m.subtitleSyncPlus100.focus = true
+                    m.subtitleSyncPlus100.setfocus(true)
+                    return true
+                end if
+
+                if m.subtitleSyncReset.hasfocus()
+                    m.subtitleSyncReset.focus = false
+                    m.subtitleSyncPlus500.focus = true
+                    m.subtitleSyncPlus500.setfocus(true)
+                    return true
+                end if
+            end if
+
+            if isStringEqual(key, KeyCode.OK)
+                if m.subtitleSyncReset.hasfocus()
+                    changeSubtitleTimeOffset(m.subtitleOffset > 0 ? - m.subtitleOffset : abs(m.subtitleOffset))
+                    return true
+                end if
+
+                if m.subtitleSyncMinus100.hasfocus()
+                    changeSubtitleTimeOffset(-100)
+                    return true
+                end if
+
+                if m.subtitleSyncMinus500.hasfocus()
+                    changeSubtitleTimeOffset(-500)
+                    return true
+                end if
+
+                if m.subtitleSyncPlus100.hasfocus()
+                    changeSubtitleTimeOffset(100)
+                    return true
+                end if
+
+                if m.subtitleSyncPlus500.hasfocus()
+                    changeSubtitleTimeOffset(500)
+                    return true
+                end if
+            end if
+
+            hidesyncmenuAction()
+            return true
+        end if
+    end if
+
     ' Keypress handler while user is inside the chapter menu
     if m.chapterMenu.hasFocus()
         if not press then return false

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -94,6 +94,7 @@ sub init()
 
     m.subtitleSyncValue = m.top.findNode("subtitleSyncValue")
     m.subtitleSyncValue.font.size = 26
+    m.subtitleSyncValue.text = `${tr("Current Offset")}: 0 ms`
 
     m.subtitleTimingButtons = m.top.findNode("subtitleTimingButtons")
     m.subtitleTimingButtons.color = ColorPalette.BLACK90

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -53,5 +53,39 @@
     </Rectangle>
 
     <StandardButton id="skipSegment" visible="false" height="85" width="250" translation="[1500, 900]" />
+
+    <Rectangle id="subtitleTimingButtons" height="120" width="560" translation="[100, 900]" visible="false">
+      <Text id="subtitleSyncValue" translation="[10, 20]" text="Current Offset: 0 ms" />
+      <StandardButton
+        id="subtitleSyncMinus500"
+        text="-500ms"
+        translation="[10, 55]"
+        height="50"
+        width="100" />
+      <StandardButton
+        id="subtitleSyncMinus100"
+        text="-100ms"
+        translation="[120, 55]"
+        height="50"
+        width="100" />
+      <StandardButton
+        id="subtitleSyncPlus100"
+        text="+100ms"
+        translation="[230, 55]"
+        height="50"
+        width="100" />
+      <StandardButton
+        id="subtitleSyncPlus500"
+        text="+500ms"
+        translation="[340, 55]"
+        height="50"
+        width="100" />
+      <StandardButton
+        id="subtitleSyncReset"
+        text="Reset"
+        translation="[450, 55]"
+        height="50"
+        width="100" />
+    </Rectangle>
   </children>
 </component>

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -55,7 +55,7 @@
     <StandardButton id="skipSegment" visible="false" height="85" width="250" translation="[1500, 900]" />
 
     <Rectangle id="subtitleTimingButtons" height="120" width="560" translation="[100, 900]" visible="false">
-      <Text id="subtitleSyncValue" translation="[10, 20]" text="Current Offset: 0 ms" />
+      <Text id="subtitleSyncValue" translation="[10, 20]" />
       <StandardButton
         id="subtitleSyncMinus500"
         text="-500ms"

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2265,5 +2265,13 @@
             <source>If auto play next episode is disabled, display the next episode's detail screen after an episode finishes playing. If no next up episode is found, return to the just-played episode's page.</source>
             <translation>If auto play next episode is disabled, display the next episode's detail screen after an episode finishes playing. If no next up episode is found, return to the just-played episode's page.</translation>
         </message>
+        <message>
+            <source>Current Offset</source>
+            <translation>Current Offset</translation>
+        </message>
+        <message>
+            <source>Adjust Subtitle Timing</source>
+            <translation>Adjust Subtitle Timing</translation>
+        </message>
     </context>
 </TS>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Building upon @betilloXann work on the subtitle timing sync:
- Removes the new button in the OSD
- Adds button below OK in the subtitle popup
- Replaces Subtitle Sync popup with an on screen box with sync controls
- Only shows sync button if custom subtitle setting is enabled

This change keeps subtitle elements together in the subtitle popup and allows users to change timing sync while seeing the results in real time.

## Screenshots

Offset Button
![WIN_20260131_15_22_31_Pro](https://github.com/user-attachments/assets/d220089d-26e7-4ff7-bb27-5099bd665617)


Offset Menu
![WIN_20260131_15_22_36_Pro](https://github.com/user-attachments/assets/b840a7ef-83e6-456f-bcd1-ae49bf567050)
