### PR TITLE
Direct play anamorphic video

### DIFF
--- a/source/static/whatsNew/3.1.6.json
+++ b/source/static/whatsNew/3.1.6.json
@@ -34,5 +34,9 @@
   {
     "description": "In playback info popup, ensure video media stream data is shown",
     "author": "FractalBoy"
+  },
+  {
+    "description": "Allow direct play of anamorphic video",
+    "author": "FractalBoy"
   }
 ]

--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -641,12 +641,6 @@ function getCodecProfiles(videoCodec = string.EMPTY as string) as object
         "Codec": "h264",
         "Conditions": [
             {
-                "Condition": "NotEquals",
-                "Property": "IsAnamorphic",
-                "Value": "true",
-                "IsRequired": false
-            },
-            {
                 "Condition": "LessThanEqual",
                 "Property": "VideoBitDepth",
                 "Value": "8",
@@ -812,12 +806,6 @@ function getCodecProfiles(videoCodec = string.EMPTY as string) as object
             "Type": "Video",
             "Codec": "hevc",
             "Conditions": [
-                {
-                    "Condition": "NotEquals",
-                    "Property": "IsAnamorphic",
-                    "Value": "true",
-                    "IsRequired": false
-                },
                 {
                     "Condition": "EqualsAny",
                     "Property": "VideoProfile",


### PR DESCRIPTION
## Changes
Currently, anamorphic video (video with non-square pixels) gets transcoded.

On my Roku TV, direct playing anamorphic video works fine. On request, I can provide an example video though it is quite large (19 GB). I believe this is the part of ffprobe output that denotes that it is anamorphic (`SAR 31679:31680`):

```
  Stream #0:0[0x2](eng): Video: hevc (Main 10) (hev1 / 0x31766568), yuv420p10le(tv, bt2020nc/bt2020/smpte2084), 3840x1604 [SAR 1:1 DAR 960:401], 24289 kb/s, SAR 31679:31680 DAR 79:33, 23.98 fps, 23.98 tbr, 16k tbn (default)
```

Granted, this video is basically 1:1 and has only slightly non-square pixels, but it did play just fine.

Before:
<img width="1978" height="1489" alt="image" src="https://github.com/user-attachments/assets/9e4fa866-9d40-43cd-b714-25d58ccbc7e2" />

After:
<img width="1978" height="1489" alt="image" src="https://github.com/user-attachments/assets/fd7a117b-9b94-4e12-9a89-3818cecd730e" />


## Issues
#732 
