### PR TITLE
Update description for custom subtitles setting

### DIFF
--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -907,8 +907,8 @@
             <extracomment>Name of a setting - custom subtitles that support CJK fonts</extracomment>
         </message>
         <message>
-            <source>Replace Roku&apos;s default subtitle functions with custom functions. If a fallback font is configured and enabled on the server, that font will be used. A fallback font is required for CJK rendering to work. To support bold and italics with your fallback font, you must have additional font files on the server with the words &quot;bold&quot;, &quot;italic&quot;, and &quot;bolditalic&quot;.</source>
-            <translation>Replace Roku&apos;s default subtitle functions with custom functions. If a fallback font is configured and enabled on the server, that font will be used. A fallback font is required for CJK rendering to work. To support bold and italics with your fallback font, you must have additional font files on the server with the words &quot;bold&quot;, &quot;italic&quot;, and &quot;bolditalic&quot;.</translation>
+            <source>Replace Roku&apos;s default subtitle functions with custom functions. If fallback fonts are configured and enabled on the server, those fonts will be used. A CJK fallback font is required for CJK rendering. To support bold and italics, you must have additional font files with the words &quot;bold&quot;, &quot;italic&quot;, and &quot;bolditalic&quot; in the filename.</source>
+            <translation>Replace Roku&apos;s default subtitle functions with custom functions. If fallback fonts are configured and enabled on the server, those fonts will be used. A CJK fallback font is required for CJK rendering. To support bold and italics, you must have additional font files with the words &quot;bold&quot;, &quot;italic&quot;, and &quot;bolditalic&quot; in the filename.</translation>
             <extracomment>Description of a setting - custom subtitles that support CJK fonts</extracomment>
         </message>
         <message>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -907,8 +907,8 @@
             <extracomment>Name of a setting - custom subtitles that support CJK fonts</extracomment>
         </message>
         <message>
-            <source>Replace Roku's default subtitle functions with custom functions that support CJK fonts. Fallback fonts must be configured and enabled on the server for CJK rendering to work.</source>
-            <translation>Replace Roku's default subtitle functions with custom functions that support CJK fonts. Fallback fonts must be configured and enabled on the server for CJK rendering to work.</translation>
+            <source>Replace Roku&apos;s default subtitle functions with custom functions. If a fallback font is configured and enabled on the server, that font will be used. A fallback font is required for CJK rendering to work. To support bold and italics with your fallback font, you must have additional font files on the server with the words &quot;bold&quot;, &quot;italic&quot;, and &quot;bolditalic&quot;.</source>
+            <translation>Replace Roku&apos;s default subtitle functions with custom functions. If a fallback font is configured and enabled on the server, that font will be used. A fallback font is required for CJK rendering to work. To support bold and italics with your fallback font, you must have additional font files on the server with the words &quot;bold&quot;, &quot;italic&quot;, and &quot;bolditalic&quot;.</translation>
             <extracomment>Description of a setting - custom subtitles that support CJK fonts</extracomment>
         </message>
         <message>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -86,7 +86,7 @@
       },
       {
         "title": "Custom Subtitles",
-        "description": "Replace Roku's default subtitle functions with custom functions that support CJK fonts. Fallback fonts must be configured and enabled on the server for CJK rendering to work.",
+        "description": "Replace Roku's default subtitle functions with custom functions. If a fallback font is configured and enabled on the server, that font will be used. A fallback font is required for CJK rendering to work. To support bold and italics with your fallback font, you must have additional font files on the server with the words \"bold\", \"italic\", and \"bolditalic\".",
         "settingName": "playback.subs.custom",
         "type": "bool",
         "default": "false"
@@ -336,7 +336,7 @@
         "type": "integer",
         "default": "30"
       },
-        {
+      {
         "title": "Playback Speed Controls (Experimental)",
         "description": "Use at your own risk. We make no guarantees this will work for you. \n 1. This feature may not work on this device, yet work on others \n 2. Some speed options may not work on this device, yet work on others \n 3. Roku may block this feature without warning; even if the Jellyfin client doesn't update",
         "settingName": "playback.showPlaybackSpeedControls",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -86,7 +86,7 @@
       },
       {
         "title": "Custom Subtitles",
-        "description": "Replace Roku's default subtitle functions with custom functions. If a fallback font is configured and enabled on the server, that font will be used. A fallback font is required for CJK rendering to work. To support bold and italics with your fallback font, you must have additional font files on the server with the words \"bold\", \"italic\", and \"bolditalic\".",
+        "description": "Replace Roku's default subtitle functions with custom functions. If fallback fonts are configured and enabled on the server, those fonts will be used. A CJK fallback font is required for CJK rendering. To support bold and italics, you must have additional font files with the words \"bold\", \"italic\", and \"bolditalic\" in the filename.",
         "settingName": "playback.subs.custom",
         "type": "bool",
         "default": "false"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Updated the description of the custom subtitles setting to document the new support for bold and italics with a fallback font. (#808)

I tried to keep it as short as possible, because of limited screen space, while still giving all the information needed for someone to use the feature. If you can recommend more concise wording, feel free.

This is what it looks like on screen:
<img width="2000" height="1126" alt="20260505_171800" src="https://github.com/user-attachments/assets/1fc64f87-fe5e-4bab-a584-4612a06aea08" />
