### PR TITLE
Fix possible crash when pressing back on the home screen

### DIFF
--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -312,9 +312,12 @@ function onKeyEvent(key as string, press as boolean) as boolean
     ' If the user hit back and is not on the first item of the row,
     ' assume they want to go to the first item of the row.
     ' Otherwise, they are exiting the app.
-    if isStringEqual(key, KeyCode.BACK) and m.homeRows.rowItemFocused[1] > 0
-        m.homeRows.jumpToRowItem = [m.homeRows.rowItemFocused[0], 0]
-        return true
+    if isStringEqual(key, KeyCode.BACK)
+        rowItemFocused = chainLookupReturn(m.homeRows, "rowItemFocused", [0, 0])
+        if rowItemFocused[1] > 0
+            m.homeRows.jumpToRowItem = [rowItemFocused[0], 0]
+            return true
+        end if
     end if
 
     if isStringEqual(key, KeyCode.OPTIONS)

--- a/source/static/whatsNew/3.1.9.json
+++ b/source/static/whatsNew/3.1.9.json
@@ -14,5 +14,9 @@
   {
     "description": "Fix the media segment skip button not showing after back button dismissal",
     "author": "VTRunner"
+  },
+  {
+    "description": "Fix possible crash when pressing back on the home screen",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Use chain lookup to safely evaluate m.homeRows.rowItemFocused when user presses back on home screen

## Notes
- Currently, this is # 1 reported crash in Roku logs