### PR TITLE
Fix media segment skip button not showing after back button dismissal

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1130,8 +1130,14 @@ sub checkSegmentSkipButton(position as double)
         exit for
     end for
 
-    ' Check if no match was found but the skip segment button is visible
+    ' Check if no match was found.  Reset skip button values if needed and hide the skip segment button if it is visible
     if not matchFound
+        ' When we are no longer in a media segment, we want to reset the currentSegmentType and mediaSegmentDismissed values so that if we encounter another segment of the same type later in the video, the button will show again.
+        ' Since this routine is called frequently, to reduce assignment cycles, check if segment button values have changed before resetting values
+        if isValid(m.currentSegmentType) or (isValid(m.mediaSegmentDismissed) and m.mediaSegmentDismissed.count() > 0)
+            m.currentSegmentType = invalid
+            m.mediaSegmentDismissed = {}
+        end if
         if m.skipSegmentButton.visible
             hideSegmentSkipButton()
         end if

--- a/source/static/whatsNew/3.1.9.json
+++ b/source/static/whatsNew/3.1.9.json
@@ -10,5 +10,9 @@
   {
     "description": "Change when video fast forward and rewind automatically resume play",
     "author": "VTRunner"
+  },
+  {
+    "description": "Fix the media segment skip button not showing after back button dismissal",
+    "author": "VTRunner"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
Reset dismissed media segments when play or scrubbing exits the current media segment for which the skip media segment button was dismissed using the back button.  This will allow the media segment skip button to show when play or scrubbing reenters a media segment.

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes Issue #835 