### PR TITLE
Fix VTT subtitle default positioning for cues without explicit line value

### DIFF
--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -427,7 +427,9 @@ end function
 function extractStyles(lineData as string) as object
     returnData = {
         endTimestamp: "",
-        styles: {}
+        ' WebVTT spec default for line is "auto" (often omitted by encoders).
+        ' 90% positions cues near the bottom without overflowing at 100%.
+        styles: { line: "90%" }
     }
 
     lineDataArray = lineData.split(" ")
@@ -435,12 +437,10 @@ function extractStyles(lineData as string) as object
 
     for each style in lineDataArray
         styleData = style.split(":")
-
-        ' We don't support RTL text, so positionAlign properties must be removed
         styleDataPositionAlign = styleData[1].split(",")
-
         returnData.styles.addreplace(styleData[0], styleDataPositionAlign[0])
     end for
+
 
     return returnData
 end function

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -74,5 +74,9 @@
   {
     "description": "Fix Next Up overlay text overflow with custom fonts",
     "author": "ferezvi"
+  },
+  {
+    "description": "Fix VTT subtitle default positioning for cues without explicit line value",
+    "author": "ferezvi"
   }
 ]


### PR DESCRIPTION
Fix VTT captions without explicit line cue rendering off-screen
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Fix incorrect positioning of VTT captions that do not specify an explicit line cue.
Previously, captions without any cue settings produced an empty style object ({}), which isValidAndNotEmpty treated as invalid, causing an early return with verticalPosition fixed at LOWEST_CAPTION without accounting for caption height — pushing captions off-screen.
This fix makes two changes in prepareStyles:

Replace isValidAndNotEmpty with isValid to allow empty style objects to continue processing, since an empty AA is valid — it just has no explicit cues.
Explicitly handle the missing line case by offsetting LOWEST_CAPTION by the caption height, so the bottom edge of the caption sits at the safe area boundary.
<!-- Describe your changes here in 1-5 sentences. -->

## Issues
Fixes #880
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
