### PR TITLE
Create settings to control sorting of favorites row on home screen

### DIFF
--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -478,12 +478,16 @@ end function
 function loadFavorites() as object
     results = []
 
+    sortField = chainLookupReturn(m.global.session, "user.settings.`ui.home.favoritesSortField`", "random")
+    sortOrder = chainLookupReturn(m.global.session, "user.settings.`ui.home.favoritesSortOrder`", "Ascending")
+
     params = {
         userid: m.global.session.user.id,
         Filters: "IsFavorite",
         Limit: 25,
         recursive: true,
-        sortby: "random",
+        sortby: sortField,
+        sortOrder: sortOrder,
         EnableTotalRecordCount: false
     }
 

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2265,5 +2265,33 @@
             <source>If auto play next episode is disabled, display the next episode's detail screen after an episode finishes playing. If no next up episode is found, return to the just-played episode's page.</source>
             <translation>If auto play next episode is disabled, display the next episode's detail screen after an episode finishes playing. If no next up episode is found, return to the just-played episode's page.</translation>
         </message>
+        <message>
+            <source>Favorites Row</source>
+            <translation>Favorites Row</translation>
+        </message>
+        <message>
+            <source>Settings relating to the favorites row on the home screen.</source>
+            <translation>Settings relating to the favorites row on the home screen.</translation>
+        </message>
+        <message>
+            <source>Sort By Field</source>
+            <translation>Sort By Field</translation>
+        </message>
+        <message>
+            <source>Field to sort the row by.</source>
+            <translation>Field to sort the row by.</translation>
+        </message>
+        <message>
+            <source>Date Created</source>
+            <translation>Date Created</translation>
+        </message>
+        <message>
+            <source>Is Unplayed</source>
+            <translation>Is Unplayed</translation>
+        </message>
+        <message>
+            <source>Sort Order for the row - Ascending,Descending.</source>
+            <translation>Sort Order for the row - Ascending,Descending.</translation>
+        </message>
     </context>
 </TS>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -643,6 +643,70 @@
             ]
           },
           {
+            "title": "Favorites Row",
+            "description": "Settings relating to the favorites row on the home screen.",
+            "children": [
+              {
+                "title": "Sort By Field",
+                "description": "Field to sort the row by.",
+                "settingName": "ui.home.favoritesSortField",
+                "type": "radio",
+                "default": "random",
+                "options": [
+                  {
+                    "title": "Date Created",
+                    "id": "DateCreated"
+                  },
+                  {
+                    "title": "DATE_PLAYED",
+                    "id": "DatePlayed"
+                  },
+                  {
+                    "title": "Is Unplayed",
+                    "id": "IsUnplayed"
+                  },
+                  {
+                    "title": "Name",
+                    "id": "SortName"
+                  },
+                  {
+                    "title": "PLAY_COUNT",
+                    "id": "PlayCount"
+                  },
+                  {
+                    "title": "RELEASE_DATE",
+                    "id": "PremiereDate"
+                  },
+                  {
+                    "title": "Random",
+                    "id": "random"
+                  },
+                  {
+                    "title": "RUNTIME",
+                    "id": "Runtime"
+                  }
+                ]
+              },
+              {
+                "title": "Sort Order",
+                "description": "Sort Order for the row - Ascending,Descending.",
+                "settingName": "ui.home.favoritesSortOrder",
+                "type": "radio",
+                "default": "Ascending",
+                "options": [
+                  {
+                    "title": "Ascending",
+                    "id": "Ascending"
+                  },
+                  {
+                    "title": "Descending",
+                    "id": "Descending"
+                  }
+                ]
+              }
+            ]
+          },
+          {
             "title": "Hide Clock",
             "description": "Hide all clocks in Jellyfin. Jellyfin will need to be closed and reopened for changes to take effect.",
             "settingName": "ui.design.hideclock",

--- a/source/static/whatsNew/3.1.2.json
+++ b/source/static/whatsNew/3.1.2.json
@@ -38,5 +38,9 @@
   {
     "description": "Add manual subtitle synchronization offset",
     "author": "betilloxann"
+  },
+  {
+    "description": "Create settings to control sorting of favorites row on home screen",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Adds 2 new user settings under `User Inferface / General / Favorites Row` allowing users to control the sort field and sort order of the favorites row on the home screen.

Default is unchanged and remains Random.

## Issues
Fixes #692