### PR TITLE
Fix logo image not hiding when OSD does

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -760,12 +760,17 @@ sub onVideoContentLoaded()
     ' Attempt to add logo to OSD and the display of info during buffering
     if isValidAndNotEmpty(videoContent[0].logoImage)
         m.osd.logoImage = videoContent[0].logoImage
-        bufferingLogoImage = createObject("roSGNode", "Poster")
-        bufferingLogoImage.Id = "bufferingLogoImage"
+
+        ' Create the buffering screen logo image node if it doesn't already exist
+        bufferingLogoImage = m.top.findNode("bufferingLogoImage")
+        if not isValid(bufferingLogoImage)
+            bufferingLogoImage = createObject("roSGNode", "Poster")
+            bufferingLogoImage.Id = "bufferingLogoImage"
+            bufferingLogoImage.translation = [103, 61]
+            m.top.appendChild(bufferingLogoImage)
+        end if
         bufferingLogoImage.observeField("loadStatus", "onBufferingLogoLoadStatusChanged")
         bufferingLogoImage.uri = videoContent[0].logoImage
-        bufferingLogoImage.translation = [103, 61]
-        m.top.appendChild(bufferingLogoImage)
 
         ' Don't show both the logo and the video title if this isn't an episode or trailer
         if m.top.content.contenttype <> 4 and videoContent[0].extraType <> "trailer"

--- a/source/static/whatsNew/3.1.9.json
+++ b/source/static/whatsNew/3.1.9.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "Fix media logo image not hiding when OSD does",
-    "author": "VTRunner"
+    "description": "",
+    "author": ""
   }
 ]

--- a/source/static/whatsNew/3.1.9.json
+++ b/source/static/whatsNew/3.1.9.json
@@ -2,5 +2,9 @@
   {
     "description": "Move the next up graphic and hide it if the OSD is visible",
     "author": "VTRunner"
+  },
+  {
+    "description": "Fix media logo image not hiding when OSD does",
+    "author": "VTRunner"
   }
 ]

--- a/source/static/whatsNew/3.1.9.json
+++ b/source/static/whatsNew/3.1.9.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "",
-    "author": ""
+    "description": "Fix media logo image not hiding when OSD does",
+    "author": "VTRunner"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Fix issue with the buffering screen logo image not being hidden under certain conditions

## Issues
Fixes [Jellyfin Roku Issue #822](https://github.com/jellyfin/jellyfin-roku/issues/822)