### PR TITLE
Fix multi-line subtitles going off bottom of screen

### DIFF
--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -193,7 +193,7 @@ function prepareStyles(styles as object, rect, lineCount = 1 as integer) as obje
     ' Line
     if not isStringEqual(captionLine, string.EMPTY)
         captionLineHeight = (rect.BoundingRect().height / lineCount)
-        verticalPosition = processLineCue(captionLine, captionLineHeight)
+        verticalPosition = processLineCue(captionLine, captionLineHeight, rect.BoundingRect().height)
     end if
 
     ' Position
@@ -220,13 +220,13 @@ function processPositionCue(captionPosition as string, captionLineWidth as float
     return calculatedPosition
 end function
 
-function processLineCue(captionLine as string, captionLineHeight as float) as integer
+function processLineCue(captionLine as string, captionLineHeight as float, captionTotalHeight as float) as integer
     ' A percentage
     if captionLine.Instr("%") <> -1
         calculatedPosition = 1080 * (val(captionLine) / 100)
 
-        if calculatedPosition + captionLineHeight > 1080
-            calculatedPosition = 1080 - captionLineHeight
+        if calculatedPosition + captionTotalHeight > 1080
+            calculatedPosition = 1080 - captionTotalHeight
         end if
 
         return calculatedPosition
@@ -241,8 +241,8 @@ function processLineCue(captionLine as string, captionLineHeight as float) as in
     if lineValue >= 0
         calculatedPosition = lineValue * captionLineHeight
 
-        if calculatedPosition + captionLineHeight > 1080
-            calculatedPosition = 1080 - captionLineHeight
+        if calculatedPosition + captionTotalHeight > 1080
+            calculatedPosition = 1080 - captionTotalHeight
         end if
 
         return calculatedPosition
@@ -250,6 +250,10 @@ function processLineCue(captionLine as string, captionLineHeight as float) as in
 
     ' A negative line value. Count from the bottom
     calculatedPosition = 1080 - Abs(lineValue * captionLineHeight)
+
+    if calculatedPosition + captionTotalHeight > 1080
+        calculatedPosition = 1080 - captionTotalHeight
+    end if
 
     if calculatedPosition < 0
         calculatedPosition = 0

--- a/source/static/whatsNew/3.1.6.json
+++ b/source/static/whatsNew/3.1.6.json
@@ -30,5 +30,9 @@
   {
     "description": "Fix movie data component crash when no userdata is returned by API",
     "author": "1hitsong"
+  },
+  {
+    "description": "Fix multi-line subtitles going off bottom of screen",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Changes logic that evaluates if subtitles will go off the bottom of the screen to use height of entire subtitle block instead of height of single line.

## Issues
Fixes #544

## Screenshots

Before
![WIN_20260221_14_15_35_Pro](https://github.com/user-attachments/assets/4e502173-acd1-4c1d-b3db-857276047561)

After
![WIN_20260221_14_14_49_Pro](https://github.com/user-attachments/assets/0b809076-a987-4184-acd9-0e2337f511ac)

