### PR TITLE
Show search and setting if user presses up rapidly

### DIFF
--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -329,6 +329,11 @@ function onKeyEvent(key as string, press as boolean) as boolean
     end if
 
     if isStringEqual(key, KeyCode.UP)
+        ' In case the user pressed up rapidly and the focused row wasn't able to update in time
+        if m.buttons.opacity < 1
+            toggleButtonsVisibility(true)
+        end if
+
         m.searchButton.focus = true
         m.searchButton.setfocus(true)
         setLastFocus(m.searchButton)


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
If you rapidly press UP on the remote, Roku can't/won't keep up updating the focused row property. Due to this, if on the home screen you press down a few times so the search row hides, then press up many times quickly, the cursor will move to the search row, but the search row won't show.

This PR fixes this so if the cursor moves up past the home rows, it will ensure the search row is shown.