### PR TITLE
Stop resetting playback position on Home button press

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1091,8 +1091,10 @@ sub onState(msg)
         ReportPlayback()
     else if isStringEqual(m.top.state, MediaPlaybackState.STOPPED)
         m.playbackTimer.control = "stop"
-        ReportPlayback("stop")
-        m.playReported = false
+        if m.playReported
+            ReportPlayback("stop")
+            m.playReported = false
+        end if
     else if isStringEqual(m.top.state, MediaPlaybackState.FINISHED)
         m.playbackTimer.control = "stop"
         ReportPlayback("stop")

--- a/source/static/whatsNew/3.1.8.json
+++ b/source/static/whatsNew/3.1.8.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "",
-    "author": ""
+    "description": "Fix losing playback position when pressing Home button",
+    "author": "FractalBoy"
   }
 ]


### PR DESCRIPTION
## Changes
Currently, whenever a video starts to play, a stop event is triggered before the start event. This sends a 0 playback position back to the server.

If the user exits via the Home button before 30 seconds have played or before they have pressed Back, all progress is lost and the position is set back to the beginning.

This change suppresses the first "stop" event sent to the server - from what I can tell, there is no need to send a stop event with a 0 position before the video has played at all.

## Issues
Fixes #770 