### PR TITLE
Move next up content and hide if OSD is visible

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1045,7 +1045,7 @@ sub displaySegmentSkipButton(segmentType as string, endticks as double)
 
     if isStringEqual(segmentType, MediaSegmentType.OUTRO)
         if m.nextupbuttonseconds = 0 then return ' is the button disabled?
-        displayNextItem()
+        if not m.osd.visible then displayNextItem() ' only show next episode info if OSD is not visible
     end if
 
     m.skipSegmentButton.visible = true
@@ -1508,6 +1508,7 @@ end sub
 '
 ' @param {string} whichfocus - indicates which element should be focused when showing the OSD. Accepts "videoControls" or "progressBar"
 sub showOSD(whichfocus as string)
+    hideNextItem() ' Hide next up info display when OSD is visible
     m.osd.visible = true
     m.osd.hasFocus = true
     if whichfocus = "videoControls"

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1045,7 +1045,9 @@ sub displaySegmentSkipButton(segmentType as string, endticks as double)
 
     if isStringEqual(segmentType, MediaSegmentType.OUTRO)
         if m.nextupbuttonseconds = 0 then return ' is the button disabled?
-        if not m.osd.visible then displayNextItem() ' only show next episode info if OSD is not visible
+        if not m.osd.visible 
+            displayNextItem() ' only show next episode info if OSD is not visible
+        end if
     end if
 
     m.skipSegmentButton.visible = true

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -54,7 +54,7 @@
 
     <Text id="videoEndingTime" font="font:SmallSystemFont" color="0xffffffFF" horizAlign="right" width="200" translation="[1617,900]" visible="false" />
 
-    <Rectangle id="nextUp" visible="false" color="0x000000CC" height="144" width="500" translation="[1275, 800]">
+    <Rectangle id="nextUp" visible="false" color="0x000000CC" height="144" width="785" translation="[1000, 920]">
       <Poster id="nextItemPoster" width="150" height="124" translation="[10, 10]" />
       <LayoutGroup layoutDirection="vert" horizAlignment="left" itemSpacings="[10, 10]" translation="[180, 15]">
         <Text text="Next Up" color="#FFFFFF" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="center" />

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -54,7 +54,7 @@
 
     <Text id="videoEndingTime" font="font:SmallSystemFont" color="0xffffffFF" horizAlign="right" width="200" translation="[1617,900]" visible="false" />
 
-    <Rectangle id="nextUp" visible="false" color="0x000000CC" height="144" width="500" translation="[1400, 500]">
+    <Rectangle id="nextUp" visible="false" color="0x000000CC" height="144" width="500" translation="[1275, 800]">
       <Poster id="nextItemPoster" width="150" height="124" translation="[10, 10]" />
       <LayoutGroup layoutDirection="vert" horizAlignment="left" itemSpacings="[10, 10]" translation="[180, 15]">
         <Text text="Next Up" color="#FFFFFF" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="center" />

--- a/source/static/whatsNew/3.1.9.json
+++ b/source/static/whatsNew/3.1.9.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "",
-    "author": ""
+    "description": "Move the next up graphic and hide it if the OSD is visible",
+    "author": "VTRunner"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Move the next up info graphic to just above the skip media button (same appearance as v3.1.7) and hide the next up graphic when the OSD is visible.

<img width="384" height="212" alt="Nextup Restored" src="https://github.com/user-attachments/assets/ad4ef744-1d92-49b1-84f4-1a3432aead07" />

## Issues
Fixes Jellyfin Roku Issue #827 