### PR TITLE
Improve library grid Down navigation for short last row

### DIFF
--- a/components/ItemGrid/LibraryItemGrid.bs
+++ b/components/ItemGrid/LibraryItemGrid.bs
@@ -1,0 +1,27 @@
+import "pkg:/source/enums/KeyCode.bs"
+
+function onKeyEvent(key as string, press as boolean) as boolean
+    if not press then return false
+    if not m.top.isInFocusChain() then return false
+    if key <> KeyCode.DOWN then return false
+    if m.top.content = invalid then return false
+
+    itemCount = m.top.content.getChildCount()
+    focusedIndex = m.top.itemFocused
+    numColumns = m.top.numColumns
+
+    if itemCount <= 0 then return false
+    if focusedIndex < 0 then return false
+    if numColumns <= 0 then return false
+
+    nextRowStart = (Fix(focusedIndex / numColumns) + 1) * numColumns
+    sameColumnNextRowIndex = focusedIndex + numColumns
+
+    if nextRowStart < itemCount and sameColumnNextRowIndex >= itemCount
+        ' Jump directly to the last item in a short next row.
+        m.top.jumpToItem = itemCount - 1
+        return true
+    end if
+
+    return false
+end function

--- a/components/ItemGrid/LibraryItemGrid.xml
+++ b/components/ItemGrid/LibraryItemGrid.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component name="LibraryItemGrid" extends="MarkupGrid">
+</component>

--- a/components/Libraries/AudioBookLibraryView.xml
+++ b/components/Libraries/AudioBookLibraryView.xml
@@ -4,7 +4,7 @@
     <poster id="backdrop" loadDisplayMode="scaleToFill" width="1920" height="1080" opacity="0.25" />
     <poster id="backdropTransition" loadDisplayMode="scaleToFill" width="1920" height="1080" opacity="0.25" />
 
-    <MarkupGrid
+    <LibraryItemGrid
       id="itemGrid"
       translation="[96, 60]"
       itemComponentName="AudioBookGridItem"

--- a/components/Libraries/LiveTVLibraryView.xml
+++ b/components/Libraries/LiveTVLibraryView.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="LiveTVLibraryView" extends="JFGroup">
   <children>
-    <MarkupGrid
+    <LibraryItemGrid
       id="itemGrid"
       translation="[96, 60]"
       itemComponentName="GridItemSmall"

--- a/components/Libraries/MusicLibraryView.xml
+++ b/components/Libraries/MusicLibraryView.xml
@@ -7,13 +7,13 @@
       translation="[820, 0]"
       maskSize="[1220,700]" />
 
-    <MarkupGrid
+    <LibraryItemGrid
       id="itemGrid"
       itemComponentName="MusicArtistGridItem"
       vertFocusAnimationStyle="fixed"
       itemSpacing="[20, 20]" />
 
-    <MarkupGrid
+    <LibraryItemGrid
       id="genrelist"
       itemComponentName="MusicArtistGridItem"
       vertFocusAnimationStyle="fixed"

--- a/components/Libraries/OtherLibrary.bs
+++ b/components/Libraries/OtherLibrary.bs
@@ -98,7 +98,7 @@ sub init()
 end sub
 
 sub createItemGrid()
-    m.itemGrid = createObject("rosgnode", "MarkupGrid")
+    m.itemGrid = createObject("rosgnode", "LibraryItemGrid")
     m.itemGrid.id = "itemGrid"
     m.itemGrid.translation = "[96, 60]"
     m.itemGrid.itemComponentName = "GridItemSmall"

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -1571,7 +1571,7 @@ sub onViewChange(viewChoice)
 end sub
 
 sub createItemGrid(itemGridID = "itemGrid" as string)
-    m.itemGrid = createObject("rosgnode", "MarkupGrid")
+    m.itemGrid = createObject("rosgnode", "LibraryItemGrid")
     m.itemGrid.id = itemGridID
     m.itemGrid.itemSpacing = "[20, 20]"
     m.itemGrid.vertFocusAnimationStyle = "fixed"

--- a/components/Libraries/VisualLibraryScene.xml
+++ b/components/Libraries/VisualLibraryScene.xml
@@ -7,7 +7,7 @@
       translation="[820, 0]"
       maskSize="[1220,700]" />
 
-    <MarkupGrid
+    <LibraryItemGrid
       id="itemGrid"
       itemComponentName="GridItemSmall"
       vertFocusAnimationStyle="fixed"

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -22,5 +22,9 @@
   {
     "description": "Allow Force Transcode for live TV only",
     "author": "FractalBoy"
+  },
+  {
+    "description": "Improve Down navigation in library grids with short last rows",
+    "author": "VX-101"
   }
 ]


### PR DESCRIPTION
## Summary

When a library grid has a short last row, pressing `Down` from a row above in a column that does not exist in the last row did nothing. Those trailing items were only reachable by moving `Left` first.

## Changes

Adds `LibraryItemGrid` (extends `MarkupGrid`) which jumps to the last item in the short row in this case. 
Used in `VisualLibraryScene`, `AudioBookLibraryView`, `LiveTVLibraryView`, `MusicLibraryView`, and `OtherLibrary`.
Uses `jumpToItem` instead of `animateToItem` since the diagonal animation looked bad.

## Testing

- Ran `npm run build` successfully.
- Sideloaded the generated Roku package.
- Tested movie grids with short last rows in multiple layouts.
- Verified `Down` moves to the same column when that item exists in the next row.
- Verified `Down` moves to the last item when the next row exists, but the same-column item does not.
- Verified the focus transition is immediate and does not resize through intermediate positions.

## Todo 
Make a similar fix for `AlbumGrid`  see  #896 

## See also: 
#918 #958