### PR TITLE
Apply screen padding for subtitles

### DIFF
--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -244,9 +244,11 @@ function processLineCue(captionLine as string, captionLineHeight as float, capti
     end if
 
     if calculatedPosition + captionTotalHeight > LOWEST_CAPTION
-        calculatedPosition = LOWEST_CAPTION - captionTotalHeight
-    else if calculatedPosition < SCREEN_PADDING
-        calculatedPosition = SCREEN_PADDING
+        return LOWEST_CAPTION - captionTotalHeight
+    end if
+
+    if calculatedPosition < SCREEN_PADDING
+        return SCREEN_PADDING
     end if
 
     return calculatedPosition

--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -19,7 +19,7 @@ sub init()
     m.tags = CreateObject("roRegex", "{\\an\d*}|&lt;.*?&gt;|<.*?>", "s")
 
     ' Caption Style
-    m.fontSizeDict = { "Default": 60, "Large": 60, "Extra Large": 70, "Medium": 50, "Small": 40 }
+    m.fontSizeDict = { "Default": 60, "Large": 60, "Extra Large": 70, "Medium": 50, "Small": 40, "Extra Small": 30 }
     m.percentageDict = { "Default": 1.0, "100%": 1.0, "75%": 0.75, "50%": 0.5, "25%": 0.25, "Off": 0 }
     m.textColorDict = { "Default": &HFFFFFFFF, "White": &HFFFFFFFF, "Black": &H000000FF, "Red": &HFF0000FF, "Green": &H008000FF, "Blue": &H0000FFFF, "Yellow": &HFFFF00FF, "Magenta": &HFF00FFFF, "Cyan": &H00FFFFFF }
     m.bgColorDict = { "Default": &H000000FF, "White": &HFFFFFFFF, "Black": &H000000FF, "Red": &HFF0000FF, "Green": &H008000FF, "Blue": &H0000FFFF, "Yellow": &HFFFF00FF, "Magenta": &HFF00FFFF, "Cyan": &H00FFFFFF }
@@ -193,7 +193,7 @@ function prepareStyles(styles as object, rect, lineCount = 1 as integer) as obje
     ' Line
     if not isStringEqual(captionLine, string.EMPTY)
         captionLineHeight = (rect.BoundingRect().height / lineCount)
-        verticalPosition = processLineCue(captionLine, captionLineHeight, rect.BoundingRect().height)
+        verticalPosition = processLineCue(captionLine, captionLineHeight, lineCount)
     end if
 
     ' Position
@@ -220,13 +220,18 @@ function processPositionCue(captionPosition as string, captionLineWidth as float
     return calculatedPosition
 end function
 
-function processLineCue(captionLine as string, captionLineHeight as float, captionTotalHeight as float) as integer
+function processLineCue(captionLine as string, captionLineHeight as float, lineCount as integer) as integer
+    captionTotalHeight = lineCount * captionLineHeight
     ' A percentage
     if captionLine.Instr("%") <> -1
-        calculatedPosition = 1080 * (val(captionLine) / 100)
+        calculatedPosition = 1080 * (val(captionLine) / 100) - (lineCount - 1) * captionLineHeight
 
         if calculatedPosition + captionTotalHeight > 1080
             calculatedPosition = 1080 - captionTotalHeight
+        end if
+
+        if calculatedPosition < 0
+            calculatedPosition = 0
         end if
 
         return calculatedPosition
@@ -249,7 +254,7 @@ function processLineCue(captionLine as string, captionLineHeight as float, capti
     end if
 
     ' A negative line value. Count from the bottom
-    calculatedPosition = 1080 - Abs(lineValue * captionLineHeight)
+    calculatedPosition = 1080 - Abs(lineValue * captionLineHeight) - (lineCount - 1) * captionLineHeight
 
     if calculatedPosition + captionTotalHeight > 1080
         calculatedPosition = 1080 - captionTotalHeight

--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -4,6 +4,10 @@ import "pkg:/source/enums/MediaPlaybackState.bs"
 import "pkg:/source/enums/String.bs"
 import "pkg:/source/utils/config.bs"
 
+const SCREEN_PADDING = 60
+const LOWEST_CAPTION = 1080 - SCREEN_PADDING
+const VIEWABLE_AREA = 1080 - 2 * SCREEN_PADDING
+
 sub init()
     m.top.playerState = MediaPlaybackState.STOPPED
     m.top.observeField("url", "fetchCaption")
@@ -178,9 +182,9 @@ end function
 
 function prepareStyles(styles as object, rect, lineCount = 1 as integer) as object
     captionStyles = styles
-    finalStyles = { translation: [960, 1020] }
+    finalStyles = { translation: [960, LOWEST_CAPTION] }
 
-    verticalPosition = 1020
+    verticalPosition = LOWEST_CAPTION
     horizontalPositon = 960 - (rect.BoundingRect().width / 2)
 
     if not isValidAndNotEmpty(captionStyles)
@@ -193,7 +197,7 @@ function prepareStyles(styles as object, rect, lineCount = 1 as integer) as obje
     ' Line
     if not isStringEqual(captionLine, string.EMPTY)
         captionLineHeight = (rect.BoundingRect().height / lineCount)
-        verticalPosition = processLineCue(captionLine, captionLineHeight, lineCount)
+        verticalPosition = processLineCue(captionLine, captionLineHeight, rect.BoundingRect().height)
     end if
 
     ' Position
@@ -220,48 +224,29 @@ function processPositionCue(captionPosition as string, captionLineWidth as float
     return calculatedPosition
 end function
 
-function processLineCue(captionLine as string, captionLineHeight as float, lineCount as integer) as integer
-    captionTotalHeight = lineCount * captionLineHeight
+function processLineCue(captionLine as string, captionLineHeight as float, captionTotalHeight as float) as integer
     ' A percentage
     if captionLine.Instr("%") <> -1
-        calculatedPosition = 1080 * (val(captionLine) / 100) - (lineCount - 1) * captionLineHeight
+        calculatedPosition = SCREEN_PADDING + VIEWABLE_AREA * (val(captionLine) / 100)
+    else
+        ' Note: Non-numeric values are treated as 0
+        lineValue = val(captionLine)
 
-        if calculatedPosition + captionTotalHeight > 1080
-            calculatedPosition = 1080 - captionTotalHeight
+        if lineValue = 0 then return SCREEN_PADDING
+
+        if lineValue > 0
+            ' A positive line value. Count from the top
+            calculatedPosition = SCREEN_PADDING + lineValue * captionLineHeight
+        else
+            ' A negative line value. Count from the bottom
+            calculatedPosition = LOWEST_CAPTION - Abs(lineValue * captionLineHeight)
         end if
-
-        if calculatedPosition < 0
-            calculatedPosition = 0
-        end if
-
-        return calculatedPosition
     end if
 
-    ' Note: Non-numeric values are treated as 0
-    lineValue = val(captionLine)
-
-    if lineValue = 0 then return 0
-
-    ' A positive line value. Count from the top
-    if lineValue >= 0
-        calculatedPosition = lineValue * captionLineHeight
-
-        if calculatedPosition + captionTotalHeight > 1080
-            calculatedPosition = 1080 - captionTotalHeight
-        end if
-
-        return calculatedPosition
-    end if
-
-    ' A negative line value. Count from the bottom
-    calculatedPosition = 1080 - Abs(lineValue * captionLineHeight) - (lineCount - 1) * captionLineHeight
-
-    if calculatedPosition + captionTotalHeight > 1080
-        calculatedPosition = 1080 - captionTotalHeight
-    end if
-
-    if calculatedPosition < 0
-        calculatedPosition = 0
+    if calculatedPosition + captionTotalHeight > LOWEST_CAPTION
+        calculatedPosition = LOWEST_CAPTION - captionTotalHeight
+    else if calculatedPosition < SCREEN_PADDING
+        calculatedPosition = SCREEN_PADDING
     end if
 
     return calculatedPosition

--- a/source/static/whatsNew/3.1.8.json
+++ b/source/static/whatsNew/3.1.8.json
@@ -14,5 +14,9 @@
   {
     "description": "Add toggle played status and add to playlist functions to more button on TV season screen",
     "author": "1hitsong"
+  },
+  {
+    "description": "Prevent subtitles from getting too close to the top or bottom of the screen",
+    "author": "gabeluci"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Prevents subtitles from going off the bottom of the screen or getting too close to the top or bottom of the screen where they can get clipped by a TV's overscan.

Also, I noticed that the "Extra small" font size wasn't mapped, so if that was selected, no subtitles showed up at all.

## Issues
#781 Two-line subtitles are cut off at the bottom of the screen
