### PR TITLE
Fix library bug that caused lazy-loading to stop working

### DIFF
--- a/components/Libraries/AudioBookLibraryView.bs
+++ b/components/Libraries/AudioBookLibraryView.bs
@@ -1,5 +1,6 @@
 import "pkg:/source/api/baserequest.bs"
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/enums/TaskControl.bs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/deviceCapabilities.bs"
 import "pkg:/source/utils/misc.bs"
@@ -189,11 +190,8 @@ end sub
 'Handle loaded data, and add to Grid
 sub ItemDataLoaded(msg)
     itemData = msg.GetData()
-    m.loadItemsTask.unobserveField("content")
-    m.loadItemsTask.content = []
 
-    if not isValid(itemData)
-        m.Loading = false
+    if not isValidAndNotEmpty(itemData)
         stopLoadingSpinner()
         return
     end if
@@ -209,7 +207,6 @@ sub ItemDataLoaded(msg)
     'Update the stored counts
     m.loadedItems = m.itemGrid.content.getChildCount()
     m.loadedRows = m.loadedItems / m.itemGrid.numColumns
-    m.Loading = false
 
     'If there are no items to display, show message
     if m.loadedItems = 0
@@ -285,10 +282,9 @@ end sub
 
 'Load next set of items
 sub loadMoreData()
-    if m.Loading = true then return
+    if isStringEqual(m.loadItemsTask.state, TaskControl.RUN) then return
 
     startLoadingSpinner(false)
-    m.Loading = true
     m.loadItemsTask.startIndex = m.loadedItems
     m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.control = "RUN"

--- a/components/Libraries/AudioBookLibraryView.bs
+++ b/components/Libraries/AudioBookLibraryView.bs
@@ -52,6 +52,7 @@ sub init()
     m.loadItemsTask = createObject("roSGNode", "LoadItemsTask2")
 
     'set inital counts for overhang before content is loaded.
+    m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.totalRecordCount = 0
 
     m.top.gridTitles = m.global.session.user.settings["itemgrid.gridTitles"]
@@ -105,7 +106,6 @@ sub loadInitialItems()
 
     setColumnSizes()
 
-    m.loadItemsTask.observeField("content", "ItemDataLoaded")
     startLoadingSpinner(false)
     m.loadItemsTask.control = "RUN"
     SetUpOptions()
@@ -286,7 +286,6 @@ sub loadMoreData()
 
     startLoadingSpinner(false)
     m.loadItemsTask.startIndex = m.loadedItems
-    m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.control = "RUN"
 end sub
 

--- a/components/Libraries/LiveTVLibraryView.bs
+++ b/components/Libraries/LiveTVLibraryView.bs
@@ -273,11 +273,8 @@ end sub
 'Handle loaded data, and add to Grid
 sub ItemDataLoaded(msg)
     itemData = msg.GetData()
-    m.loadItemsTask.unobserveField("content")
-    m.loadItemsTask.content = []
 
-    if not isValid(itemData)
-        m.Loading = false
+    if not isValidAndNotEmpty(itemData)
         stopLoadingSpinner()
         return
     end if
@@ -302,7 +299,6 @@ sub ItemDataLoaded(msg)
     'Update the stored counts
     m.loadedItems = m.itemGrid.content.getChildCount()
     m.loadedRows = m.loadedItems / m.itemGrid.numColumns
-    m.Loading = false
 
     'If there are no items to display, show message
     if m.loadedItems = 0
@@ -345,10 +341,9 @@ end sub
 
 'Load next set of items
 sub loadMoreData()
-    if m.Loading = true then return
+    if isStringEqual(m.loadItemsTask.state, TaskControl.RUN) then return
 
     startLoadingSpinner(false)
-    m.Loading = true
     m.loadItemsTask.startIndex = m.loadedItems
     m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.control = "RUN"

--- a/components/Libraries/LiveTVLibraryView.bs
+++ b/components/Libraries/LiveTVLibraryView.bs
@@ -60,6 +60,7 @@ sub init()
     setColumnSizes(ImageLayout.PORTRAIT)
 
     'set inital counts for overhang before content is loaded.
+    m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.totalRecordCount = 0
 
     m.alpha = m.top.findNode("alpha")
@@ -159,7 +160,6 @@ sub loadInitialItems()
         showTvGuide()
     end if
 
-    m.loadItemsTask.observeField("content", "ItemDataLoaded")
     startLoadingSpinner(false)
     m.loadItemsTask.control = "RUN"
 
@@ -345,7 +345,6 @@ sub loadMoreData()
 
     startLoadingSpinner(false)
     m.loadItemsTask.startIndex = m.loadedItems
-    m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.control = "RUN"
 end sub
 
@@ -356,6 +355,7 @@ end sub
 
 sub alphaSelectedChanged()
     if m.top.alphaSelected <> string.EMPTY
+        m.loadItemsTask.control = TaskControl.STOP
         m.loadedRows = 0
         m.loadedItems = 0
         m.data = CreateObject("roSGNode", "ContentNode")

--- a/components/Libraries/MusicLibraryView.bs
+++ b/components/Libraries/MusicLibraryView.bs
@@ -665,11 +665,8 @@ end sub
 'Handle loaded data, and add to Grid
 sub ItemDataLoaded(msg)
     itemData = msg.GetData()
-    m.loadItemsTask.unobserveField("content")
-    m.loadItemsTask.content = []
 
-    if itemData = invalid
-        m.Loading = false
+    if not isValidAndNotEmpty(itemData)
         stopLoadingSpinner()
         return
     end if
@@ -700,7 +697,6 @@ sub ItemDataLoaded(msg)
             group.lastFocus = m.voiceBox
         end if
 
-        m.loading = false
         stopLoadingSpinner()
         return
     end if
@@ -726,7 +722,6 @@ sub ItemDataLoaded(msg)
     'Update the stored counts
     m.loadedItems = m.itemGrid.content.getChildCount()
     m.loadedRows = m.loadedItems / m.itemGrid.numColumns
-    m.Loading = false
 
     'If there are no items to display, show message
     if m.loadedItems = 0
@@ -940,10 +935,9 @@ end sub
 '
 'Load next set of items
 sub loadMoreData()
-    if m.Loading = true then return
+    if isStringEqual(m.loadItemsTask.state, TaskControl.RUN) then return
 
     startLoadingSpinner(false)
-    m.Loading = true
     m.loadItemsTask.startIndex = m.loadedItems
     m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.control = TaskControl.RUN

--- a/components/Libraries/MusicLibraryView.bs
+++ b/components/Libraries/MusicLibraryView.bs
@@ -115,6 +115,7 @@ sub init()
     m.getFiltersTask = createObject("roSGNode", "GetFiltersTask")
 
     'set inital counts for overhang before content is loaded.
+    m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.totalRecordCount = 0
 
     if not m.global.device.hasVoiceRemote
@@ -398,7 +399,6 @@ sub loadInitialItems()
 
     setColumnSizes()
 
-    m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.control = TaskControl.RUN
 
     m.getFiltersTask.observeField("filters", "FilterDataLoaded")
@@ -939,7 +939,6 @@ sub loadMoreData()
 
     startLoadingSpinner(false)
     m.loadItemsTask.startIndex = m.loadedItems
-    m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.control = TaskControl.RUN
 end sub
 
@@ -1078,6 +1077,7 @@ sub alphaSelectedChanged()
         end if
     end if
 
+    m.loadItemsTask.control = TaskControl.STOP
     m.loadedRows = 0
     m.loadedItems = 0
 

--- a/components/Libraries/OtherLibrary.bs
+++ b/components/Libraries/OtherLibrary.bs
@@ -620,11 +620,8 @@ end sub
 'Handle loaded data, and add to Grid
 sub ItemDataLoaded(msg)
     itemData = msg.GetData()
-    m.loadItemsTask.unobserveField("content")
-    m.loadItemsTask.content = []
 
-    if not isValid(itemData)
-        m.Loading = false
+    if not isValidAndNotEmpty(itemData)
         stopLoadingSpinner()
         return
     end if
@@ -645,7 +642,6 @@ sub ItemDataLoaded(msg)
         group = m.global.sceneManager.callFunc("getActiveScene")
         group.lastFocus = m.genreList
 
-        m.loading = false
         stopLoadingSpinner()
         return
     end if
@@ -671,7 +667,6 @@ sub ItemDataLoaded(msg)
     'Update the stored counts
     m.loadedItems = m.itemGrid.content.getChildCount()
     m.loadedRows = m.loadedItems / m.itemGrid.numColumns
-    m.Loading = false
 
     'If there are no items to display, show message
     if m.loadedItems = 0
@@ -748,10 +743,9 @@ end sub
 
 'Load next set of items
 sub loadMoreData()
-    if m.Loading = true then return
+    if isStringEqual(m.loadItemsTask.state, TaskControl.RUN) then return
 
     startLoadingSpinner(false)
-    m.Loading = true
     m.loadItemsTask.startIndex = m.loadedItems
     m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.control = TaskControl.RUN

--- a/components/Libraries/OtherLibrary.bs
+++ b/components/Libraries/OtherLibrary.bs
@@ -86,6 +86,7 @@ sub init()
     end if
 
     'set inital counts for overhang before content is loaded.
+    m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.totalRecordCount = 0
 
     m.alpha = m.top.findNode("alpha")
@@ -303,7 +304,6 @@ sub loadInitialItems()
         m.loadItemsTask.view = "Movies"
     end if
 
-    m.loadItemsTask.observeField("content", "ItemDataLoaded")
     startLoadingSpinner(false)
     m.loadItemsTask.control = TaskControl.RUN
 
@@ -747,7 +747,6 @@ sub loadMoreData()
 
     startLoadingSpinner(false)
     m.loadItemsTask.startIndex = m.loadedItems
-    m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.control = TaskControl.RUN
 end sub
 
@@ -759,6 +758,7 @@ end sub
 
 sub alphaSelectedChanged()
     if not isStringEqual(m.top.alphaSelected, string.EMPTY)
+        m.loadItemsTask.control = TaskControl.STOP
         m.loadedRows = 0
         m.loadedItems = 0
         m.data = CreateObject("roSGNode", "ContentNode")

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -979,11 +979,8 @@ end sub
 'Handle loaded data, and add to Grid
 sub ItemDataLoaded(msg)
     itemData = msg.GetData()
-    m.loadItemsTask.unobserveField("content")
-    m.loadItemsTask.content = []
 
-    if not isValid(itemData)
-        m.Loading = false
+    if not isValidAndNotEmpty(itemData)
         return
     end if
 
@@ -1004,7 +1001,6 @@ sub ItemDataLoaded(msg)
         group = m.global.sceneManager.callFunc("getActiveScene")
         group.lastFocus = m.genreList
 
-        m.loading = false
         stopLoadingSpinner()
 
         ' Return focus to options menu if it was opened while library was loading
@@ -1050,7 +1046,6 @@ sub ItemDataLoaded(msg)
     'Update the stored counts
     m.loadedItems = m.itemGrid.content.getChildCount()
     m.loadedRows = m.loadedItems / m.itemGrid.numColumns
-    m.Loading = false
 
     onItemFocused()
 
@@ -1357,10 +1352,9 @@ end sub
 '
 'Load next set of items
 sub loadMoreData()
-    if m.Loading = true then return
+    if isStringEqual(m.loadItemsTask.state, TaskControl.RUN) then return
 
     startLoadingSpinner(false)
-    m.Loading = true
     m.loadItemsTask.startIndex = m.loadedItems
     m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.control = TaskControl.RUN

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -143,6 +143,7 @@ sub init()
     m.getFiltersTask = createObject("roSGNode", "GetFiltersTask")
 
     'set inital counts for overhang before content is loaded.
+    m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.totalRecordCount = 0
 
     if not m.global.device.hasVoiceRemote
@@ -597,7 +598,6 @@ sub loadInitialItems()
         setColumnSizes(posterOrientation)
     end if
 
-    m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.control = TaskControl.RUN
 
     m.getFiltersTask.observeField("filters", "FilterDataLoaded")
@@ -1356,7 +1356,6 @@ sub loadMoreData()
 
     startLoadingSpinner(false)
     m.loadItemsTask.startIndex = m.loadedItems
-    m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.control = TaskControl.RUN
 end sub
 
@@ -1480,6 +1479,7 @@ sub alphaSelectedChanged()
         end if
     end if
 
+    m.loadItemsTask.control = TaskControl.STOP
     m.loadedRows = 0
     m.loadedItems = 0
 

--- a/source/static/whatsNew/3.1.6.json
+++ b/source/static/whatsNew/3.1.6.json
@@ -34,5 +34,9 @@
   {
     "description": "In playback info popup, ensure video media stream data is shown",
     "author": "FractalBoy"
+  },
+  {
+    "description": "Fix library bug that caused lazy-loading to stop working",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Changes lazy-load functionality to use task state instead of global variable to determine if it's in a load state
- Stops load task when alpha character is clicked 

## Issues
Fixes #756

## Steps to recreate bug

- Load a library that has enough content for letters A and B that it lazy loads items as you scroll
- Click A from alpha menu
- Scroll grid down until loading spinner appears
- Quickly Click B from alpha menu - while spinner is still showing
- Lazy load now doesn't work
