### PR TITLE
Fix transcode trickplay resume

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1600,6 +1600,8 @@ function onKeyEvent(key as string, press as boolean) as boolean
     if (key = KeyCode.OK or key = KeyCode.PLAY) and m.top.trickPlayBar.visible and m.isTranscoded
         if m.top.state = "paused"
             m.top.control = VideoControl.RESUME
+            m.top.trickPlayBar.visible = false
+            return true
         end if
     end if
 

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1597,6 +1597,12 @@ function onKeyEvent(key as string, press as boolean) as boolean
         return false
     end if
 
+    if (key = KeyCode.OK or key = KeyCode.PLAY) and m.top.trickPlayBar.visible and m.isTranscoded
+        if m.top.state = "paused"
+            m.top.control = VideoControl.RESUME
+        end if
+    end if
+
     ' Disable OSD for intro videos
     if not m.LoadMetaDataTask.isIntro
         if key = KeyCode.PLAY and not m.top.trickPlayBar.visible

--- a/source/static/whatsNew/3.1.8.json
+++ b/source/static/whatsNew/3.1.8.json
@@ -17,8 +17,8 @@
   },
   {
     "description": "Fix subtitle background opacity affecting text",
-    "author": "gabeluci"    
-  },  
+    "author": "gabeluci"
+  },
   {
     "description": "Prevent subtitles from getting too close to the top or bottom of the screen",
     "author": "gabeluci"
@@ -30,5 +30,9 @@
   {
     "description": "Add setting to select how many items are loaded together on library screens",
     "author": "brianpardy"
+  },
+  {
+    "description": "Fix resuming from trickplay on transcoded videos",
+    "author": "FractalBoy"
   }
 ]


### PR DESCRIPTION
## Changes
I am encountering a strange issue where if I try to use trickplay on a transcoded video, I can never resume it. It seems to also put the app into a strange state whereby the only thing I can do to fix it is press the Home button.

It effectively means I can't seek on any transcoded videos.

Reproduction Steps:

1. Start transcoded video
2. Use trickplay to fast forward a couple of minutes
3. Try both Play and OK to resume, neither work
4. Try pressing back - app is completely frozen

I don't know why this is a problem to begin with so I acknowledge it seems like a complete hack. Direct play videos do not encounter this issue at all. It seems like it might be a Roku bug that needs to be worked around.

## Issues

I don't see anyone else having filed any issues about this, which makes me think it is something specific to my Roku TV. So I'm not even sure if anyone else can reproduce.