### PR TITLE
Add outline to subtitles when Custom Subtitles are enabled and background opacity is off

### DIFF
--- a/components/captionShadow.bs
+++ b/components/captionShadow.bs
@@ -8,7 +8,7 @@ const OUTLINE_DIAG_RATIO = 0.06 ' ~6% fontSize for diagonals
 const BASE_OFFSET = 5 ' Matches lg.translation in captionTask.bs
 
 sub createShadowLabels(rect as object, styledText as string, drawingStyles as object)
-    if styledText = invalid or styledText = "" then return
+    if not isValidAndNotEmpty(styledText) then return
 
     fontSize = 60 ' fallback
     for each key in drawingStyles.keys()

--- a/components/captionShadow.bs
+++ b/components/captionShadow.bs
@@ -18,18 +18,18 @@ sub createShadowLabels(rect as object, styledText as string, drawingStyles as ob
         ' No shadow labels - Roku's Default visually produces no visible effect, so we treat it as None
         return
     else if isStringEqual(textEffect, "Raised")
-        ' Shadow below and to the right, giving the text a raised appearance
-        offsets = [
-            [BASE_OFFSET + outlineStep, BASE_OFFSET],
-            [BASE_OFFSET, BASE_OFFSET + outlineStep],
-            [BASE_OFFSET + outlineDiag, BASE_OFFSET + outlineDiag]
-        ]
-    else if isStringEqual(textEffect, "Depressed")
-        ' Shadow above and to the left, giving the text a depressed appearance
+        ' Shadow above and to the left, giving the text a raised appearance
         offsets = [
             [BASE_OFFSET - outlineStep, BASE_OFFSET],
             [BASE_OFFSET, BASE_OFFSET - outlineStep],
             [BASE_OFFSET - outlineDiag, BASE_OFFSET - outlineDiag]
+        ]
+    else if isStringEqual(textEffect, "Depressed")
+        ' Shadow below and to the right, giving the text a depressed appearance
+        offsets = [
+            [BASE_OFFSET + outlineStep, BASE_OFFSET],
+            [BASE_OFFSET, BASE_OFFSET + outlineStep],
+            [BASE_OFFSET + outlineDiag, BASE_OFFSET + outlineDiag]
         ]
     else if isStringEqual(textEffect, "Drop shadow (left)")
         ' Single diagonal shadow to the bottom-left

--- a/components/captionShadow.bs
+++ b/components/captionShadow.bs
@@ -7,31 +7,56 @@ const OUTLINE_STEP_RATIO = 0.085 ' ~8.5% fontSize for cardinal directions
 const OUTLINE_DIAG_RATIO = 0.06 ' ~6% fontSize for diagonals
 const BASE_OFFSET = 5 ' Matches lg.translation in captionTask.bs
 
-sub createShadowLabels(rect as object, styledText as string, drawingStyles as object)
-    if not isValidAndNotEmpty(styledText) then return
+sub createShadowLabels(rect as object, styledText as string, drawingStyles as object, textEffect as string)
 
-    fontSize = 60 ' fallback
-    for each key in drawingStyles.keys()
-        fontSize = drawingStyles[key].fontSize
-        exit for
-    end for
+    fontSize = drawingStyles["default"].fontSize
 
     outlineStep = Int(fontSize * OUTLINE_STEP_RATIO)
     outlineDiag = Int(fontSize * OUTLINE_DIAG_RATIO)
 
-    ' 4 cardinals (large step) + 4 diagonals (small step) = uniform outline
-    ' Offset base [5,5] compensates for lg.translation = [5,5] in captionTask.bs
-    ' so shadow labels align with the main text label
-    offsets = [
-        [BASE_OFFSET, BASE_OFFSET - outlineStep],
-        [BASE_OFFSET, BASE_OFFSET + outlineStep],
-        [BASE_OFFSET - outlineStep, BASE_OFFSET],
-        [BASE_OFFSET + outlineStep, BASE_OFFSET],
-        [BASE_OFFSET - outlineDiag, BASE_OFFSET - outlineDiag],
-        [BASE_OFFSET + outlineDiag, BASE_OFFSET - outlineDiag],
-        [BASE_OFFSET - outlineDiag, BASE_OFFSET + outlineDiag],
-        [BASE_OFFSET + outlineDiag, BASE_OFFSET + outlineDiag]
-    ]
+    if isStringEqual(textEffect, "None") or isStringEqual(textEffect, "Default")
+        ' No shadow labels - Roku's Default visually produces no visible effect, so we treat it as None
+        return
+    else if isStringEqual(textEffect, "Raised")
+        ' Shadow below and to the right, giving the text a raised appearance
+        offsets = [
+            [BASE_OFFSET + outlineStep, BASE_OFFSET],
+            [BASE_OFFSET, BASE_OFFSET + outlineStep],
+            [BASE_OFFSET + outlineDiag, BASE_OFFSET + outlineDiag]
+        ]
+    else if isStringEqual(textEffect, "Depressed")
+        ' Shadow above and to the left, giving the text a depressed appearance
+        offsets = [
+            [BASE_OFFSET - outlineStep, BASE_OFFSET],
+            [BASE_OFFSET, BASE_OFFSET - outlineStep],
+            [BASE_OFFSET - outlineDiag, BASE_OFFSET - outlineDiag]
+        ]
+    else if isStringEqual(textEffect, "Drop shadow (left)")
+        ' Single diagonal shadow to the bottom-left
+        offsets = [
+            [BASE_OFFSET - outlineDiag, BASE_OFFSET + outlineDiag]
+        ]
+    else if isStringEqual(textEffect, "Drop shadow (right)")
+        ' Single diagonal shadow to the bottom-right
+        offsets = [
+            [BASE_OFFSET + outlineDiag, BASE_OFFSET + outlineDiag]
+        ]
+    else
+        ' Uniform and any unrecognized value
+        ' 4 cardinals (large step) + 4 diagonals (small step) = uniform outline
+        ' Offset base [5,5] compensates for lg.translation = [5,5] in captionTask.bs
+        ' so shadow labels align with the main text label
+        offsets = [
+            [BASE_OFFSET, BASE_OFFSET - outlineStep],
+            [BASE_OFFSET, BASE_OFFSET + outlineStep],
+            [BASE_OFFSET - outlineStep, BASE_OFFSET],
+            [BASE_OFFSET + outlineStep, BASE_OFFSET],
+            [BASE_OFFSET - outlineDiag, BASE_OFFSET - outlineDiag],
+            [BASE_OFFSET + outlineDiag, BASE_OFFSET - outlineDiag],
+            [BASE_OFFSET - outlineDiag, BASE_OFFSET + outlineDiag],
+            [BASE_OFFSET + outlineDiag, BASE_OFFSET + outlineDiag]
+        ]
+    end if
 
     shadowDrawingStyles = {}
     for each key in drawingStyles.keys()

--- a/components/captionShadow.bs
+++ b/components/captionShadow.bs
@@ -1,0 +1,32 @@
+' captionShadow.bs
+' Adds outline/shadow labels to a caption rectangle
+
+sub createShadowLabels(rect as object, styledText as string, drawingStyles as object)
+    if styledText = invalid or styledText = "" then return
+
+    ' 4 corners at 2px offset (lighter, subtle outline)
+    ' offsets = [[3, 3], [7, 3], [3, 7], [7, 7]]
+
+    ' 8 points at 4px offset (fuller outline)
+    offsets = [[1, 1], [9, 1], [1, 9], [9, 9], [5, 1], [5, 9], [1, 5], [9, 5]]
+
+    shadowDrawingStyles = {}
+    for each key in drawingStyles.keys()
+        style = drawingStyles[key]
+        shadowDrawingStyles[key] = {
+            "fontUri": style.fontUri,
+            "fontSize": style.fontSize,
+            "color": "0x000000CC"
+        }
+    end for
+
+    for each offset in offsets
+        lbl = CreateObject("roSGNode", "MultiStyleLabel")
+        lbl.drawingStyles = shadowDrawingStyles
+        lbl.text = styledText
+        lbl.horizAlign = "center"
+        lbl.translation = offset
+        rect.appendchild(lbl)
+    end for
+
+end sub

--- a/components/captionShadow.bs
+++ b/components/captionShadow.bs
@@ -1,14 +1,37 @@
 ' captionShadow.bs
 ' Adds outline/shadow labels to a caption rectangle
 
+' Ratios relative to fontSize for consistent outline across text sizes
+' 8.5 and 6 were chosen based on visual testing to create a balanced outline effect (WAF)
+const OUTLINE_STEP_RATIO = 0.085 ' ~8.5% fontSize for cardinal directions
+const OUTLINE_DIAG_RATIO = 0.06 ' ~6% fontSize for diagonals
+const BASE_OFFSET = 5 ' Matches lg.translation in captionTask.bs
+
 sub createShadowLabels(rect as object, styledText as string, drawingStyles as object)
     if styledText = invalid or styledText = "" then return
 
-    ' 4 corners at 2px offset (lighter, subtle outline)
-    ' offsets = [[3, 3], [7, 3], [3, 7], [7, 7]]
+    fontSize = 60 ' fallback
+    for each key in drawingStyles.keys()
+        fontSize = drawingStyles[key].fontSize
+        exit for
+    end for
 
-    ' 8 points at 4px offset (fuller outline)
-    offsets = [[1, 1], [9, 1], [1, 9], [9, 9], [5, 1], [5, 9], [1, 5], [9, 5]]
+    outlineStep = Int(fontSize * OUTLINE_STEP_RATIO)
+    outlineDiag = Int(fontSize * OUTLINE_DIAG_RATIO)
+
+    ' 4 cardinals (large step) + 4 diagonals (small step) = uniform outline
+    ' Offset base [5,5] compensates for lg.translation = [5,5] in captionTask.bs
+    ' so shadow labels align with the main text label
+    offsets = [
+        [BASE_OFFSET, BASE_OFFSET - outlineStep],
+        [BASE_OFFSET, BASE_OFFSET + outlineStep],
+        [BASE_OFFSET - outlineStep, BASE_OFFSET],
+        [BASE_OFFSET + outlineStep, BASE_OFFSET],
+        [BASE_OFFSET - outlineDiag, BASE_OFFSET - outlineDiag],
+        [BASE_OFFSET + outlineDiag, BASE_OFFSET - outlineDiag],
+        [BASE_OFFSET - outlineDiag, BASE_OFFSET + outlineDiag],
+        [BASE_OFFSET + outlineDiag, BASE_OFFSET + outlineDiag]
+    ]
 
     shadowDrawingStyles = {}
     for each key in drawingStyles.keys()

--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -37,8 +37,7 @@ sub init()
     deviceBGColor = chainLookupReturn(m.bgColorDict, deviceInfo.GetCaptionsOption("Background/Color"), m.bgColorDict.Default)
     deviceBGOpacity = chainLookupReturn(m.percentageDict, deviceInfo.GetCaptionsOption("Background/Opacity"), m.percentageDict.Default)
     m.bgColor = `${deviceBGColor}${deviceBGOpacity}`
-
-    m.shadowEnabled = isStringEqual(deviceBGOpacity, "00")
+    m.textEffect = deviceInfo.GetCaptionsOption("Text/Effect")
 
     if isValidAndNotEmpty(m.global.fallbackFont)
         m.fonts = m.global.fallbackFont
@@ -82,10 +81,8 @@ function newRect(lg, id as string, styledText = invalid, drawingStyles = invalid
 
     rect = CreateObject("roSGNode", "Rectangle")
     rect.addreplace("id", id)
-    if m.shadowEnabled
-        if isValid(styledText)
-        createShadowLabels(rect, styledText, drawingStyles)
-    end if
+    createShadowLabels(rect, styledText, drawingStyles, m.textEffect)
+
     rect.appendchild(lg)
     lg.translation = [5, 5]
 
@@ -118,8 +115,6 @@ sub updateCaption()
         if entry["start"] <= m.top.currentPos and m.top.currentPos < entry["end"]
 
             fullText = entry["text"].Join(Chr(10))
-            plainText = m.undesirableTags.replaceAll(fullText, "")
-            plainText = CreateObject("roRegex", "<[^>]*>", "i").replaceAll(plainText, "")
 
             ' look for style tags
             currentStyle = {

--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -1,3 +1,4 @@
+import "pkg:/components/captionShadow.bs"
 import "pkg:/source/api/baserequest.bs"
 import "pkg:/source/enums/CaptionMoveDirection.bs"
 import "pkg:/source/enums/MediaPlaybackState.bs"
@@ -37,6 +38,8 @@ sub init()
     deviceBGOpacity = chainLookupReturn(m.percentageDict, deviceInfo.GetCaptionsOption("Background/Opacity"), m.percentageDict.Default)
     m.bgColor = `${deviceBGColor}${deviceBGOpacity}`
 
+    m.shadowEnabled = isStringEqual(deviceBGOpacity, "00")
+
     if isValidAndNotEmpty(m.global.fallbackFont)
         m.fonts = m.global.fallbackFont
     else
@@ -73,11 +76,15 @@ function newLayoutGroup(label)
     return newlg
 end function
 
-function newRect(lg, id as string)
+
+function newRect(lg, id as string, styledText = invalid, drawingStyles = invalid)
     rectxy = lg.BoundingRect()
 
     rect = CreateObject("roSGNode", "Rectangle")
     rect.addreplace("id", id)
+    if styledText <> invalid and m.shadowEnabled
+        createShadowLabels(rect, styledText, drawingStyles)
+    end if
     rect.appendchild(lg)
     lg.translation = [5, 5]
 
@@ -110,6 +117,8 @@ sub updateCaption()
         if entry["start"] <= m.top.currentPos and m.top.currentPos < entry["end"]
 
             fullText = entry["text"].Join(Chr(10))
+            plainText = m.undesirableTags.replaceAll(fullText, "")
+            plainText = CreateObject("roRegex", "<[^>]*>", "i").replaceAll(plainText, "")
 
             ' look for style tags
             currentStyle = {
@@ -284,9 +293,10 @@ sub updateCaption()
             label.drawingStyles = drawingStyles
             label.text = styledText
             label.horizAlign = "center"
-            lines = newLayoutGroup(label)
-            rect = newRect(lines, entry.LookupCI("id"))
 
+
+            lines = newLayoutGroup(label)
+            rect = newRect(lines, entry.LookupCI("id"), styledText, drawingStyles)
             finalStyles = prepareStyles(entry["styles"], rect, entry["text"].count())
             rect.translation = finalStyles.translation
 

--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -82,7 +82,8 @@ function newRect(lg, id as string, styledText = invalid, drawingStyles = invalid
 
     rect = CreateObject("roSGNode", "Rectangle")
     rect.addreplace("id", id)
-    if styledText <> invalid and m.shadowEnabled
+    if m.shadowEnabled
+        if isValid(styledText)
         createShadowLabels(rect, styledText, drawingStyles)
     end if
     rect.appendchild(lg)

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -38,5 +38,9 @@
   {
     "description": "Improve Down navigation in library grids with short last rows",
     "author": "VX-101"
+  },
+  {
+    "description": "Honor Roku text edge effects for custom subtitles",
+    "author": "ferezvi"
   }
 ]


### PR DESCRIPTION

When Custom Subtitles are enabled (Settings > Playback > Custom Subtitles) AND Background Opacity is "Off" (Roku Settings > Accessibility > Captions style), subtitles are hard to read on bright backgrounds because there is no outline.

This PR adds a semi-transparent black outline to fix this.

Closes #870 

<img width="2570" height="590" alt="comparison" src="https://github.com/user-attachments/assets/8abda2d2-ed8d-40d0-a535-297e95d4a1c9" />