### PR TITLE
Use alpha channel for subtitle opacity

### DIFF
--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -20,16 +20,14 @@ sub init()
 
     ' Caption Style
     m.fontSizeDict = { "Default": 60, "Large": 60, "Extra Large": 70, "Medium": 50, "Small": 40 }
-    m.percentageDict = { "Default": 1.0, "100%": 1.0, "75%": 0.75, "50%": 0.5, "25%": 0.25, "Off": 0 }
-    m.textColorDict = { "Default": &HFFFFFFFF, "White": &HFFFFFFFF, "Black": &H000000FF, "Red": &HFF0000FF, "Green": &H008000FF, "Blue": &H0000FFFF, "Yellow": &HFFFF00FF, "Magenta": &HFF00FFFF, "Cyan": &H00FFFFFF }
-    m.bgColorDict = { "Default": &H000000FF, "White": &HFFFFFFFF, "Black": &H000000FF, "Red": &HFF0000FF, "Green": &H008000FF, "Blue": &H0000FFFF, "Yellow": &HFFFF00FF, "Magenta": &HFF00FFFF, "Cyan": &H00FFFFFF }
+    m.percentageDict = { "Default": "FF", "100%": "FF", "75%": "BF", "50%": "7F", "25%": "4B", "Off": "00" }
+    m.textColorDict = { "Default": "0xFFFFFF", "White": "0xFFFFFF", "Black": "0x000000", "Red": "0xFF0000", "Green": "0x008000", "Blue": "0x0000FF", "Yellow": "0xFFFF00", "Magenta": "0xFF00FF", "Cyan": "0x00FFFF" }
+    m.bgColorDict = { "Default": "0x000000", "White": "0xFFFFFF", "Black": "0x000000", "Red": "0xFF0000", "Green": "0x008000", "Blue": "0x0000FF", "Yellow": "0xFFFF00", "Magenta": "0xFF00FF", "Cyan": "0x00FFFF" }
 
     deviceInfo = CreateObject("roDeviceInfo")
     m.fontSize = m.fontSizeDict[deviceInfo.GetCaptionsOption("Text/Size")]
-    m.textColor = m.textColorDict[deviceInfo.GetCaptionsOption("Text/Color")]
-    m.textOpac = m.percentageDict[deviceInfo.GetCaptionsOption("Text/Opacity")]
-    m.bgColor = m.bgColorDict[deviceInfo.GetCaptionsOption("Background/Color")]
-    m.bgOpac = m.percentageDict[deviceInfo.GetCaptionsOption("Background/Opacity")]
+    m.textColor = m.textColorDict[deviceInfo.GetCaptionsOption("Text/Color")] + m.percentageDict[deviceInfo.GetCaptionsOption("Text/Opacity")]
+    m.bgColor = m.bgColorDict[deviceInfo.GetCaptionsOption("Background/Color")] + m.percentageDict[deviceInfo.GetCaptionsOption("Background/Opacity")]
     setFont()
 end sub
 
@@ -64,7 +62,6 @@ function newlabel(txt)
     label.font = m.font
     label.font.size = m.fontSize
     label.color = m.textColor
-    label.opacity = m.textOpac
     return label
 end function
 
@@ -87,7 +84,6 @@ function newRect(lg, id as string)
     lg.translation = [5, 5]
 
     rect.color = m.bgColor
-    rect.opacity = m.bgOpac
     rect.width = rectxy.width + 10
     rect.height = rectxy.height + 10
 

--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -21,13 +21,17 @@ sub init()
     ' Caption Style
     m.fontSizeDict = { "Default": 60, "Large": 60, "Extra Large": 70, "Medium": 50, "Small": 40 }
     m.percentageDict = { "Default": "FF", "100%": "FF", "75%": "BF", "50%": "7F", "25%": "4B", "Off": "00" }
-    m.textColorDict = { "Default": "0xFFFFFF", "White": "0xFFFFFF", "Black": "0x000000", "Red": "0xFF0000", "Green": "0x008000", "Blue": "0x0000FF", "Yellow": "0xFFFF00", "Magenta": "0xFF00FF", "Cyan": "0x00FFFF" }
-    m.bgColorDict = { "Default": "0x000000", "White": "0xFFFFFF", "Black": "0x000000", "Red": "0xFF0000", "Green": "0x008000", "Blue": "0x0000FF", "Yellow": "0xFFFF00", "Magenta": "0xFF00FF", "Cyan": "0x00FFFF" }
+    m.textColorDict = { "Default": "0xCCCCCC", "Bright White": "0xFFFFFF", "White": "0xCCCCCC", "Black": "0x000000", "Red": "0xFF0000", "Green": "0x008000", "Blue": "0x0000FF", "Yellow": "0xFFFF00", "Magenta": "0xFF00FF", "Cyan": "0x00FFFF" }
+    m.bgColorDict = { "Default": "0x000000", "Bright White": "0xFFFFFF", "White": "0xCCCCCC", "Black": "0x000000", "Red": "0xFF0000", "Green": "0x008000", "Blue": "0x0000FF", "Yellow": "0xFFFF00", "Magenta": "0xFF00FF", "Cyan": "0x00FFFF" }
 
     deviceInfo = CreateObject("roDeviceInfo")
     m.fontSize = m.fontSizeDict[deviceInfo.GetCaptionsOption("Text/Size")]
-    m.textColor = m.textColorDict[deviceInfo.GetCaptionsOption("Text/Color")] + m.percentageDict[deviceInfo.GetCaptionsOption("Text/Opacity")]
-    m.bgColor = m.bgColorDict[deviceInfo.GetCaptionsOption("Background/Color")] + m.percentageDict[deviceInfo.GetCaptionsOption("Background/Opacity")]
+    textColor = chainLookupReturn(m.textColorDict, deviceInfo.GetCaptionsOption("Text/Color"), m.textColorDict.Default)
+    m.textOpac = chainLookupReturn(m.percentageDict, deviceInfo.GetCaptionsOption("Text/Opacity"), m.percentageDict.Default)
+    m.textColor = `${textColor}${m.textOpac}`
+    deviceBGColor = chainLookupReturn(m.bgColorDict, deviceInfo.GetCaptionsOption("Background/Color"), m.bgColorDict.Default)
+    deviceBGOpacity = chainLookupReturn(m.percentageDict, deviceInfo.GetCaptionsOption("Background/Opacity"), m.percentageDict.Default)
+    m.bgColor = `${deviceBGColor}${deviceBGOpacity}`
     setFont()
 end sub
 

--- a/source/static/whatsNew/3.1.8.json
+++ b/source/static/whatsNew/3.1.8.json
@@ -2,9 +2,13 @@
   {
     "description": "Fix crash when filtering Live TV guide by favorites",
     "author": "michaelcresswell"
-  },  
+  },
   {
     "description": "Fix losing playback position when pressing Home button",
     "author": "FractalBoy"
+  },
+  {
+    "description": "Fix subtitle background opacity affecting text",
+    "author": "gabeluci"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Subtitle background opacity was being set on the parent rectangle, but that makes it apply to child items too, including the text. The result is the subtitle text always having the same opacity as the background, even if that's not what your settings call for.

Instead, this change applies your opacity settings to the alpha channel of the background color. It made sense to do the same for the text color.

With background opacity set to 25% and text opacity set to default, this is what it looks like in 3.1.7:
![20260310_212519](https://github.com/user-attachments/assets/e37d6ac8-91e9-49f8-b314-5b9124864dc5)

And after this fix (but without the other fix for the position):
![20260310_212631](https://github.com/user-attachments/assets/20508451-5ee5-4da1-bea3-94433928f16f)
