### PR TITLE
Fix Roku subtitle menu for burned-in tracks

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -803,7 +803,6 @@ sub onVideoContentLoaded()
 
         if subtitle.Index = videoContent[0].selectedSubtitle
             selectedSubtitle = subtitle
-            exit for
         end if
     end for
 
@@ -826,9 +825,7 @@ sub onVideoContentLoaded()
         end if
     end if
 
-    if not (m.isTranscoded and burnInSubtitles)
-        m.top.selectedSubtitle = videoContent[0].selectedSubtitle
-    end if
+    m.top.selectedSubtitle = videoContent[0].selectedSubtitle
 
     m.top.observeField("selectedSubtitle", "onSubtitleChange")
 

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -26,5 +26,9 @@
   {
     "description": "Keep focus on the top row when opening playback options",
     "author": "VX-101"
+  },
+  {
+    "description": "Fix subtitle menu selection for burned-in subtitles",
+    "author": "VX-101"
   }
 ]


### PR DESCRIPTION
## Changes

Fixes the in-playback subtitle menu state when playback is transcoding with burned-in subtitles.

When burn-in subtitles were enabled, `onVideoContentLoaded()` marked subtitle tracks as encoded but stopped iterating after finding the selected track. That meant any later subtitle tracks were dropped from `fullSubtitleData`, so the playback subtitle menu could show an incomplete list.

The player also skipped updating `selectedSubtitle` during burned-in subtitle playback, so the menu could show `None` even though Jellyfin had selected and burned in a default subtitle stream.

This change:
- keeps processing the full subtitle list when marking burned-in tracks as encoded
- always updates `selectedSubtitle` while the observer is temporarily removed
- preserves the existing observer guard so this state update does not trigger an unnecessary reload

Fixes #851, #553

## Testing

- Ran `npm run build` successfully.
- Sideloaded the generated Roku package.
- Tested with an MKV containing two English PGS subtitle tracks.
- Confirmed the in-playback subtitle menu shows `None` plus both PGS tracks.
- Confirmed the default burned-in subtitle track is selected correctly and default CC works.
