### PR TITLE
Use full screen to show seasons on TV series screen

### DIFF
--- a/components/tvshows/TVSeasonGrid.bs
+++ b/components/tvshows/TVSeasonGrid.bs
@@ -10,7 +10,6 @@ sub init()
     m.scrollBar = m.top.findnode("scrollBar")
     m.thumb = m.top.findnode("thumb")
     m.thumbStep = 0
-    m.rowCount = 1
     m.displayedRows = 1
 
     m.scrollBar.opacity = .75
@@ -20,6 +19,13 @@ sub init()
     m.top.observeFieldscoped("itemFocused", "onItemFocusedChange")
     m.top.observeFieldscoped("numRows", "onNumRowsChange")
     m.top.observeFieldscoped("content", "contentChanged")
+    m.top.observeFieldscoped("clippingRect", "onclippingRectChange")
+end sub
+
+sub onclippingRectChange()
+    m.scrollBar.height = m.top.clippingRect.height * .90
+    calculateButtonThumbProperties()
+    onItemFocusedChange()
 end sub
 
 sub onNumRowsChange()
@@ -49,13 +55,16 @@ sub calculateButtonThumbProperties()
 
     m.scrollBar.visible = true
 
-    m.rowCount = Fix(m.top.content.getChildCount() / 8)
-    m.thumbStep = 227 / m.rowCount
 
-    m.displayedRows = m.rowCount
-    if (m.top.content.getChildCount() / 8) > m.rowCount
-        m.displayedRows += 1
+    rowCount = Fix(m.top.content.getChildCount() / m.top.numColumns)
+    displayedRows = rowCount
+
+    if (m.top.content.getChildCount() / m.top.numColumns) > rowCount
+        displayedRows += 1
     end if
+
+    m.thumb.height = m.scrollBar.height / displayedRows
+    m.thumbStep = m.thumb.height
 end sub
 
 sub onItemFocusedChange()

--- a/components/tvshows/TVSeasonGridItem.bs
+++ b/components/tvshows/TVSeasonGridItem.bs
@@ -41,8 +41,8 @@ sub onHeightChanged()
     m.backdrop.height = calculatedHeight
     m.itemPoster.height = calculatedHeight
     m.posterText.height = calculatedHeight
-    m.title.translation = [0, calculatedHeight + 15]
-    m.itemTextExtra.translation = [0, calculatedHeight + 45]
+    m.title.translation = [0, calculatedHeight]
+    m.itemTextExtra.translation = [0, calculatedHeight + 30]
 end sub
 
 sub onWidthChanged()
@@ -51,8 +51,8 @@ sub onWidthChanged()
     m.posterText.width = m.top.width
     m.title.maxWidth = m.top.width
     m.itemTextExtra.maxWidth = m.top.width
-    m.itemIcon.translation = [m.top.width, 15]
-    m.playedIndicator.translation = [m.top.width - m.playedIndicator.width, 15]
+    m.itemIcon.translation = [m.top.width, 0]
+    m.playedIndicator.translation = [m.top.width - m.playedIndicator.width, 0]
 end sub
 
 sub itemContentChanged()

--- a/components/tvshows/TVSeasonGridItem.xml
+++ b/components/tvshows/TVSeasonGridItem.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="TVSeasonGridItem" extends="Group">
   <children>
-    <Poster id="backdrop" translation="[0,15]" loadDisplayMode="scaleToZoom" uri="pkg:/images/white.9.png" />
-    <Poster id="itemPoster" translation="[0,15]" loadDisplayMode="scaleToZoom" />
+    <Poster id="backdrop" translation="[0,0]" loadDisplayMode="scaleToZoom" uri="pkg:/images/white.9.png" />
+    <Poster id="itemPoster" translation="[0,0]" loadDisplayMode="scaleToZoom" />
 
-    <ScrollingText id="title" horizAlign="left" vertAlign="bottom" font="font:SmallBoldSystemFont" height="34" maxWidth="384" translation="[8,290]" repeatCount="0" />
-    <ScrollingText id="itemTextExtra" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" height="32" maxWidth="384" translation="[8,325]" color="#777777FF" repeatCount="0" />
+    <ScrollingText id="title" horizAlign="left" vertAlign="bottom" font="font:SmallBoldSystemFont" height="34" maxWidth="384" translation="[8,275]" repeatCount="0" />
+    <ScrollingText id="itemTextExtra" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" height="32" maxWidth="384" translation="[8,310]" color="#777777FF" repeatCount="0" />
 
     <Poster id="itemIcon" width="50" height="50" />
     <Text id="posterText" translation="[5,5]" horizAlign="center" vertAlign="center" ellipsizeOnBoundary="true" wrap="true" />

--- a/components/tvshows/TVSeriesDetails.bs
+++ b/components/tvshows/TVSeriesDetails.bs
@@ -11,7 +11,7 @@ sub init()
     m.top.optionsAvailable = false
     m.extrasSlider = m.top.findNode("tvSeasonExtras")
     m.getShuffleEpisodesTask = createObject("roSGNode", "getShuffleEpisodesTask")
-    m.extrasSlider.visible = true
+    m.extrasSlider.visible = false
     m.seasons = m.top.findNode("seasons")
     m.seasons.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
     m.overview = m.top.findNode("overview")
@@ -23,6 +23,16 @@ sub init()
 
     seasonListRect = m.top.FindNode("seasonListRect")
     seasonListRect.color = ColorPalette.BLACK77
+    m.defaultClippingRect = "[-10,-10,2020,370]"
+
+    m.toplevel = m.top.findnode("toplevel")
+    m.seasonListRect = m.top.findnode("seasonListRect")
+    m.revealSeasonsAnimation = m.top.findNode("revealSeasonsAnimation")
+    m.toplevelTranslation = m.top.findNode("toplevelTranslation")
+    m.seasonListRectTranslation = m.top.findNode("seasonListRectTranslation")
+    m.seasonsTranslation = m.top.findNode("seasonsTranslation")
+    m.seasonListRectHeight = m.top.findNode("seasonListRectHeight")
+    m.seasonListRectWidth = m.top.findNode("seasonListRectWidth")
 
     m.buttonGrp = m.top.findNode("buttons")
     m.buttonCount = m.buttonGrp.getChildCount()
@@ -367,6 +377,30 @@ sub createFullDscrDlg()
     end if
 end sub
 
+sub enterEpisodeListFullScreen()
+    if m.toplevel.translation[1] <> 100 then return
+
+    m.seasonListRect.color = ColorPalette.BLACKDD
+    m.toplevelTranslation.reverse = false
+    m.seasonListRectTranslation.reverse = false
+    m.seasonsTranslation.reverse = false
+    m.seasonListRectHeight.reverse = false
+    m.seasonListRectWidth.reverse = false
+    m.revealSeasonsAnimation.control = AnimationControl.START
+    m.seasons.clippingRect = "[-10,-10,2020,980]"
+end sub
+
+sub exitEpisodeListFullScreen()
+    m.seasonListRect.color = ColorPalette.BLACK77
+    m.toplevelTranslation.reverse = true
+    m.seasonListRectTranslation.reverse = true
+    m.seasonsTranslation.reverse = true
+    m.seasonListRectHeight.reverse = true
+    m.seasonListRectWidth.reverse = true
+    m.revealSeasonsAnimation.control = AnimationControl.START
+    m.seasons.clippingRect = m.defaultClippingRect
+end sub
+
 function onKeyEvent(key as string, press as boolean) as boolean
     if m.buttonGrp.isInFocusChain()
         if isStringEqual(key, KeyCode.UP)
@@ -437,6 +471,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 selectedButton.focus = false
                 m.seasons.setFocus(true)
                 m.top.lastFocus = m.seasons
+                enterEpisodeListFullScreen()
                 return true
             end if
         end if
@@ -464,19 +499,23 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     if seasonRow.isInFocusChain()
         if isStringEqual(key, KeyCode.DOWN)
-            extrasSection.setFocus(true)
-            group = m.global.sceneManager.callFunc("getActiveScene")
-            group.lastFocus = extrasSection
-            m.top.findNode("VertSlider").reverse = false
-            m.top.findNode("extrasFader").reverse = false
-            m.top.findNode("pplAnime").control = AnimationControl.START
-            return true
+            return false
+
+            ' extrasSection.setFocus(true)
+            ' group = m.global.sceneManager.callFunc("getActiveScene")
+            ' group.lastFocus = extrasSection
+            ' m.top.findNode("VertSlider").reverse = false
+            ' m.top.findNode("extrasFader").reverse = false
+            ' m.top.findNode("pplAnime").control = AnimationControl.START
         end if
 
-        if isStringEqual(key, KeyCode.UP)
+        if isStringEqual(key, KeyCode.BACK)
+            exitEpisodeListFullScreen()
             onButtonSelectedChange()
             return true
         end if
+
+        return false
     end if
 
     if m.overview.isInFocusChain()

--- a/components/tvshows/TVSeriesDetails.xml
+++ b/components/tvshows/TVSeriesDetails.xml
@@ -58,24 +58,55 @@
           <PlayedCheckmark id="playedIndicator" translation="[240, 0]" />
         </Poster>
       </LayoutGroup>
-
-      <Rectangle id='seasonListRect' translation="[-30, 0]" width="1720" height="400">
-        <TVSeasonGrid
-          id="seasons"
-          numColumns="8"
-          numRows="2"
-          clippingRect="[-10,-10,2020,370]"
-          vertFocusAnimationStyle="fixed"
-          itemComponentName="TVSeasonGridItem"
-          itemSpacing="[20, 50]"
-          itemSize="[180, 320]"
-          rowHeights="[320]"
-          drawFocusFeedback="true"
-          translation="[45, 25]" />
-      </Rectangle>
     </LayoutGroup>
 
+    <Rectangle id='seasonListRect' translation="[100, 575]" width="1720" height="400">
+      <TVSeasonGrid
+        id="seasons"
+        numColumns="8"
+        numRows="3"
+        clippingRect="[-10,-10,2020,370]"
+        vertFocusAnimationStyle="fixedFocusWrap"
+        itemComponentName="TVSeasonGridItem"
+        itemSpacing="[20, 50]"
+        itemSize="[180, 320]"
+        rowHeights="[320]"
+        drawFocusFeedback="true"
+        translation="[45, 25]" />
+    </Rectangle>
+
     <ExtrasSlider visible="false" id="tvSeasonExtras" />
+    <Animation id="revealSeasonsAnimation" duration=".4" repeat="false" easeFunction="linear">
+      <Vector2DFieldInterpolator
+        id="toplevelTranslation"
+        key="[0.0, 1]"
+        keyValue="[[100, 100], [100, -500]]"
+        fieldToInterp="toplevel.translation" />
+
+      <Vector2DFieldInterpolator
+        id="seasonListRectTranslation"
+        key="[0.0, 1]"
+        keyValue="[[100, 575], [0, 0]]"
+        fieldToInterp="seasonListRect.translation" />
+
+      <Vector2DFieldInterpolator
+        id="seasonsTranslation"
+        key="[0.0, 1]"
+        keyValue="[[45, 25], [145, 100]]"
+        fieldToInterp="seasons.translation" />
+
+      <FloatFieldInterpolator
+        id="seasonListRectHeight"
+        key="[0.0, 1]"
+        keyValue="[400.0, 1080.0]"
+        fieldToInterp="seasonListRect.height" />
+
+      <FloatFieldInterpolator
+        id="seasonListRectWidth"
+        key="[0.0, 1]"
+        keyValue="[1720.0, 1920.0]"
+        fieldToInterp="seasonListRect.width" />
+    </Animation>
   </children>
   <interface>
     <function name="getFocusedItem" />

--- a/source/static/whatsNew/3.1.4.json
+++ b/source/static/whatsNew/3.1.4.json
@@ -10,5 +10,9 @@
   {
     "description": "Keep backdrop image aspect ratio in presentation view",
     "author": "1hitsong"
+  },
+  {
+    "description": "Use full screen to show seasons on TV series screen",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- When cursor moves into season grid, expand grid to use full screen
- Makes season grid wrap
- Back button closes full screen and returns cursor to buttons
- Hides Extras slider and comments out activation code - this will be moved to a button in a follow up PR