### PR TITLE
Fix `None` subtitle playback selection after PR854. 

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -811,6 +811,11 @@ sub onVideoContentLoaded()
         m.top.globalCaptionMode = "Off"
     end if
 
+    if videoContent[0].selectedSubtitle = SubtitleSelection.NONE
+        m.top.globalCaptionMode = "Off"
+        m.top.subtitleTrack = ""
+    end if
+
     if isValid(selectedSubtitle)
         availableSubtitleTrackIndex = availSubtitleTrackIdx(selectedSubtitle.Track.TrackName)
         if availableSubtitleTrackIndex <> SubtitleSelection.NONE

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -803,7 +803,6 @@ sub onVideoContentLoaded()
 
         if subtitle.Index = videoContent[0].selectedSubtitle
             selectedSubtitle = subtitle
-            exit for
         end if
     end for
 
@@ -826,9 +825,7 @@ sub onVideoContentLoaded()
         end if
     end if
 
-    if not (m.isTranscoded and burnInSubtitles)
-        m.top.selectedSubtitle = videoContent[0].selectedSubtitle
-    end if
+    m.top.selectedSubtitle = videoContent[0].selectedSubtitle
 
     m.top.observeField("selectedSubtitle", "onSubtitleChange")
 


### PR DESCRIPTION
## Summary

This PR fixes a previously hidden Roku caption-mode issue exposed by #854.

After #854, pre-playback subtitle selection can pass `SubtitleSelection.NONE` into playback. However, Roku’s native caption renderer could still remain `On`, allowing subtitles to display even though `None` was selected.

This change turns Roku caption mode off and clears the active subtitle track when playback starts with `SubtitleSelection.NONE`.

## Related PRs

- Depends on #854 because this issue is only visible once pre-playback subtitle selection reaches playback.
- Related to #857, but separate. PR857 covers subtitle info/checkmark display; this PR only fixes playback after `None` is explicitly selected.

## Testing

- Ran `npm run build` successfully.
- Sideloaded local Roku build.
- Tested with generated SRT/SubRip subtitle clips.
- Verified selecting a real subtitle track before playback still displays subtitles.
- Verified selecting `None` after selecting a real subtitle track starts playback with no subtitles displayed.