### PR TITLE
Prevent switching audio tracks to the one already playing

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -174,6 +174,11 @@ sub onAvailableAudioTracksChanged()
             m.global.queueManager.callFunc("setPreferredAudioTrackIndex", audioTrack.LookupCI("Track").toint())
             m.top.audioIndex = audioTrack.LookupCI("Track")
 
+            if m.top.currentAudioTrack = audioTrack.LookupCI("Track")
+                ' We're already playing the track we want
+                return
+            end if
+
             ' Save the current video position
             if m.top.position <> 0
                 m.global.queueManager.callFunc("setTopStartingPoint", int(m.top.position) * 10000000&)

--- a/source/static/whatsNew/3.1.8.json
+++ b/source/static/whatsNew/3.1.8.json
@@ -2,9 +2,13 @@
   {
     "description": "Fix crash when filtering Live TV guide by favorites",
     "author": "michaelcresswell"
-  },  
+  },
   {
     "description": "Fix losing playback position when pressing Home button",
     "author": "FractalBoy"
+  },
+  {
+    "description": "Fix mkv videos sometimes loading twice",
+    "author": "gabeluci"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
While testing the other subtitle stuff, I was noticing that the video I was testing with would always load twice. That is, I'd see the spinner that shows it's loading, then it would go away, then it would come back, and then the video would play.

While debugging, I found that `onAvailableAudioTracksChanged` was triggering after the video already started playing. That would stop play, select the audio track that was already playing, then restart the video. I've tried with several mkv's with only one audio track, and that happened each time.

This fix checks if we're already playing the track we want, and if so, does nothing.

I feel like this could be done a better way... like why are we selecting the audio track after we've already started playing? Or is the issue that `onAvailableAudioTracksChanged` is firing after playback has already started? I don't know. And I've seen the past commits and issue related to this code so I know it's a complicated issue. This (I hope) is a bandaid for now.

Oddly, when I played the multi-audio-track video attached to #571, then `onAvailableAudioTracksChanged` does not fire at all, no matter which audio track I pre-select. But it does fire when playing any mkv file I have that has only one audio track.