### PR TITLE
Only display information for video type streams

### DIFF
--- a/components/GetPlaybackInfoTask.bs
+++ b/components/GetPlaybackInfoTask.bs
@@ -104,7 +104,13 @@ function GetTranscodingStats(deviceSession)
     end if
 
     if havePlaybackInfo()
-        stream = m.playbackInfo.mediaSources[0].MediaStreams[0]
+        stream = invalid
+        for each mediaStream in m.playbackInfo.mediaSources[0].MediaStreams
+            if mediaStream.Type = "Video"
+                stream = mediaStream
+                exit for
+            end if
+        end for
         sessionStats.data.push("<header>" + tr("Stream Information") + "</header>")
         if isValid(stream.Container)
             data = "<b>• " + tr("Container") + ":</b> " + stream.Container

--- a/components/GetPlaybackInfoTask.bs
+++ b/components/GetPlaybackInfoTask.bs
@@ -106,7 +106,7 @@ function GetTranscodingStats(deviceSession)
     if havePlaybackInfo()
         stream = invalid
         for each mediaStream in m.playbackInfo.mediaSources[0].MediaStreams
-            if mediaStream.Type = "Video"
+            if isStringEqual(chainLookup(mediaStream, "Type"), MediaStreamType.VIDEO)
                 stream = mediaStream
                 exit for
             end if

--- a/components/GetPlaybackInfoTask.bs
+++ b/components/GetPlaybackInfoTask.bs
@@ -1,5 +1,6 @@
 import "pkg:/source/api/baserequest.bs"
 import "pkg:/source/api/sdk.bs"
+import "pkg:/source/enums/MediaStreamType.bs"
 import "pkg:/source/enums/PlaybackMethod.bs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/deviceCapabilities.bs"

--- a/components/GetPlaybackInfoTask.bs
+++ b/components/GetPlaybackInfoTask.bs
@@ -150,11 +150,7 @@ function GetTranscodingStats(deviceSession)
 end function
 
 function getVideoStream()
-    if not isValid(m.playbackInfo)
-        return invalid
-    end if
-
-    if not isValid(m.playbackInfo.mediaSources)
+    if not isChainValid(m.playbackInfo, "mediaSources")
         return invalid
     end if
 
@@ -162,11 +158,7 @@ function getVideoStream()
         return invalid
     end if
 
-    if not isValid(m.playbackInfo.mediaSources[0].MediaStreams)
-        return invalid
-    end if
-
-    if m.playbackInfo.mediaSources[0].MediaStreams.Count() <= 0
+    if not isValidAndNotEmpty(m.playbackInfo.mediaSources[0].MediaStreams)
         return invalid
     end if
 

--- a/components/GetPlaybackInfoTask.bs
+++ b/components/GetPlaybackInfoTask.bs
@@ -104,14 +104,9 @@ function GetTranscodingStats(deviceSession)
         sessionStats.data.push("<b>" + tr("The source file is entirely compatible with this client and the session is receiving the file without modifications.") + "</b>")
     end if
 
-    if havePlaybackInfo()
-        stream = invalid
-        for each mediaStream in m.playbackInfo.mediaSources[0].MediaStreams
-            if isStringEqual(chainLookup(mediaStream, "Type"), MediaStreamType.VIDEO)
-                stream = mediaStream
-                exit for
-            end if
-        end for
+    stream = getVideoStream()
+
+    if isValid(stream)
         sessionStats.data.push("<header>" + tr("Stream Information") + "</header>")
         if isValid(stream.Container)
             data = "<b>• " + tr("Container") + ":</b> " + stream.Container
@@ -154,34 +149,34 @@ function GetTranscodingStats(deviceSession)
     return sessionStats
 end function
 
-function havePlaybackInfo()
+function getVideoStream()
     if not isValid(m.playbackInfo)
-        return false
+        return invalid
     end if
 
     if not isValid(m.playbackInfo.mediaSources)
-        return false
+        return invalid
     end if
 
     if m.playbackInfo.mediaSources.Count() <= 0
-        return false
+        return invalid
     end if
 
     if not isValid(m.playbackInfo.mediaSources[0].MediaStreams)
-        return false
+        return invalid
     end if
 
     if m.playbackInfo.mediaSources[0].MediaStreams.Count() <= 0
-        return false
+        return invalid
     end if
 
     for each mediaStream in m.playbackInfo.mediaSources[0].MediaStreams
         if isStringEqual(chainLookup(mediaStream, "Type"), MediaStreamType.VIDEO)
-            return true
+            return mediaStream
         end if
     end for
 
-    return false
+    return invalid
 end function
 
 function getDisplayBitrate(bitrate)

--- a/components/GetPlaybackInfoTask.bs
+++ b/components/GetPlaybackInfoTask.bs
@@ -175,7 +175,13 @@ function havePlaybackInfo()
         return false
     end if
 
-    return true
+    for each mediaStream in m.playbackInfo.mediaSources[0].MediaStreams
+        if isStringEqual(chainLookup(mediaStream, "Type"), MediaStreamType.VIDEO)
+            return true
+        end if
+    end for
+
+    return false
 end function
 
 function getDisplayBitrate(bitrate)

--- a/source/static/whatsNew/3.1.6.json
+++ b/source/static/whatsNew/3.1.6.json
@@ -32,7 +32,7 @@
     "author": "1hitsong"
   },
   {
-    "description": "Only display information for video type media streams",
+    "description": "In playback info popup, ensure video media stream data is shown",
     "author": "FractalBoy"
   }
 ]

--- a/source/static/whatsNew/3.1.6.json
+++ b/source/static/whatsNew/3.1.6.json
@@ -30,5 +30,9 @@
   {
     "description": "Fix movie data component crash when no userdata is returned by API",
     "author": "1hitsong"
+  },
+  {
+    "description": "Only display information for video type media streams",
+    "author": "FractalBoy"
   }
 ]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
When viewing video information, there is no filtering done of multiple streams; the first stream is always the one that is used. However, in some cases, subtitle or audio streams are the first stream.

This change picks the video stream from the list of media streams.

Before:
<img width="1978" height="1489" alt="image" src="https://github.com/user-attachments/assets/7de2f232-dc88-4993-bef4-72206001b4d1" />

After:
<img width="1978" height="1489" alt="image" src="https://github.com/user-attachments/assets/0d0e8ae4-df28-48fa-b431-221aa76118c6" />
