### PR TITLE
Show Channel Logo Beside Channel Title In TV Guide

### DIFF
--- a/components/liveTv/ChannelInfo.bs
+++ b/components/liveTv/ChannelInfo.bs
@@ -35,7 +35,7 @@ sub onWidthChanged()
 
     m.channelLogo.width = logoWidth
     m.channelTitle.maxWidth = titleWidth
-    m.channelTitle.translation = `[${titleTranslationHorizontal}, 0]`
+    m.channelTitle.translation = [titleTranslationHorizontal, 0]
 
     m.borderTop.width = m.top.width
     m.backdrop.width = m.top.width
@@ -65,10 +65,14 @@ sub contentChanged()
         m.channelTitle.text = itemData.LookupCI("title")
     end if
 
+    toggleChannelIdVisibility()
+end sub
+
+sub toggleChannelIdVisibility()
     if isValidAndNotEmpty(m.channelLogo.uri) and isValidAndNotEmpty(m.channelTitle.text)
         m.channelLogo.visible = true
         m.channelTitle.visible = true
-    else if isValidAndNotEmpty(m.channelTitle.uri)
+    else if isValidAndNotEmpty(m.channelLogo.uri)
         m.channelLogo.visible = true
         m.channelTitle.visible = false
     else

--- a/components/liveTv/ChannelInfo.bs
+++ b/components/liveTv/ChannelInfo.bs
@@ -16,17 +16,6 @@ sub init()
     m.channelTitle.color = ColorPalette.OFFWHITE
 end sub
 
-sub onLoadStatusChanged()
-    if m.channelLogo.loadStatus <> PosterLoadStatus.LOADING
-        m.channelLogo.unobserveFieldScoped("loadStatus")
-    end if
-
-    if m.channelLogo.loadStatus = PosterLoadStatus.READY
-        m.channelLogo.visible = true
-        return
-    end if
-end sub
-
 sub onWidthChanged()
     logoWidth = int(m.top.width / 3)
 
@@ -48,36 +37,20 @@ sub onHeightChanged()
 end sub
 
 sub contentChanged()
-    itemData = m.top.content
-
-    if not isValid(itemData) then return
-
     ' Reset all values due to Roku's component reuse
     m.channelLogo.uri = ""
     m.channelTitle.text = ""
 
+    itemData = m.top.content
+
+    if not isValid(itemData) then return
+
     if isValidAndNotEmpty(itemData.LookupCI("hdsmalliconurl"))
-        m.channelLogo.observeFieldScoped("loadStatus", "onLoadStatusChanged")
         m.channelLogo.uri = itemData.LookupCI("hdsmalliconurl")
     end if
 
     if isValid(itemData.LookupCI("title"))
         m.channelTitle.text = itemData.LookupCI("title")
-    end if
-
-    toggleChannelIdVisibility()
-end sub
-
-sub toggleChannelIdVisibility()
-    if isValidAndNotEmpty(m.channelLogo.uri) and isValidAndNotEmpty(m.channelTitle.text)
-        m.channelLogo.visible = true
-        m.channelTitle.visible = true
-    else if isValidAndNotEmpty(m.channelLogo.uri)
-        m.channelLogo.visible = true
-        m.channelTitle.visible = false
-    else
-        m.channelLogo.visible = false
-        m.channelTitle.visible = true
     end if
 
 end sub

--- a/components/liveTv/ChannelInfo.bs
+++ b/components/liveTv/ChannelInfo.bs
@@ -22,17 +22,23 @@ sub onLoadStatusChanged()
     end if
 
     if m.channelLogo.loadStatus = PosterLoadStatus.READY
-        m.channelTitle.visible = false
         m.channelLogo.visible = true
         return
     end if
 end sub
 
 sub onWidthChanged()
-    m.channelLogo.width = m.top.width
+    logoWidth = int(m.top.width / 3)
+
+    titleTranslationHorizontal = logoWidth + 10
+    titleWidth = m.top.width - titleTranslationHorizontal
+
+    m.channelLogo.width = logoWidth
+    m.channelTitle.maxWidth = titleWidth
+    m.channelTitle.translation = `[${titleTranslationHorizontal}, 0]`
+
     m.borderTop.width = m.top.width
     m.backdrop.width = m.top.width
-    m.channelTitle.maxWidth = m.top.width - 20
 end sub
 
 sub onHeightChanged()
@@ -49,16 +55,25 @@ sub contentChanged()
     ' Reset all values due to Roku's component reuse
     m.channelLogo.uri = ""
     m.channelTitle.text = ""
-    m.channelTitle.visible = true
 
     if isValidAndNotEmpty(itemData.LookupCI("hdsmalliconurl"))
         m.channelLogo.observeFieldScoped("loadStatus", "onLoadStatusChanged")
         m.channelLogo.uri = itemData.LookupCI("hdsmalliconurl")
-    else
-        m.channelLogo.visible = false
     end if
 
     if isValid(itemData.LookupCI("title"))
         m.channelTitle.text = itemData.LookupCI("title")
     end if
+
+    if isValidAndNotEmpty(m.channelLogo.uri) and isValidAndNotEmpty(m.channelTitle.text)
+        m.channelLogo.visible = true
+        m.channelTitle.visible = true
+    else if isValidAndNotEmpty(m.channelTitle.uri)
+        m.channelLogo.visible = true
+        m.channelTitle.visible = false
+    else
+        m.channelLogo.visible = false
+        m.channelTitle.visible = true
+    end if
+
 end sub

--- a/components/liveTv/ChannelInfo.xml
+++ b/components/liveTv/ChannelInfo.xml
@@ -4,7 +4,7 @@
     <Rectangle id="backdrop" />
 
     <ScrollingText id="channelTitle" horizAlign="left" vertAlign="center" translation="[10, 0]" />
-    <Poster id="channelLogo" visible="false" translation="[0, 0]" loadDisplayMode="scaleToFit" />
+    <Poster id="channelLogo" translation="[0, 0]" loadDisplayMode="scaleToFit" />
 
     <Rectangle id="borderTop" height="1" />
   </children>

--- a/source/static/whatsNew/3.1.6.json
+++ b/source/static/whatsNew/3.1.6.json
@@ -14,5 +14,9 @@
   {
     "description": "Fix back button logic on home screen",
     "author": "jimdogx"
+  },
+  {
+    "description": "Show channel logo next to channel title in TV Guide",
+    "author": "michaelcresswell"
   }
 ]


### PR DESCRIPTION
## Changes
Show channel logos beside the channel title in the header column on the TV Guide, instead of only showing one of the two.

Uses 1/3 of the channel header column for the channel logo and the remainder of the column for the title text.

## Issues
Fixes #688, #734 

## Screenshots

Before:
![Before](https://github.com/user-attachments/assets/6a618bae-9bb4-437c-acb1-0e5f3eed33a7)

After:
![After](https://github.com/user-attachments/assets/eb078404-8a0e-48de-be1f-cfd04b12c6f1)
