### PR TITLE
Create force transcode live TV setting

### DIFF
--- a/components/GetPlaybackInfoTask.bs
+++ b/components/GetPlaybackInfoTask.bs
@@ -14,12 +14,16 @@ function ItemPostPlaybackInfo(id as string)
     currentView = m.global.sceneManager.callFunc("getActiveScene")
     currentItem = m.global.queueManager.callFunc("getCurrentItem")
 
+    if not isValid(currentItem)
+        return invalid
+    end if
+
     body = {
         "DeviceProfile": getDeviceProfile()
     }
     params = {
         "UserId": m.global.session.user.id,
-        "StartTimeTicks": currentItem.startingPoint,
+        "StartTimeTicks": chainLookupReturn(currentItem, "startingPoint", 0),
         "IsPlayback": true,
         "AutoOpenLiveStream": true,
         "MaxStreamingBitrate": "140000000",

--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -352,20 +352,19 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
 end sub
 
 sub setTranscodeCodec(video as object, mediaSourceId as dynamic, audio_stream_idx as integer, subtitle_idx as integer, playbackPosition as longinteger)
-    if isStringEqual(m.global.queueManager.callFunc("getTranscodeCodec"), string.EMPTY)
-        for i = 0 to m.playbackInfo.MediaSources[0].MediaStreams.Count() - 1
-            if m.playbackInfo.MediaSources[0].MediaStreams[i].Type = "Video"
-                m.global.queueManager.callFunc("setForceTranscode", PlaybackMethod.FORCETRANSCODEDISABLEREMUX, m.playbackInfo.MediaSources[0].MediaStreams[i].Codec ?? string.EMPTY)
-                exit for
-            end if
-        end for
+    if not isStringEqual(m.global.queueManager.callFunc("getTranscodeCodec"), string.EMPTY) then return
 
-        m.playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition)
-        if not isValid(m.playbackInfo)
-            video.errorMsg = "Error loading playback info"
-            video.content = invalid
-            return
+    for i = 0 to m.playbackInfo.MediaSources[0].MediaStreams.Count() - 1
+        if m.playbackInfo.MediaSources[0].MediaStreams[i].Type = "Video"
+            m.global.queueManager.callFunc("setForceTranscode", PlaybackMethod.FORCETRANSCODEDISABLEREMUX, m.playbackInfo.MediaSources[0].MediaStreams[i].Codec ?? string.EMPTY)
+            exit for
         end if
+    end for
+
+    m.playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition)
+    if not isValid(m.playbackInfo)
+        video.errorMsg = "Error loading playback info"
+        video.content = invalid
     end if
 end sub
 

--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -246,21 +246,9 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
 
     ' If forceTranscode setting is enabled, but we haven't set the transcode codec yet, set it now and update Playback Info
     if isStringEqual(PlaybackMethod.FORCETRANSCODEDISABLEREMUX, chainLookupReturn(m.global.session, "user.settings.`playback.media.forceTranscode`", PlaybackMethod.PLAYNORMALLY))
-        if isStringEqual(m.global.queueManager.callFunc("getTranscodeCodec"), string.EMPTY)
-            for i = 0 to m.playbackInfo.MediaSources[0].MediaStreams.Count() - 1
-                if m.playbackInfo.MediaSources[0].MediaStreams[i].Type = "Video"
-                    m.global.queueManager.callFunc("setForceTranscode", PlaybackMethod.FORCETRANSCODEDISABLEREMUX, m.playbackInfo.MediaSources[0].MediaStreams[i].Codec ?? string.EMPTY)
-                    exit for
-                end if
-            end for
-
-            m.playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, m.top.selectedSubtitleIndex, playbackPosition)
-            if not isValid(m.playbackInfo)
-                video.errorMsg = "Error loading playback info"
-                video.content = invalid
-                return
-            end if
-        end if
+        setTranscodeCodec(video, mediaSourceId, audio_stream_idx, m.top.selectedSubtitleIndex, playbackPosition)
+    else if meta.live and isStringEqual(PlaybackMethod.FORCETRANSCODEDISABLEREMUX, chainLookupReturn(m.global.session, "user.settings.`playback.media.forceTranscodeLiveTV`", PlaybackMethod.PLAYNORMALLY))
+        setTranscodeCodec(video, mediaSourceId, audio_stream_idx, m.top.selectedSubtitleIndex, playbackPosition)
     end if
 
     addSubtitlesToVideo(video, meta)
@@ -361,6 +349,24 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
 
     setCertificateAuthority(video.content)
     video.content = authRequest(video.content)
+end sub
+
+sub setTranscodeCodec(video as object, mediaSourceId as dynamic, audio_stream_idx as integer, subtitle_idx as integer, playbackPosition as longinteger)
+    if isStringEqual(m.global.queueManager.callFunc("getTranscodeCodec"), string.EMPTY)
+        for i = 0 to m.playbackInfo.MediaSources[0].MediaStreams.Count() - 1
+            if m.playbackInfo.MediaSources[0].MediaStreams[i].Type = "Video"
+                m.global.queueManager.callFunc("setForceTranscode", PlaybackMethod.FORCETRANSCODEDISABLEREMUX, m.playbackInfo.MediaSources[0].MediaStreams[i].Codec ?? string.EMPTY)
+                exit for
+            end if
+        end for
+
+        m.playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, subtitle_idx, playbackPosition)
+        if not isValid(m.playbackInfo)
+            video.errorMsg = "Error loading playback info"
+            video.content = invalid
+            return
+        end if
+    end if
 end sub
 
 function isHTTPStream() as boolean

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1379,6 +1379,16 @@
             <extracomment>User Setting - Description for option</extracomment>
         </message>
         <message>
+            <source>Force Transcoding Live TV</source>
+            <translation>Force Transcoding Live TV</translation>
+            <extracomment>User Setting - Title for option</extracomment>
+        </message>
+        <message>
+            <source>Force live TV to be transcoded. If Force Transcoding is already set to Force Transcode (Remux Disabled), this setting is ignored.</source>
+            <translation>Force live TV to be transcoded. If Force Transcoding is already set to Force Transcode (Remux Disabled), this setting is ignored.</translation>
+            <extracomment>User Setting - Description for option</extracomment>
+        </message>
+        <message>
             <source>Media Segment Actions</source>
             <translation>Media Segment Actions</translation>
             <extracomment>User Setting - Title for option</extracomment>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1374,18 +1374,28 @@
             <extracomment>User Setting - Title for option</extracomment>
         </message>
         <message>
+            <source>Force media to be transcoded.</source>
+            <translation>Force media to be transcoded.</translation>
+            <extracomment>User Setting - Description for option</extracomment>
+        </message>
+        <message>
+            <source>All Playable Media</source>
+            <translation>All Playable Media</translation>
+            <extracomment>User Setting - Title for option</extracomment>
+        </message>
+        <message>
             <source>Force all playable media to be transcoded.</source>
             <translation>Force all playable media to be transcoded.</translation>
             <extracomment>User Setting - Description for option</extracomment>
         </message>
         <message>
-            <source>Force Transcoding Live TV</source>
-            <translation>Force Transcoding Live TV</translation>
+            <source>Live TV</source>
+            <translation>Live TV</translation>
             <extracomment>User Setting - Title for option</extracomment>
         </message>
         <message>
-            <source>Force live TV to be transcoded. If Force Transcoding is already set to Force Transcode (Remux Disabled), this setting is ignored.</source>
-            <translation>Force live TV to be transcoded. If Force Transcoding is already set to Force Transcode (Remux Disabled), this setting is ignored.</translation>
+            <source>Force live TV to be transcoded. If All Playable Media is already set to Force Transcode (Remux Disabled), this setting is ignored.</source>
+            <translation>Force live TV to be transcoded. If All Playable Media is already set to Force Transcode (Remux Disabled), this setting is ignored.</translation>
             <extracomment>User Setting - Description for option</extracomment>
         </message>
         <message>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -130,6 +130,23 @@
         ]
       },
       {
+        "title": "Force Transcoding Live TV",
+        "description": "Force live TV to be transcoded. If Force Transcoding is already set to Force Transcode (Remux Disabled), this setting is ignored.",
+        "settingName": "playback.media.forceTranscodeLiveTV",
+        "type": "radio",
+        "default": "playNormally",
+        "options": [
+          {
+            "title": "Play Normally",
+            "id": "playNormally"
+          },
+          {
+            "title": "Force Transcode (Remux Disabled)",
+            "id": "forceTranscodeDisableRemux"
+          }
+        ]
+      },
+      {
         "title": "Maximum Audio Channels",
         "description": "Configure the maximum audio channels when playing video files on this device.",
         "settingName": "playback.media.maxAudioChannels",
@@ -336,7 +353,7 @@
         "type": "integer",
         "default": "30"
       },
-        {
+      {
         "title": "Playback Speed Controls (Experimental)",
         "description": "Use at your own risk. We make no guarantees this will work for you. \n 1. This feature may not work on this device, yet work on others \n 2. Some speed options may not work on this device, yet work on others \n 3. Roku may block this feature without warning; even if the Jellyfin client doesn't update",
         "settingName": "playback.showPlaybackSpeedControls",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -110,39 +110,45 @@
       },
       {
         "title": "Force Transcoding",
-        "description": "Force all playable media to be transcoded.",
-        "settingName": "playback.media.forceTranscode",
-        "type": "radio",
-        "default": "playNormally",
-        "options": [
+        "description": "Force media to be transcoded.",
+        "children": [
           {
-            "title": "Play Normally",
-            "id": "playNormally"
+            "title": "All Playable Media",
+            "description": "Force all playable media to be transcoded.",
+            "settingName": "playback.media.forceTranscode",
+            "type": "radio",
+            "default": "playNormally",
+            "options": [
+              {
+                "title": "Play Normally",
+                "id": "playNormally"
+              },
+              {
+                "title": "Force Transcode (Allow Remux)",
+                "id": "forceTranscodeAllowRemux"
+              },
+              {
+                "title": "Force Transcode (Remux Disabled)",
+                "id": "forceTranscodeDisableRemux"
+              }
+            ]
           },
           {
-            "title": "Force Transcode (Allow Remux)",
-            "id": "forceTranscodeAllowRemux"
-          },
-          {
-            "title": "Force Transcode (Remux Disabled)",
-            "id": "forceTranscodeDisableRemux"
-          }
-        ]
-      },
-      {
-        "title": "Force Transcoding Live TV",
-        "description": "Force live TV to be transcoded. If Force Transcoding is already set to Force Transcode (Remux Disabled), this setting is ignored.",
-        "settingName": "playback.media.forceTranscodeLiveTV",
-        "type": "radio",
-        "default": "playNormally",
-        "options": [
-          {
-            "title": "Play Normally",
-            "id": "playNormally"
-          },
-          {
-            "title": "Force Transcode (Remux Disabled)",
-            "id": "forceTranscodeDisableRemux"
+            "title": "Live TV",
+            "description": "Force live TV to be transcoded. If All Playable Media is already set to Force Transcode (Remux Disabled), this setting is ignored.",
+            "settingName": "playback.media.forceTranscodeLiveTV",
+            "type": "radio",
+            "default": "playNormally",
+            "options": [
+              {
+                "title": "Play Normally",
+                "id": "playNormally"
+              },
+              {
+                "title": "Force Transcode (Remux Disabled)",
+                "id": "forceTranscodeDisableRemux"
+              }
+            ]
           }
         ]
       },

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -18,5 +18,9 @@
   {
     "description": "Fix Cinema Mode Intros",
     "author": "Starwarsfan2099"
+  },
+  {
+    "description": "Allow Force Transcode for live TV only",
+    "author": "FractalBoy"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
Currently, there is no option to force transcoding for only live TV. My live TV does not work well without transcoding but I don't want to go back and forth and flip the main setting back and forth depending on what I'm watching.

This PR adds an option to force transcoding, which will only apply to live TV.

I only included the "Disable Remux" option because I don't see the benefit of the "Allow Remux" for this purpose, and it seemed trickier to implement. I also considered putting the new setting under Live TV options but landed on putting it next to the main "Force Transcoding" option.

I also included a bug fix which was causing Roku to crash when opening the Playback Info dialog on (some) live TV.
