### PR TITLE
Add Dolby Vision HDR10, HDR10+, HLG fallback video ranges

### DIFF
--- a/source/static/whatsNew/3.1.6.json
+++ b/source/static/whatsNew/3.1.6.json
@@ -2,5 +2,9 @@
   {
     "description": "Fix chapter list menu padding",
     "author": "noahpodgurski"
+  },
+  {
+    "description": "Add compatibility with more HDR formats",
+    "author": "FractalBoy"
   }
 ]

--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -602,6 +602,7 @@ function getCodecProfiles(videoCodec = string.EMPTY as string) as object
     end if
     if dp.Hdr10Plus
         hevcVideoRangeTypes = hevcVideoRangeTypes + "|HDR10Plus|DOVIWithHDR10Plus"
+        vp9VideoRangeTypes = vp9VideoRangeTypes + "|HDR10Plus|DOVIWithHDR10Plus"
         av1VideoRangeTypes = av1VideoRangeTypes + "|HDR10Plus|DOVIWithHDR10Plus"
     end if
     if dp.HLG

--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -601,6 +601,7 @@ function getCodecProfiles(videoCodec = string.EMPTY as string) as object
         av1VideoRangeTypes = av1VideoRangeTypes + "|HDR10|DOVIWithHDR10"
     end if
     if dp.Hdr10Plus
+        hevcVideoRangeTypes = hevcVideoRangeTypes + "|HDR10Plus|DOVIWithHDR10Plus"
         av1VideoRangeTypes = av1VideoRangeTypes + "|HDR10Plus|DOVIWithHDR10Plus"
     end if
     if dp.HLG

--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -601,7 +601,7 @@ function getCodecProfiles(videoCodec = string.EMPTY as string) as object
         av1VideoRangeTypes = av1VideoRangeTypes + "|HDR10|DOVIWithHDR10"
     end if
     if dp.Hdr10Plus
-        av1VideoRangeTypes = av1VideoRangeTypes + "|HDR10+|DOVIWithHDR10Plus"
+        av1VideoRangeTypes = av1VideoRangeTypes + "|HDR10Plus|DOVIWithHDR10Plus"
     end if
     if dp.HLG
         hevcVideoRangeTypes = hevcVideoRangeTypes + "|HLG|DOVIWithHLG"

--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -589,10 +589,10 @@ function getCodecProfiles(videoCodec = string.EMPTY as string) as object
     end if
 
     ' HDR SUPPORT
-    h264VideoRangeTypes = "SDR"
-    hevcVideoRangeTypes = "SDR"
-    vp9VideoRangeTypes = "SDR"
-    av1VideoRangeTypes = "SDR"
+    h264VideoRangeTypes = "SDR|DOVIWithSDR"
+    hevcVideoRangeTypes = "SDR|DOVIWithSDR"
+    vp9VideoRangeTypes = "SDR|DOVIWithSDR"
+    av1VideoRangeTypes = "SDR|DOVIWithSDR"
 
     dp = di.GetDisplayProperties()
     if dp.Hdr10

--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -596,23 +596,23 @@ function getCodecProfiles(videoCodec = string.EMPTY as string) as object
 
     dp = di.GetDisplayProperties()
     if dp.Hdr10
-        hevcVideoRangeTypes = hevcVideoRangeTypes + "|HDR10"
-        vp9VideoRangeTypes = vp9VideoRangeTypes + "|HDR10"
-        av1VideoRangeTypes = av1VideoRangeTypes + "|HDR10"
+        hevcVideoRangeTypes = hevcVideoRangeTypes + "|HDR10|DOVIWithHDR10"
+        vp9VideoRangeTypes = vp9VideoRangeTypes + "|HDR10|DOVIWithHDR10"
+        av1VideoRangeTypes = av1VideoRangeTypes + "|HDR10|DOVIWithHDR10"
     end if
     if dp.Hdr10Plus
-        av1VideoRangeTypes = av1VideoRangeTypes + "|HDR10+"
+        av1VideoRangeTypes = av1VideoRangeTypes + "|HDR10+|DOVIWithHDR10Plus"
     end if
     if dp.HLG
-        hevcVideoRangeTypes = hevcVideoRangeTypes + "|HLG"
-        vp9VideoRangeTypes = vp9VideoRangeTypes + "|HLG"
-        av1VideoRangeTypes = av1VideoRangeTypes + "|HLG"
+        hevcVideoRangeTypes = hevcVideoRangeTypes + "|HLG|DOVIWithHLG"
+        vp9VideoRangeTypes = vp9VideoRangeTypes + "|HLG|DOVIWithHLG"
+        av1VideoRangeTypes = av1VideoRangeTypes + "|HLG|DOVIWithHLG"
     end if
     if dp.DolbyVision
-        h264VideoRangeTypes = h264VideoRangeTypes + "|DOVI"
-        hevcVideoRangeTypes = hevcVideoRangeTypes + "|DOVI"
+        h264VideoRangeTypes = h264VideoRangeTypes + "|DOVI|DOVIWithHDR10|DOVIWithHDR10Plus|DOVIWithHLG"
+        hevcVideoRangeTypes = hevcVideoRangeTypes + "|DOVI|DOVIWithHDR10|DOVIWithHDR10Plus|DOVIWithHLG"
         'vp9VideoRangeTypes = vp9VideoRangeTypes + ",DOVI" no evidence that vp9 can hold DOVI
-        av1VideoRangeTypes = av1VideoRangeTypes + "|DOVI"
+        av1VideoRangeTypes = av1VideoRangeTypes + "|DOVI|DOVIWithHDR10|DOVIWithHDR10Plus|DOVIWithHLG"
     end if
 
     ' H264

--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -589,6 +589,7 @@ function getCodecProfiles(videoCodec = string.EMPTY as string) as object
     end if
 
     ' HDR SUPPORT
+    ' See https://github.com/jellyfin/jellyfin/blob/master/Jellyfin.Data/Enums/VideoRangeType.cs for valid range types
     h264VideoRangeTypes = "SDR|DOVIWithSDR"
     hevcVideoRangeTypes = "SDR|DOVIWithSDR"
     vp9VideoRangeTypes = "SDR|DOVIWithSDR"


### PR DESCRIPTION
## Changes
Currently, the Jellyfin client for Roku doesn't recognize the DOVIWith* video ranges, even when compatible with the client. It always ends up transcoding the video, even when it should direct play. Additionally, because it's transcoded, it ends up SDR when it could direct play as DOVI/HDR10/HDR10+.

I also noticed that the string "HDR10+" is being used even though the enum in Jellyfin is HDR10Plus, so it seems like that would be breaking HDR10+ entirely?

I could be wrong about all this - just submitting this now because it seems like a straightforward change. I plan on testing tonight when I get home from work.