### PR TITLE
Improve loading live TV schedule

### DIFF
--- a/components/liveTv/schedule.bs
+++ b/components/liveTv/schedule.bs
@@ -153,8 +153,6 @@ sub loadScheduleData()
 
     m.LoadScheduleTask.channelIds = m.channelIdList.slice(startingIndex, startingIndex + m.channelScheduleLimit).join(", ")
     m.LoadScheduleTask.control = TaskControl.RUN
-
-    m.channelScheduleLimit = 500
 end sub
 
 ' When LoadScheduleTask completes (initial or more data) and we have a schedule to display
@@ -193,8 +191,13 @@ sub onScheduleLoaded()
     stopLoadingSpinner()
 
     m.channelScheduleLoadedCount = m.loadedChannels.count()
-
     m.LoadScheduleTask.schedule = invalid
+
+    ' Received fewer channels than requested, so we likely have an incomplete EPG
+    ' Don't try to load any more channels even if we haven't hit the expected number of channels
+    if m.channelScheduleLoadedCount < m.channelScheduleLimit
+        return
+    end if
 
     if m.LoadChannelsTask.totalRecordCount > m.channelScheduleLoadedCount
         loadScheduleData()

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -22,5 +22,13 @@
   {
     "description": "Allow Force Transcode for live TV only",
     "author": "FractalBoy"
+  },
+  {
+    "description": "Stop loading live TV EPG when there is no more data to load",
+    "author": "FractalBoy"
+  },
+  {
+    "description": "Only load 50 live TV channels at a time",
+    "author": "FractalBoy"
   }
 ]


### PR DESCRIPTION
## Changes
This PR contains two changes:

Currently, live TV loading works as follows:

1. 50 channels are loaded, and the loading is considered complete and the spinner goes away.
2. The next 500 channels are loaded, then the next 500, etc, until there is EPG data for all channels.

There are two problems with this approach:

1. If Jellyfin returns an incomplete EPG (i.e. you have x channels, but Jellyfin returns y < x channels), then the Roku app never recognizes that loading is complete, and continues to keep loading the last chunk.
2. Loading 500 channels at a time is slow, and if you scroll quickly you will see a delay in loading and "No data available" for later channels.

The solution:

1. If the amount of EPG channels returned by Jellyfin is less than the requested amount, stop loading channels. Jellyfin should give us the amount of channels requested. If it returns less than that, it should mean there is nothing left to return and we shouldn't request more.
2. Rather than loading 50, then 500, then 500, just load 50 at a time. In my testing, 50 was fast enough to keep up with fast scrolling and I never saw "No data available".