### PR TITLE
Add Load Items Limit setting

### DIFF
--- a/components/ItemGrid/LoadItemsTask2.bs
+++ b/components/ItemGrid/LoadItemsTask2.bs
@@ -12,7 +12,7 @@ sub init()
     m.top.sortField = "SortName"
     m.top.functionName = "loadItems"
 
-    m.top.limit = 60
+    m.top.limit = m.global.session.user.settings["ui.library.loadItemsLimit"]
 end sub
 
 sub loadItems()

--- a/components/ItemGrid/LoadItemsTask2.bs
+++ b/components/ItemGrid/LoadItemsTask2.bs
@@ -12,7 +12,7 @@ sub init()
     m.top.sortField = "SortName"
     m.top.functionName = "loadItems"
 
-    m.top.limit = m.global.session.user.settings["ui.library.loadItemsLimit"]
+    m.top.limit = chainLookupReturn(m.global.session, "user.settings.`ui.library.loadItemsLimit`", 60)
 end sub
 
 sub loadItems()

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -148,6 +148,10 @@ sub onKeyGridSubmit()
         m.integerSetting.text = selectedSetting.max
         return
     end if
+    if isValid(selectedSetting.min) and m.integerSetting.text.ToInt() < selectedSetting.min.ToInt()
+        m.integerSetting.text = selectedSetting.min
+        return
+    end if
     set_user_setting(selectedSetting.settingName, m.integerSetting.text)
     m.settingsMenu.setFocus(true)
 end sub

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1569,8 +1569,8 @@
 	    <extracomment>Libraries Setting - Setting title</extracomment>
         </message>
 	<message>
-	    <source>How many items should load when a library opens.</source>
-	    <translation>How many items should load when a library opens.</translation>
+	    <source>Number of items to load together on library screens.</source>
+	    <translation>Number of items to load together on library screens.</translation>
 	    <extracomment>Libraries Setting - Setting description</extracomment>
         </message>
 

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1563,6 +1563,16 @@
             <translation>Number of columns in library view when showing square images</translation>
             <extracomment>Libraries Setting - Setting description</extracomment>
         </message>
+	<message>
+	    <source>Load Items Limit</source>
+	    <translation>Load Items Limit</translation>
+	    <extracomment>Libraries Setting - Setting title</extracomment>
+        </message>
+	<message>
+	    <source>How many items should load when a library opens.</source>
+	    <translation>How many items should load when a library opens.</translation>
+	    <extracomment>Libraries Setting - Setting description</extracomment>
+        </message>
 
         <message>
             <source>View All Next Up</source>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1297,13 +1297,13 @@
               }
             ]
           },
-	  {
-	    "title": "Load Items Limit",
-	    "description": "Number of items to load together on library screens.",
+          {
+            "title": "Load Items Limit",
+            "description": "Number of items to load together on library screens.",
             "settingName": "ui.library.loadItemsLimit",
-	    "type": "integer",
+            "type": "integer",
             "default": "60"
-	  },
+          },
           {
             "title": "TV Shows",
             "description": "Settings relating to the appearance of pages in TV Libraries.",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1297,6 +1297,13 @@
               }
             ]
           },
+	  {
+	    "title": "Load Items Limit",
+	    "description": "How many items should load when a library opens.",
+            "settingName": "ui.library.loadItemsLimit",
+	    "type": "integer",
+            "default": "60"
+	  },
           {
             "title": "TV Shows",
             "description": "Settings relating to the appearance of pages in TV Libraries.",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1299,7 +1299,7 @@
           },
 	  {
 	    "title": "Load Items Limit",
-	    "description": "How many items should load when a library opens.",
+	    "description": "Number of items to load together on library screens.",
             "settingName": "ui.library.loadItemsLimit",
 	    "type": "integer",
             "default": "60"

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1302,6 +1302,7 @@
             "description": "Number of items to load together on library screens.",
             "settingName": "ui.library.loadItemsLimit",
             "type": "integer",
+            "min": "15",
             "default": "60"
           },
           {

--- a/source/static/whatsNew/3.1.8.json
+++ b/source/static/whatsNew/3.1.8.json
@@ -22,5 +22,9 @@
   {
     "description": "Prevent subtitles from getting too close to the top or bottom of the screen",
     "author": "gabeluci"
+  },
+  {
+    "description": "Add setting to select how many items are loaded when entering a library",
+    "author": "brianpardy"
   }
 ]

--- a/source/static/whatsNew/3.1.8.json
+++ b/source/static/whatsNew/3.1.8.json
@@ -28,7 +28,7 @@
     "author": "gabeluci"
   },
   {
-    "description": "Add setting to select how many items are loaded when entering a library",
+    "description": "Add setting to select how many items are loaded together on library screens",
     "author": "brianpardy"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Add a user library setting to specify the number of library items preloaded upon entering a library. This overrides the hardcoded `m.top.limit = 60` in `LoadItemsTask2.bs`, allowing a user quickly scrolling down in a library to avoid waiting for the next batch of 60 items to lazy load. The setting defaults to the existing hardcoded value, so nothing changes for any user unless they modify this setting. 

After adding this setting a value of 100 provides a smoother scrolling experience on my system. I'm not sure why this limit was hardcoded in 621e53e64 but my 2024 Ultra 4850X handles preloading 100 items with no trouble.
<!-- Describe your changes here in 1-5 sentences. -->

