### PR TITLE
Keep backdrop image aspect ratio in presentation view

### DIFF
--- a/components/Libraries/MusicLibraryView.xml
+++ b/components/Libraries/MusicLibraryView.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="MusicLibraryView" extends="JFScreen">
   <children>
-    <maskGroup translation="[820, 0]" id="backgroundMask" maskUri="pkg:/images/backgroundmask.png" maskSize="[1220,445]">
-      <poster id="backdrop" loadDisplayMode="scaleToFill" width="1100" height="450" opacity="1" />
-      <poster id="backdropTransition" loadDisplayMode="scaleToFill" width="1100" height="450" opacity="1" />
+    <maskGroup translation="[820, 0]" id="backgroundMask" maskUri="pkg:/images/backgroundmask.png" maskSize="[1220,700]">
+      <poster id="backdrop" loadDisplayMode="scaleToZoom" width="1100" height="700" opacity="1" />
+      <poster id="backdropTransition" loadDisplayMode="scaleToZoom" width="1100" height="700" opacity="1" />
     </maskGroup>
 
     <MarkupGrid

--- a/components/Libraries/VisualLibraryScene.xml
+++ b/components/Libraries/VisualLibraryScene.xml
@@ -2,8 +2,8 @@
 <component name="VisualLibraryScene" extends="JFScreen">
   <children>
     <maskGroup translation="[820, 0]" id="backgroundMask" maskUri="pkg:/images/backgroundmask.png" maskSize="[1220,700]">
-      <poster id="backdrop" loadDisplayMode="scaleToFill" width="1100" height="700" opacity="1" />
-      <poster id="backdropTransition" loadDisplayMode="scaleToFill" width="1100" height="700" opacity="1" />
+      <poster id="backdrop" loadDisplayMode="scaleToZoom" width="1100" height="700" opacity="1" />
+      <poster id="backdropTransition" loadDisplayMode="scaleToZoom" width="1100" height="700" opacity="1" />
     </maskGroup>
 
     <MarkupGrid

--- a/source/static/whatsNew/3.1.4.json
+++ b/source/static/whatsNew/3.1.4.json
@@ -6,5 +6,9 @@
   {
     "description": "Create user-level setting on TV season screen to choose if episodes are displayed in two columns",
     "author": "1hitsong"
+  },
+  {
+    "description": "Keep backdrop image aspect ratio in presentation view",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION


<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- In libraries, the backdrop images used in presentation view now keeps aspect ratio
- Expands mask size in music library to match movie library

## Issues
Fixes #708

## Screenshots
Before
![WIN_20260207_21_11_37_Pro](https://github.com/user-attachments/assets/18109191-306f-4b15-8c40-3b60a700b7a9)

After
![WIN_20260207_21_10_46_Pro](https://github.com/user-attachments/assets/fa7007a1-efea-49f2-a1ba-fc935d4efe64)


