### PR TITLE
Handle empty library loads without indefinite spinner

### DIFF
--- a/components/ItemGrid/LoadItemsTask2.bs
+++ b/components/ItemGrid/LoadItemsTask2.bs
@@ -172,11 +172,17 @@ sub loadItems()
             end if
         end for
 
-        if not isValid(myListPlaylist) or not isValidAndNotEmpty(myListPlaylist.items) then return
+        if not isValid(myListPlaylist) or not isValidAndNotEmpty(myListPlaylist.items)
+            m.top.content = results
+            return
+        end if
 
         playlistID = myListPlaylist.items[0].LookupCI("id")
 
-        if not isValid(playlistID) then return
+        if not isValid(playlistID)
+            m.top.content = results
+            return
+        end if
 
         url = "/items/"
 
@@ -227,7 +233,7 @@ sub loadItems()
         end if
     end if
 
-    if data <> invalid
+    if isValid(data) and isValid(data.Items)
 
         if data.TotalRecordCount <> invalid then m.top.totalRecordCount = data.TotalRecordCount
 

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -980,7 +980,8 @@ end sub
 sub ItemDataLoaded(msg)
     itemData = msg.GetData()
 
-    if not isValidAndNotEmpty(itemData)
+    if not isValid(itemData)
+        stopLoadingSpinner()
         return
     end if
 


### PR DESCRIPTION
## Issue

A movie library had a trailing space in its configured media path. When opening that library, Roku showed the loading spinner forever instead of an **error** (!)

If the server cannot read a library path, the app can get an empty or invalid item response for a Movies/VisualLibrary screen. That response path returned before the spinner stopped.

## Changes

- Stop the VisualLibrary spinner when item loading returns no payload.
- Let empty item results use the existing "No items found" state.
- Return an empty result from `LoadItemsTask2` when item data is missing or malformed.

## Testing

- Built and tested sideload package: `jf-roku-3.1.10.0000.0017.zip`
- Confirmed the affected library now shows "No items found. Try adjusting your selected filters." instead of spinning forever.

## To Do
- Improve error message
- Fix server (a separate PR)
