### PR TITLE
fix Quick Connect initiate using POST instead of GET

### DIFF
--- a/source/api/sdk.bs
+++ b/source/api/sdk.bs
@@ -1360,7 +1360,7 @@ namespace api
         ' Initiate a new quick connect request.
         function Initiate()
             req = APIRequest("/quickconnect/initiate")
-            return getJson(req)
+            return postJson(req)
         end function
     end namespace
 

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -30,5 +30,9 @@
   {
     "description": "Fix subtitle menu selection for burned-in subtitles",
     "author": "VX-101"
+  },
+  {
+    "description": "Fix Quick Connect initiate to use POST instead of GET",
+    "author": "no-reply"
   }
 ]


### PR DESCRIPTION
`jellyfin` server changed `/quickconnect/initiate` to use HTTP POST in jellyfin/jellyfin@722ad3fe97 (in 2022!). until january, it shimmed compatibility for GET, removed in jellyfin/jellyfin@874fd9ac0a. since then the client has been receiving 405 for quick connect attempts.