### PR TITLE
Avoid burning in SRT subtitles during audio-only transcode

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -482,9 +482,9 @@ function shouldBurnInSelectedSubtitle(playbackInfo as object, selectedSubtitleIn
     if not isValid(mediaSource.MediaStreams) then return true
 
     for each stream in mediaSource.MediaStreams
-        if LCase(stream.LookupCI("Type")) = "subtitle" and stream.LookupCI("Index") = subtitleIndex
-            if stream.LookupCI("DeliveryMethod") = "External" then return false
-            if stream.LookupCI("IsTextSubtitleStream") = true and stream.LookupCI("DeliveryMethod") <> "Encode" then return false
+        if isStringEqual(stream.LookupCI("Type"), "subtitle") and stream.LookupCI("Index") = subtitleIndex
+            if isStringEqual(stream.LookupCI("DeliveryMethod"), "External") then return false
+            if stream.LookupCI("IsTextSubtitleStream") = true and not isStringEqual(stream.LookupCI("DeliveryMethod"), "Encode") then return false
 
             return true
         end if

--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -333,13 +333,16 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
         return
     end if
 
+    video.subtitlesBurnedIn = false
+
     ' If transcoding and burnInSubtitlesIfTrancoding is enabled, zero out SubtitleProfiles
-    if chainLookupReturn(m.global, "session.user.settings.`playback.subs.burnin`", true) and meta.live = false
+    if chainLookupReturn(m.global, "session.user.settings.`playback.subs.burnin`", true) and meta.live = false and shouldBurnInSelectedSubtitle(m.playbackInfo, m.top.selectedSubtitleIndex)
         m.playbackInfo = ItemPostPlaybackInfo(video.id, mediaSourceId, audio_stream_idx, m.top.selectedSubtitleIndex, playbackPosition, {
             emptySubtitleProfiles: true
         })
         ' Re-posting playback info will generate a new PlaysessionId
         video.PlaySessionId = m.playbackInfo.PlaySessionId
+        video.subtitlesBurnedIn = true
     end if
 
     ' Get transcoding reason
@@ -459,6 +462,35 @@ function getTranscodeReasons(url as string) as object
     end if
 
     return []
+end function
+
+function shouldBurnInSelectedSubtitle(playbackInfo as object, selectedSubtitleIndex as integer) as boolean
+    if selectedSubtitleIndex = SubtitleSelection.NONE then return false
+    if not isValid(playbackInfo) then return true
+    if not isValidAndNotEmpty(playbackInfo.MediaSources) then return true
+    if not isValid(playbackInfo.MediaSources[0]) then return true
+
+    mediaSource = playbackInfo.MediaSources[0]
+    subtitleIndex = selectedSubtitleIndex
+
+    if selectedSubtitleIndex = SubtitleSelection.NOTSET
+        defaultSubtitleIndex = mediaSource.LookupCI("DefaultSubtitleStreamIndex")
+        if not isValid(defaultSubtitleIndex) then return false
+        subtitleIndex = defaultSubtitleIndex
+    end if
+
+    if not isValid(mediaSource.MediaStreams) then return true
+
+    for each stream in mediaSource.MediaStreams
+        if LCase(stream.LookupCI("Type")) = "subtitle" and stream.LookupCI("Index") = subtitleIndex
+            if stream.LookupCI("DeliveryMethod") = "External" then return false
+            if stream.LookupCI("IsTextSubtitleStream") = true and stream.LookupCI("DeliveryMethod") <> "Encode" then return false
+
+            return true
+        end if
+    end for
+
+    return true
 end function
 
 function directPlaySupported(meta as object) as boolean

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -691,9 +691,10 @@ sub onVideoContentLoaded()
 
     m.isTranscoded = videoContent[0].isTranscoded
     burnInSubtitles = chainLookupReturn(m.global, "session.user.settings.`playback.subs.burnin`", true)
+    subtitlesBurnedIn = m.isTranscoded and burnInSubtitles and chainLookupReturn(videoContent[0], "subtitlesBurnedIn", true)
 
 
-    if m.isTranscoded and burnInSubtitles
+    if subtitlesBurnedIn
         videoContent[0].content.SubtitleTracks = []
     end if
 
@@ -786,7 +787,7 @@ sub onVideoContentLoaded()
         m.top.enableTrickPlay = false
     else
         ' Allow custom captions for non intro videos unless the video is being transcoded and burn subtitles are enabled
-        m.top.allowCaptions = not (m.isTranscoded and burnInSubtitles)
+        m.top.allowCaptions = not subtitlesBurnedIn
     end if
 
     ' Allow default subtitles
@@ -796,7 +797,7 @@ sub onVideoContentLoaded()
     selectedSubtitle = invalid
     updatedSubtitleData = []
     for each subtitle in m.top.fullSubtitleData
-        if m.isTranscoded and burnInSubtitles
+        if subtitlesBurnedIn
             subtitle.IsEncoded = true
             updatedSubtitleData.push(subtitle)
         end if
@@ -806,7 +807,7 @@ sub onVideoContentLoaded()
         end if
     end for
 
-    if m.isTranscoded and burnInSubtitles
+    if subtitlesBurnedIn
         m.top.fullSubtitleData = updatedSubtitleData
         m.top.globalCaptionMode = "Off"
     end if

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -54,5 +54,9 @@
   {
     "description": "Only load 50 live TV channels at a time",
     "author": "FractalBoy"
+  },
+  {
+    "description": "Fix SRT subtitles forcing video transcode during audio-only transcodes",
+    "author": "VX-101"
   }
 ]


### PR DESCRIPTION
## Summary
Fixes a case where H.264 + AAC 5.1 + SRT could trigger video transcoding when subtitles were selected.

## Fixes
Fixes #882.

## Changes
Only request subtitle burn-in when the selected subtitle track actually needs it, so audio-only transcodes can keep video direct-streamed.

## Testing
- Ran `npm run build` successfully.
- Sideloaded local build `3.1.10.0892.0032`.
- Tested H.264 + AAC 5.1 + internal SRT subtitles: audio converted to AC3, video stayed direct streamed, subtitles were visible, and switching SRT tracks did not start video transcoding.
- Tested H.264 + AAC 2.0 + internal SRT control file: direct play worked with subtitles off and with each SRT track selected.
- Verified a PGS subtitle file still uses video transcode/burn-in.
- Regression-checked H.264 + EAC3 5.1 + internal SRT; it direct-played on Roku Ultra.