### PR TITLE
Fix top 3 crashes from Roku crash log

### DIFF
--- a/components/data/MovieData.bs
+++ b/components/data/MovieData.bs
@@ -10,7 +10,7 @@ sub setFields()
     m.top.id = json.id
     m.top.Title = json.name
     m.top.Description = json.overview
-    m.top.favorite = json.UserData.isFavorite
+    m.top.favorite = chainLookupReturn(json, "UserData.isFavorite", false)
     m.top.watched = chainLookup(json, "UserData.played")
     m.top.Type = "Movie"
 

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -629,7 +629,7 @@ sub onRefreshMovieDetailsDataEvent()
 
     currentScene = m.global.sceneManager.callFunc("getActiveScene")
 
-    if isValid(currentScene.itemContent)
+    if isChainValid(currentScene, "itemContent")
         ' Check if the content ID has changed since we last rendered the movie detail view
         contentIDChanged = false
 

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -766,6 +766,11 @@ function CreateSeriesDetailsGroup(seriesID as string) as dynamic
         enableTotalRecordCount: false
     })
 
+    if not isChainValid(apiSeasonData, "items")
+        stopLoadingSpinner()
+        return invalid
+    end if
+
     ' Divert to season details if user setting goStraightToEpisodeListing is enabled and only one season exists.
     if m.global.session.user.settings["ui.tvshows.goStraightToEpisodeListing"]
         if isChainValid(apiSeasonData, "items")

--- a/source/static/whatsNew/3.1.6.json
+++ b/source/static/whatsNew/3.1.6.json
@@ -18,5 +18,17 @@
   {
     "description": "Show channel logo next to channel title in TV Guide",
     "author": "michaelcresswell"
+  },
+  {
+    "description": "Fix TV series screen crash when API returns no data",
+    "author": "1hitsong"
+  },
+  {
+    "description": "Fix movie detail screen crash when data is in unexpected state",
+    "author": "1hitsong"
+  },
+  {
+    "description": "Fix movie data component crash when no userdata is returned by API",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Fix TV series screen crash when API returns no data
  - Fixed by adding valid check before using data

- Fix movie detail screen crash when data is in unexpected state
  - Fixed by adding valid check before using data

- Fix movie data component crash when no userdata is returned by API
  - Fixed by adding valid check before using data
