### PR TITLE
Fix voice search

### DIFF
--- a/components/Libraries/MusicLibraryView.bs
+++ b/components/Libraries/MusicLibraryView.bs
@@ -1142,10 +1142,8 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
         if m.loadedItems = 0
             m.global.sceneManager.observeFieldScoped("returnData", "onReturnData")
-            m.dropdownOptionGroup@.setFocus("sortButton", true)
-            m.sortButton.setfocus(true)
-            group = m.global.sceneManager.callFunc("getActiveScene")
-            group.lastFocus = m.sortButton
+            m.dropdownOptionGroup@.setFocus("voiceBox", true)
+            m.dropdownOptionGroup@.setSearchBackground(SearchButtonState.ACTIVE)
         else
             m.itemGrid.setFocus(m.itemGrid.opacity = 1)
             m.genreList.setFocus(m.genreList.opacity = 1)

--- a/components/Libraries/MusicLibraryView.bs
+++ b/components/Libraries/MusicLibraryView.bs
@@ -37,7 +37,7 @@ sub setupNodes()
     m.dropdownOptionGroup = m.top.findNode("dropdownOptionGroup")
     m.dropdownOptionGroup.observeFieldScoped("showOptions", "onShowOptionsChange")
     m.dropdownOptionGroup.observeFieldScoped("exit", "onExit")
-    m.dropdownOptionGroup.observeFieldScoped("searchTerm", "onSearchTermChanged")
+    m.dropdownOptionGroup.observeFieldScoped("searchTerm", "onDropdownOptionGroupSearchTermChanged")
 end sub
 
 sub onShowOptionsChange()
@@ -969,6 +969,10 @@ sub resetDropdownsToDefaultState()
     end if
 
     m.getFiltersTask.control = "RUN"
+end sub
+
+sub onDropdownOptionGroupSearchTermChanged()
+    m.top.searchTerm = m.dropdownOptionGroup.searchTerm
 end sub
 
 sub onSearchTermChanged()

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -1758,10 +1758,8 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
             if m.loadedItems = 0
                 m.global.sceneManager.observeFieldScoped("returnData", "onReturnData")
-                m.dropdownOptionGroup@.setFocus("sortButton", true)
-                m.sortButton.setfocus(true)
-                group = m.global.sceneManager.callFunc("getActiveScene")
-                group.lastFocus = m.sortButton
+                m.dropdownOptionGroup@.setFocus("voiceBox", true)
+                m.dropdownOptionGroup@.setSearchBackground(SearchButtonState.ACTIVE)
             else
                 m.itemGrid.setFocus(m.itemGrid.opacity = 1)
                 m.genreList.setFocus(m.genreList.opacity = 1)

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -55,7 +55,7 @@ sub setupNodes()
     m.dropdownOptionGroup = m.top.findNode("dropdownOptionGroup")
     m.dropdownOptionGroup.observeFieldScoped("showOptions", "onShowOptionsChange")
     m.dropdownOptionGroup.observeFieldScoped("exit", "onExit")
-    m.dropdownOptionGroup.observeFieldScoped("searchTerm", "onSearchTermChanged")
+    m.dropdownOptionGroup.observeFieldScoped("searchTerm", "onDropdownOptionGroupSearchTermChanged")
 end sub
 
 sub onShowOptionsChange()
@@ -1358,6 +1358,10 @@ sub resetDropdownsToDefaultState()
     m.dropdownOptionGroup@.setText("filterButton", tr("All"))
 
     m.getFiltersTask.control = "RUN"
+end sub
+
+sub onDropdownOptionGroupSearchTermChanged()
+    m.top.searchTerm = m.dropdownOptionGroup.searchTerm
 end sub
 
 sub onSearchTermChanged()

--- a/components/Libraries/dropdowns/DropdownMenuRow.bs
+++ b/components/Libraries/dropdowns/DropdownMenuRow.bs
@@ -97,7 +97,11 @@ sub onvoiceFilter()
     if isStringEqual(searchTerm, "reset search") then searchTerm = string.EMPTY
     if isStringEqual(searchTerm, "clear search") then searchTerm = string.EMPTY
 
-    setSearchHintText(searchTerm)
+    m.voiceBox.unObserveFieldScoped("text")
+    ' Voice input sets the text, but we don't want the text value set since it messes up
+    ' moving focus from the box to other controls (it moves through each letter without any real visual change)
+    m.voiceBox.text = string.EMPTY
+    m.voiceBox.observeFieldScoped("text", "onvoiceFilter")
 
     m.top.searchTerm = searchTerm
 end sub


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
This fixes 3 bugs that affect the Video and Music library views:

1. When using voice input on the search box, it won't actually search. This was because `onSearchTermChanged` is being called when the voice input is used, but that method doesn't read the value from the voice input. So I added a separate event method that updates `m.top.searchTerm`, which is used to actually trigger the search.
2. When using voice input, the `text` property is set on the search box. However, that causes an issue where pressing the arrows moves through every character of the text before changing focus to the next control, but there is also no visual indicator that it's doing that. Other parts of the code show an effort not to use the `text` value and instead use the `hintText` to show the current search value. So I updated `DropdownMenuRow.bs` to clear the `text` value after it's used. I also removed the call to `setSearchHintText(searchTerm)` there since it already happens in `onSearchTermChanged()` in the view.
3. When the focus is on any of the letters on the left of the screen, and there are no results displayed, pressing the "right" button tries to set focus to a non-existent `m.sortButton`, which causes a crash. I changed that to set focus to the search box, which I think is what any user would expect.
