### PR TITLE
Use full screen to show episodes on TV season screen

### DIFF
--- a/components/tvshows/TVEpisodeList.bs
+++ b/components/tvshows/TVEpisodeList.bs
@@ -11,7 +11,7 @@ sub init()
     m.thumbStep = 0
 
     m.scrollBar.opacity = .75
-    m.scrollBar.color = ColorPalette.RED
+    m.scrollBar.color = ColorPalette.BLACK77
     m.thumb.color = ColorPalette.LIGHTGREY
 
     m.firstUnwatched = 0
@@ -62,7 +62,7 @@ sub calculateButtonThumbProperties()
     m.scrollBar.visible = true
 
     rowCount = Fix(m.top.content.getChildCount() / m.top.numColumns)
-    m.thumb.height = m.scrollBar.height / rowCount
+    m.thumb.height = m.scrollBar.height / (rowCount + 1)
     m.thumbStep = m.thumb.height
 end sub
 

--- a/components/tvshows/TVEpisodeList.bs
+++ b/components/tvshows/TVEpisodeList.bs
@@ -62,7 +62,13 @@ sub calculateButtonThumbProperties()
     m.scrollBar.visible = true
 
     rowCount = Fix(m.top.content.getChildCount() / m.top.numColumns)
-    m.thumb.height = m.scrollBar.height / (rowCount + 1)
+    displayedRows = rowCount
+
+    if (m.top.content.getChildCount() / m.top.numColumns) > rowCount
+        displayedRows += 1
+    end if
+
+    m.thumb.height = m.scrollBar.height / displayedRows
     m.thumbStep = m.thumb.height
 end sub
 

--- a/components/tvshows/TVEpisodeList.bs
+++ b/components/tvshows/TVEpisodeList.bs
@@ -11,7 +11,7 @@ sub init()
     m.thumbStep = 0
 
     m.scrollBar.opacity = .75
-    m.scrollBar.color = ColorPalette.BLACK77
+    m.scrollBar.color = ColorPalette.RED
     m.thumb.color = ColorPalette.LIGHTGREY
 
     m.firstUnwatched = 0
@@ -20,11 +20,17 @@ sub init()
 
     m.top.observeFieldscoped("currFocusRow", "onCurrFocusRowChange")
     m.top.observeFieldscoped("numRows", "onNumRowsChange")
+    m.top.observeFieldscoped("clippingRect", "onclippingRectChange")
 
     if chainLookupReturn(m.global.session, "user.settings.`ui.tvshows.startListFromUnwatched`", false)
         m.top.jumpToItem = m.firstUnwatched
     end if
 
+    calculateButtonThumbProperties()
+end sub
+
+sub onclippingRectChange()
+    m.scrollBar.height = m.top.clippingRect.height * .90
     calculateButtonThumbProperties()
 end sub
 
@@ -55,8 +61,9 @@ sub calculateButtonThumbProperties()
 
     m.scrollBar.visible = true
 
-    rowCount = Fix(m.top.content.getChildCount() / 2)
-    m.thumbStep = 277 / rowCount
+    rowCount = Fix(m.top.content.getChildCount() / m.top.numColumns)
+    m.thumb.height = m.scrollBar.height / rowCount
+    m.thumbStep = m.thumb.height
 end sub
 
 sub onCurrFocusRowChange()

--- a/components/tvshows/TVSeasonDetails.bs
+++ b/components/tvshows/TVSeasonDetails.bs
@@ -6,10 +6,13 @@ import "pkg:/source/enums/ColorPalette.bs"
 import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/enums/KeyCode.bs"
 import "pkg:/source/enums/TaskControl.bs"
+import "pkg:/source/enums/ViewLoadStatus.bs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
+    m.loadStatus = ViewLoadStatus.INIT
+
     m.top.optionsAvailable = false
     m.defaultClippingRect = "[-10,-10,2020,420]"
 
@@ -172,6 +175,7 @@ sub updateSeason()
     populateOnScreenText()
 
     stopLoadingSpinner()
+    m.loadStatus = ViewLoadStatus.LOADED
 end sub
 
 sub populateOnScreenText()
@@ -227,6 +231,8 @@ sub populateOnScreenText()
 end sub
 
 sub adjustForOverview(hasOverviewText = false)
+    if m.loadStatus <> ViewLoadStatus.INIT then return
+
     title = m.top.findNode("title")
 
     if hasOverviewText
@@ -257,8 +263,8 @@ sub adjustForOverview(hasOverviewText = false)
     m.seasonListRect.height = 570
     m.seasonListRectHeight.keyValue = "[570.0, 1080.0]"
 
-    m.seasonListRect.translation = [100, 355]
-    m.seasonListRectTranslation.keyValue = "[[100, 355], [0, 0]]"
+    m.seasonListRect.translation = [100, 450]
+    m.seasonListRectTranslation.keyValue = "[[100, 450], [0, 0]]"
 
     m.rows.clippingRect = "[-10,-10,2020,540]"
     m.defaultClippingRect = "[-10,-10,2020,540]"

--- a/components/tvshows/TVSeasonDetails.bs
+++ b/components/tvshows/TVSeasonDetails.bs
@@ -1,6 +1,7 @@
 import "pkg:/source/api/baserequest.bs"
 import "pkg:/source/api/Image.bs"
 import "pkg:/source/api/sdk.bs"
+import "pkg:/source/enums/AnimationControl.bs"
 import "pkg:/source/enums/ColorPalette.bs"
 import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/enums/KeyCode.bs"
@@ -10,7 +11,16 @@ import "pkg:/source/utils/misc.bs"
 
 sub init()
     m.top.optionsAvailable = false
+    m.defaultClippingRect = "[-10,-10,2020,420]"
 
+    m.revealEpisodesAnimation = m.top.findNode("revealEpisodesAnimation")
+    m.toplevelTranslation = m.top.findNode("toplevelTranslation")
+    m.seasonListRectTranslation = m.top.findNode("seasonListRectTranslation")
+    m.pickerTranslation = m.top.findNode("pickerTranslation")
+    m.seasonListRectHeight = m.top.findNode("seasonListRectHeight")
+    m.seasonListRectWidth = m.top.findNode("seasonListRectWidth")
+
+    m.toplevel = m.top.findNode("toplevel")
     m.rows = m.top.findNode("picker")
     m.poster = m.top.findNode("seasonPoster")
     m.shuffle = m.top.findNode("shuffle")
@@ -29,8 +39,8 @@ sub init()
     m.overview = m.top.findNode("overview")
     m.overview.ellipsisText = tr("...")
 
-    seasonListRect = m.top.FindNode("seasonListRect")
-    seasonListRect.color = ColorPalette.BLACK77
+    m.seasonListRect = m.top.FindNode("seasonListRect")
+    m.seasonListRect.color = ColorPalette.BLACK77
 
     m.resume = m.top.findNode("resume")
     if isValid(m.resume)
@@ -218,7 +228,6 @@ end sub
 
 sub adjustForOverview(hasOverviewText = false)
     title = m.top.findNode("title")
-    seasonListRect = m.top.FindNode("seasonListRect")
 
     if hasOverviewText
         m.overview.height = 140
@@ -226,8 +235,15 @@ sub adjustForOverview(hasOverviewText = false)
         m.poster.width = 300
         m.playedIndicator.translation = [240, 0]
         title.maxWidth = 1400
-        seasonListRect.height = 450
+
+        m.seasonListRect.height = 450
+        m.seasonListRectHeight.keyValue = "[450.0, 1080.0]"
+
+        m.seasonListRect.translation = [100, 575]
+        m.seasonListRectTranslation.keyValue = "[[100, 575], [0, 0]]"
+
         m.rows.clippingRect = "[-10,-10,2020,420]"
+        m.defaultClippingRect = "[-10,-10,2020,420]"
 
         setFieldText("overview", m.top.seasonData.json.overview)
         return
@@ -237,8 +253,16 @@ sub adjustForOverview(hasOverviewText = false)
     m.poster.height = 330
     m.poster.width = 220
     title.maxWidth = 1480
-    seasonListRect.height = 570
+
+    m.seasonListRect.height = 570
+    m.seasonListRectHeight.keyValue = "[570.0, 1080.0]"
+
+    m.seasonListRect.translation = [100, 355]
+    m.seasonListRectTranslation.keyValue = "[[100, 355], [0, 0]]"
+
     m.rows.clippingRect = "[-10,-10,2020,540]"
+    m.defaultClippingRect = "[-10,-10,2020,540]"
+
     m.playedIndicator.translation = [160, 0]
 end sub
 
@@ -390,6 +414,30 @@ sub createFullDscrDlg()
     end if
 end sub
 
+sub enterEpisodeListFullScreen()
+    if m.toplevel.translation[1] <> 100 then return
+
+    m.seasonListRect.color = ColorPalette.BLACKDD
+    m.toplevelTranslation.reverse = false
+    m.seasonListRectTranslation.reverse = false
+    m.pickerTranslation.reverse = false
+    m.seasonListRectHeight.reverse = false
+    m.seasonListRectWidth.reverse = false
+    m.revealEpisodesAnimation.control = AnimationControl.START
+    m.rows.clippingRect = "[-10,-10,2020,980]"
+end sub
+
+sub exitEpisodeListFullScreen()
+    m.seasonListRect.color = ColorPalette.BLACK77
+    m.toplevelTranslation.reverse = true
+    m.seasonListRectTranslation.reverse = true
+    m.pickerTranslation.reverse = true
+    m.seasonListRectHeight.reverse = true
+    m.seasonListRectWidth.reverse = true
+    m.revealEpisodesAnimation.control = AnimationControl.START
+    m.rows.clippingRect = m.defaultClippingRect
+end sub
+
 ' Handle navigation input from the remote and act on it
 function onKeyEvent(key as string, press as boolean) as boolean
 
@@ -480,6 +528,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 selectedButton.focus = false
                 m.rows.setFocus(true)
                 m.top.lastFocus = m.rows
+                enterEpisodeListFullScreen()
                 return true
             end if
         end if
@@ -496,7 +545,14 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 end if
             end if
 
+            if isStringEqual(key, KeyCode.BACK)
+                exitEpisodeListFullScreen()
+                onButtonSelectedChange()
+                return true
+            end if
+
             if isStringEqual(key, KeyCode.UP)
+                exitEpisodeListFullScreen()
                 onButtonSelectedChange()
                 return true
             end if

--- a/components/tvshows/TVSeasonDetails.xml
+++ b/components/tvshows/TVSeasonDetails.xml
@@ -55,16 +55,47 @@
           <PlayedCheckmark id="playedIndicator" translation="[240, 0]" />
         </Poster>
       </LayoutGroup>
-
-      <Rectangle id='seasonListRect' translation="[-30, 0]" width="1720" height="450">
-        <TVEpisodeList
-          id="picker"
-          clippingRect="[-10,-10,2020,420]"
-          itemComponentName="TVEpisodeListItem"
-          vertFocusAnimationStyle="fixed"
-          translation="[45, 25]" />
-      </Rectangle>
     </LayoutGroup>
+
+    <Rectangle id="seasonListRect" translation="[100, 575]" width="1720" height="450">
+      <TVEpisodeList
+        id="picker"
+        clippingRect="[-10,-10,2020,420]"
+        itemComponentName="TVEpisodeListItem"
+        vertFocusAnimationStyle="fixed"
+        translation="[45, 25]" />
+    </Rectangle>
+
+    <Animation id="revealEpisodesAnimation" duration=".4" repeat="false" easeFunction="linear">
+      <Vector2DFieldInterpolator
+        id="toplevelTranslation"
+        key="[0.0, 1]"
+        keyValue="[[100, 100], [100, -500]]"
+        fieldToInterp="toplevel.translation" />
+
+      <Vector2DFieldInterpolator
+        id="seasonListRectTranslation"
+        key="[0.0, 1]"
+        fieldToInterp="seasonListRect.translation" />
+
+      <Vector2DFieldInterpolator
+        id="pickerTranslation"
+        key="[0.0, 1]"
+        keyValue="[[45, 25], [145, 100]]"
+        fieldToInterp="picker.translation" />
+
+      <FloatFieldInterpolator
+        id="seasonListRectHeight"
+        key="[0.0, 1]"
+        keyValue="[450.0, 1080.0]"
+        fieldToInterp="seasonListRect.height" />
+
+      <FloatFieldInterpolator
+        id="seasonListRectWidth"
+        key="[0.0, 1]"
+        keyValue="[1720.0, 1920.0]"
+        fieldToInterp="seasonListRect.width" />
+    </Animation>
 
   </children>
   <interface>

--- a/source/static/whatsNew/3.1.4.json
+++ b/source/static/whatsNew/3.1.4.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "",
-    "author": ""
+    "description": "Use full screen to show episodes on TV season screen",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- When cursor enters episode list on the TV season screen, maximize the list to use the full screen

## Demo Video
https://github.com/user-attachments/assets/0d34f7c8-60f3-4fee-95f7-f93501d97e86


