### PR TITLE
Prevent moving down from library dropdowns if there are no results

### DIFF
--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -959,6 +959,8 @@ sub ItemDataLoaded(msg)
         return
     end if
 
+    m.dropdownOptionGroup.canExitDown = true
+
     if isStringEqual(m.view, "Genres")
         ' Reset genre list data
         m.genreData.removeChildren(m.genreData.getChildren(-1, 0))
@@ -989,6 +991,7 @@ sub ItemDataLoaded(msg)
             m.emptyText.text = tr("No items found. Try adjusting your selected filters.")
             m.emptyText.visible = true
             m.global.sceneManager.observeFieldScoped("returnData", "onReturnData")
+            m.dropdownOptionGroup.canExitDown = false
             m.dropdownOptionGroup@.setFocus("voiceBox", true)
             m.dropdownOptionGroup@.setSearchBackground(SearchButtonState.ACTIVE)
         end if
@@ -1062,6 +1065,7 @@ sub showNoResultsText()
     m.emptyText.text = tr("No items found. Try adjusting your selected filters.")
     m.emptyText.visible = true
     m.global.sceneManager.observeFieldScoped("returnData", "onReturnData")
+    m.dropdownOptionGroup.canExitDown = false
     m.dropdownOptionGroup@.setFocus("voiceBox", true)
     m.dropdownOptionGroup@.setSearchBackground(SearchButtonState.ACTIVE)
 end sub

--- a/components/Libraries/dropdowns/DropdownMenuRow.bs
+++ b/components/Libraries/dropdowns/DropdownMenuRow.bs
@@ -209,6 +209,8 @@ function onKeyEvent(key as string, press as boolean) as boolean
     if not m.top.isinFocusChain() then return false
 
     if isStringEqual(key, KeyCode.DOWN)
+        if not m.top.canExitDown then return false
+
         unfocusAllButtons(invalid)
         m.top.exit = ExitDirection.DOWN
         return true

--- a/components/Libraries/dropdowns/DropdownMenuRow.xml
+++ b/components/Libraries/dropdowns/DropdownMenuRow.xml
@@ -76,6 +76,7 @@
   <interface>
     <field id="exit" type="integer" alwaysNotify="true" />
     <field id="parentItemID" type="string" />
+    <field id="canExitDown" type="boolean" value="true" />
     <field id="showOptions" type="boolean" alwaysNotify="true" />
     <field id="searchTerm" type="string" alwaysNotify="true" />
     <function name="unfocusAllButtons" />


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Prevents user from pressing down to leave filter dropdowns when there are no item results. Prevents losing cursor.