### PR TITLE
Fix crash when returning to audio player view from audio mini player

### DIFF
--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -227,7 +227,7 @@ sub setLastFocus(lastFocusElement)
     end if
 end sub
 
-function audioMiniPlayerIsVisible()
+function audioMiniPlayerIsVisibleInScene()
     scene = m.top.getScene()
     audioMiniPlayer = scene.findNode("audioMiniPlayer")
 
@@ -242,7 +242,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     if m.buttons.isInFocusChain()
         if isStringEqual(key, KeyCode.REPLAY)
-            if not audioMiniPlayerIsVisible() then return true
+            if not audioMiniPlayerIsVisibleInScene() then return true
             m.searchButton.focus = false
             m.settingsButton.focus = false
         end if


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Play an album from the album screen
- Press BACK from the audio player screen to return to the album screen
- Press REPLAY and select the music note to jump back to the audio player screen
- Crash

This PR fixes this bug