### PR TITLE
Fix endless spinner for empty alpha filters in video libraries

### DIFF
--- a/components/ItemGrid/LoadItemsTask2.xml
+++ b/components/ItemGrid/LoadItemsTask2.xml
@@ -21,6 +21,6 @@
     <field id="numberOfColumns" type="integer" value="7" />
     <!-- Total records available from server-->
     <field id="totalRecordCount" type="int" value="-1" />
-    <field id="content" type="array" />
+    <field id="content" type="array" alwaysNotify="true" />
   </interface>
 </component>

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -1061,6 +1061,16 @@ sub showNoResultsText()
 
     m.emptyText.text = tr("No items found. Try adjusting your selected filters.")
     m.emptyText.visible = true
+
+    if m.top.alphaActive
+        m.global.sceneManager.unobserveFieldScoped("returnData")
+        m.dropdownOptionGroup@.setSearchBackground(SearchButtonState.INACTIVE)
+        m.alphaMenu.setFocus(true)
+        group = m.global.sceneManager.callFunc("getActiveScene")
+        group.lastFocus = m.alphaMenu
+        return
+    end if
+
     m.global.sceneManager.observeFieldScoped("returnData", "onReturnData")
     m.dropdownOptionGroup@.setFocus("voiceBox", true)
     m.dropdownOptionGroup@.setSearchBackground(SearchButtonState.ACTIVE)

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -46,5 +46,9 @@
   {
     "description": "Show subtitle track information on item details screens",
     "author": "VX-101"
+  },
+  {
+    "description": "Fix endless spinner for empty video library alphabet filters",
+    "author": "VX-101"
   }
 ]


### PR DESCRIPTION
## Summary

When a video library alpha filter returned no items, the view could show an endless loading spinner.

## Changes

- Shows the existing `No items found. Try adjusting your selected filters.` message when an active alpha filter returns no items in `VisualLibraryScene`.
- Ensures empty item results notify the view so the loading spinner stops.
- Keeps focus on the alpha rail.

## Testing

- Ran `npm run build` successfully.
- Sideloaded build `3.1.10.0890.0026`.
- Verified that selecting a letter with no matching video library items shows the no-results message instead of an endless spinner.
- Verified the selected letter remains active after the empty result loads.
- Verified selecting the same letter again clears the alpha filter and shows all titles again.
- Verified selecting a letter with matching items still loads the matching titles normally.