### PR TITLE
Start with focus on top row when opening playback options

### DIFF
--- a/components/movies/MovieOptions.bs
+++ b/components/movies/MovieOptions.bs
@@ -166,7 +166,10 @@ end sub
 
 
 function onKeyEvent(key as string, press as boolean) as boolean
-    if not press then return false
+    ' Prevent the OK release that opens this menu from moving focus off the top row
+    if not press and key = KeyCode.OK and m.top.findNode("buttons").hasFocus()
+        return true
+    end if
 
     if key = KeyCode.DOWN or (key = KeyCode.OK and m.top.findNode("buttons").hasFocus())
         m.top.findNode("buttons").setFocus(false)

--- a/components/movies/MovieOptions.bs
+++ b/components/movies/MovieOptions.bs
@@ -166,6 +166,8 @@ end sub
 
 
 function onKeyEvent(key as string, press as boolean) as boolean
+    if not press then return false
+
     if key = KeyCode.DOWN or (key = KeyCode.OK and m.top.findNode("buttons").hasFocus())
         m.top.findNode("buttons").setFocus(false)
         m.menus[m.selectedItem].setFocus(true)

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -1,9 +1,5 @@
 [
   {
-    "description": "Keep focus on the top row when opening playback options.",
-    "author": "VX-101"
-  },
-  {
     "description": "Fix display of no items found text in libraries",
     "author": "1hitsong"
   },
@@ -22,5 +18,9 @@
   {
     "description": "Fix Cinema Mode Intros",
     "author": "Starwarsfan2099"
+  },
+  {
+    "description": "Keep focus on the top row when opening playback options",
+    "author": "VX-101"
   }
 ]

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -1,5 +1,9 @@
 [
   {
+    "description": "Keep focus on the top row when opening playback options.",
+    "author": "VX-101"
+  },
+  {
     "description": "Fix display of no items found text in libraries",
     "author": "1hitsong"
   },


### PR DESCRIPTION
## Summary
- Ignore the trailing OK key-up event when opening Options so focus stays on the top row.
- Keep initial focus on the top Options row until the user intentionally moves into a list.

## Testing
- Ran `npm run build` successfully.
- Sideloaded the generated Roku package.
- Verified opening Options no longer jumps the cursor into the Subtitles list.
- Tested **Options** (Play Normally / Force Transcode) and **Audio** (Default / Non-default). The selections are honored.