### PR TITLE
Fix/next up text overflow

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1095,22 +1095,60 @@ sub displayNextItem()
         nextItemPoster.uri = ImageURL(nextItem.lookupCI("id"), ImageType.PRIMARY, { "maxHeight": 124, "maxWidth": 150, "Tag": chainLookupReturn(imageTags, ImageType.PRIMARY, `cacheBuster${rnd(99999)}`) })
     end if
 
-    nextItemSeriesTitle = m.top.findNode("nextItemSeriesTitle")
-    if isValid(nextItemSeriesTitle)
-        nextItemSeriesTitle.font.size = 25
-        nextItemSeriesTitle.text = nextItem.lookupCI("SeriesName")
+    ' Get nodes
+    rectangle = m.top.findNode("nextUp")
+    layoutGroup = m.top.findNode("nextUpLayoutGroup")
+    nextUpTextNode = m.top.findNode("nextUpText")
+    seriesTitle = m.top.findNode("nextItemSeriesTitle")
+    episodeTitle = m.top.findNode("nextItemEpisodeTitle")
+
+    if isValid(seriesTitle)
+        seriesTitle.font.size = 25
+        seriesTitle.text = nextItem.lookupCI("SeriesName")
     end if
 
-    nextItemEpisodeTitle = m.top.findNode("nextItemEpisodeTitle")
-    if isValid(nextItemEpisodeTitle)
+    if isValid(episodeTitle)
         seasonName = nextItem.lookupCI("SeasonName") ?? string.EMPTY
         seasonName = seasonName.Replace("Season ", "S")
-
         episodeNumber = isValid(nextItem.lookupCI("IndexNumber")) ? `E${nextItem.lookupCI("IndexNumber")}` : string.EMPTY
-
-        nextItemEpisodeTitle.font.size = 22
-        nextItemEpisodeTitle.text = `${seasonName}${episodeNumber} - ${nextItem.lookupCI("name")}`
+        episodeTitle.font.size = 22
+        episodeTitle.text = `${seasonName}${episodeNumber} - ${nextItem.lookupCI("name")}`
     end if
+
+    ' Measure actual text heights to calculate dynamic spacing and translation
+    ' This ensures the layout adapts to any custom font metrics
+    if isValid(nextUpTextNode)
+        nextUpTextNode.font.size = 34
+        nextUpTextNode.text = tr("Next Up")
+    end if
+
+    ' Original translation from XML: translation="[180, 15]"
+    originalTranslationY = 15
+
+    ' Measure actual text heights
+    nextUpHeight = nextUpTextNode.boundingRect().height
+    seriesHeight = seriesTitle.boundingRect().height
+    episodeHeight = episodeTitle.boundingRect().height
+    totalHeight = nextUpHeight + seriesHeight + episodeHeight
+
+    ' Available space with original translation and 2px bottom padding
+    spaceAvailable = rectangle.height - originalTranslationY - 2
+
+    if totalHeight <= spaceAvailable
+        ' Case 1: Fits with original translation
+        translation = originalTranslationY
+        itemSpacing = (spaceAvailable - totalHeight) \ 2
+        if itemSpacing > 10 then itemSpacing = 10
+    else
+        ' Case 2: Too tall, reduce translation
+        translation = spaceAvailable - totalHeight
+        if translation < 2 then translation = 2
+        itemSpacing = 0
+    end if
+
+    ' Apply values
+    layoutGroup.translation = "[180, " + translation.ToStr() + "]"
+    layoutGroup.itemSpacings = "[10, " + itemSpacing.ToStr() + "]"
 
     m.nextUp.visible = true
     m.nextUpInfoLoaded = true

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1115,11 +1115,6 @@ sub displayNextItem()
         nextItemEpisodeTitle.text = `${seasonName}${episodeNumber} - ${nextItem.lookupCI("name")}`
     end if
 
-    nextUpTextNode = m.top.findNode("nextUpText")
-    nextUpTextNode.height = 35
-    nextItemSeriesTitle.height = 35
-    nextItemEpisodeTitle.height = 35
-
     m.nextUp.visible = true
     m.nextUpInfoLoaded = true
 end sub

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1115,11 +1115,9 @@ sub displayNextItem()
         episodeTitle.text = `${seasonName}${episodeNumber} - ${nextItem.lookupCI("name")}`
     end if
 
-    ' Measure actual text heights to calculate dynamic spacing and translation
-    ' This ensures the layout adapts to any custom font metrics
+    ' Set font size before measuring to get accurate boundingRect values
     if isValid(nextUpTextNode)
         nextUpTextNode.font.size = 34
-        nextUpTextNode.text = tr("Next Up")
     end if
 
     ' Original translation from XML: translation="[180, 15]"
@@ -1142,16 +1140,28 @@ sub displayNextItem()
     else
         ' Case 2: Too tall, reduce translation
         translation = spaceAvailable - totalHeight
-        if translation < 2 then translation = 2
+        if translation < 0
+            ' Case 3: Still too tall, shrink Next Up text to recover space
+            ' Recalculate available space assuming translation will be 0
+            spaceAvailable = rectangle.height - 2
+            if isValid(nextUpTextNode)
+                nextUpTextNode.font.size = 28
+                nextUpHeight = nextUpTextNode.boundingRect().height
+                totalHeight = nextUpHeight + seriesHeight + episodeHeight
+                translation = spaceAvailable - totalHeight
+            end if
+            if translation < 0 then translation = 0
+        end if
         itemSpacing = 0
     end if
 
-    ' Apply values
+    'Apply values
     layoutGroup.translation = "[180, " + translation.ToStr() + "]"
     layoutGroup.itemSpacings = "[10, " + itemSpacing.ToStr() + "]"
 
     m.nextUp.visible = true
     m.nextUpInfoLoaded = true
+
 end sub
 
 ' checkSegmentSkipButton: Handler for displaying skip buttons during media segments.

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1098,73 +1098,25 @@ sub displayNextItem()
         nextItemPoster.uri = ImageURL(nextItem.lookupCI("id"), ImageType.PRIMARY, { "maxHeight": 124, "maxWidth": 150, "Tag": chainLookupReturn(imageTags, ImageType.PRIMARY, `cacheBuster${rnd(99999)}`) })
     end if
 
-    ' Get nodes
-    rectangle = m.top.findNode("nextUp")
-    layoutGroup = m.top.findNode("nextUpLayoutGroup")
-    nextUpTextNode = m.top.findNode("nextUpText")
-    seriesTitle = m.top.findNode("nextItemSeriesTitle")
-    episodeTitle = m.top.findNode("nextItemEpisodeTitle")
-
-    if isValid(seriesTitle)
-        seriesTitle.font.size = 25
-        seriesTitle.text = nextItem.lookupCI("SeriesName")
+    nextItemSeriesTitle = m.top.findNode("nextItemSeriesTitle")
+    if isValid(nextItemSeriesTitle)
+        nextItemSeriesTitle.font.size = 25
+        nextItemSeriesTitle.text = nextItem.lookupCI("SeriesName")
     end if
 
-    if isValid(episodeTitle)
+    nextItemEpisodeTitle = m.top.findNode("nextItemEpisodeTitle")
+    if isValid(nextItemEpisodeTitle)
         seasonName = nextItem.lookupCI("SeasonName") ?? string.EMPTY
         seasonName = seasonName.Replace("Season ", "S")
+
         episodeNumber = isValid(nextItem.lookupCI("IndexNumber")) ? `E${nextItem.lookupCI("IndexNumber")}` : string.EMPTY
-        episodeTitle.font.size = 22
-        episodeTitle.text = `${seasonName}${episodeNumber} - ${nextItem.lookupCI("name")}`
+
+        nextItemEpisodeTitle.font.size = 22
+        nextItemEpisodeTitle.text = `${seasonName}${episodeNumber} - ${nextItem.lookupCI("name")}`
     end if
-
-    ' Set font size before measuring to get accurate boundingRect values
-    if isValid(nextUpTextNode)
-        nextUpTextNode.font.size = 34
-    end if
-
-    ' Original translation from XML: translation="[180, 15]"
-    originalTranslationY = 15
-
-    ' Measure actual text heights
-    nextUpHeight = nextUpTextNode.boundingRect().height
-    seriesHeight = seriesTitle.boundingRect().height
-    episodeHeight = episodeTitle.boundingRect().height
-    totalHeight = nextUpHeight + seriesHeight + episodeHeight
-
-    ' Available space with original translation and 2px bottom padding
-    spaceAvailable = rectangle.height - originalTranslationY - 2
-
-    if totalHeight <= spaceAvailable
-        ' Case 1: Fits with original translation
-        translation = originalTranslationY
-        itemSpacing = (spaceAvailable - totalHeight) \ 2
-        if itemSpacing > 10 then itemSpacing = 10
-    else
-        ' Case 2: Too tall, reduce translation
-        translation = spaceAvailable - totalHeight
-        if translation < 0
-            ' Case 3: Still too tall, shrink Next Up text to recover space
-            ' Recalculate available space assuming translation will be 0
-            spaceAvailable = rectangle.height - 2
-            if isValid(nextUpTextNode)
-                nextUpTextNode.font.size = 28
-                nextUpHeight = nextUpTextNode.boundingRect().height
-                totalHeight = nextUpHeight + seriesHeight + episodeHeight
-                translation = spaceAvailable - totalHeight
-            end if
-            if translation < 0 then translation = 0
-        end if
-        itemSpacing = 0
-    end if
-
-    'Apply values
-    layoutGroup.translation = "[180, " + translation.ToStr() + "]"
-    layoutGroup.itemSpacings = "[10, " + itemSpacing.ToStr() + "]"
 
     m.nextUp.visible = true
     m.nextUpInfoLoaded = true
-
 end sub
 
 ' checkSegmentSkipButton: Handler for displaying skip buttons during media segments.

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1115,6 +1115,11 @@ sub displayNextItem()
         nextItemEpisodeTitle.text = `${seasonName}${episodeNumber} - ${nextItem.lookupCI("name")}`
     end if
 
+    nextUpTextNode = m.top.findNode("nextUpText")
+    nextUpTextNode.height = 35
+    nextItemSeriesTitle.height = 35
+    nextItemEpisodeTitle.height = 35
+
     m.nextUp.visible = true
     m.nextUpInfoLoaded = true
 end sub

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -57,9 +57,9 @@
     <Rectangle id="nextUp" visible="false" color="0x000000CC" height="144" width="785" translation="[1000, 920]">
       <Poster id="nextItemPoster" width="150" height="124" translation="[10, 10]" />
       <LayoutGroup layoutDirection="vert" horizAlignment="left" itemSpacings="[10, 10]" translation="[180, 15]">
-        <Text id="nextUpText" text="Next Up" color="#FFFFFF" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="center" />
-        <ScrollingText id="nextItemSeriesTitle" maxWidth="300" color="#FFFFFF" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="top" />
-        <ScrollingText id="nextItemEpisodeTitle" maxWidth="300" color="#AAAAAA" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="top" />
+        <Text text="Next Up" color="#FFFFFF" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="center" height="35" />
+        <ScrollingText id="nextItemSeriesTitle" maxWidth="300" color="#FFFFFF" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="top" height="35" />
+        <ScrollingText id="nextItemEpisodeTitle" maxWidth="300" color="#AAAAAA" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="top" height="35" />
       </LayoutGroup>
     </Rectangle>
 

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -57,7 +57,7 @@
     <Rectangle id="nextUp" visible="false" color="0x000000CC" height="144" width="785" translation="[1000, 920]">
       <Poster id="nextItemPoster" width="150" height="124" translation="[10, 10]" />
       <LayoutGroup layoutDirection="vert" horizAlignment="left" itemSpacings="[10, 10]" translation="[180, 15]">
-        <Text text="Next Up" color="#FFFFFF" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="center" />
+        <Text id="nextUpText" text="Next Up" color="#FFFFFF" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="center" />
         <ScrollingText id="nextItemSeriesTitle" maxWidth="300" color="#FFFFFF" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="top" />
         <ScrollingText id="nextItemEpisodeTitle" maxWidth="300" color="#AAAAAA" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="top" />
       </LayoutGroup>

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -56,8 +56,8 @@
 
     <Rectangle id="nextUp" visible="false" color="0x000000CC" height="144" width="785" translation="[1000, 920]">
       <Poster id="nextItemPoster" width="150" height="124" translation="[10, 10]" />
-      <LayoutGroup id="nextUpLayoutGroup" layoutDirection="vert" horizAlignment="left" itemSpacings="[10, 10]" translation="[180, 15]">
-        <Text id="nextUpText" text="Next Up" color="#FFFFFF" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="center" />
+      <LayoutGroup layoutDirection="vert" horizAlignment="left" itemSpacings="[10, 10]" translation="[180, 15]">
+        <Text text="Next Up" color="#FFFFFF" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="center" />
         <ScrollingText id="nextItemSeriesTitle" maxWidth="300" color="#FFFFFF" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="top" />
         <ScrollingText id="nextItemEpisodeTitle" maxWidth="300" color="#AAAAAA" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="top" />
       </LayoutGroup>

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -56,8 +56,8 @@
 
     <Rectangle id="nextUp" visible="false" color="0x000000CC" height="144" width="785" translation="[1000, 920]">
       <Poster id="nextItemPoster" width="150" height="124" translation="[10, 10]" />
-      <LayoutGroup layoutDirection="vert" horizAlignment="left" itemSpacings="[10, 10]" translation="[180, 15]">
-        <Text text="Next Up" color="#FFFFFF" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="center" />
+      <LayoutGroup id="nextUpLayoutGroup" layoutDirection="vert" horizAlignment="left" itemSpacings="[10, 10]" translation="[180, 15]">
+        <Text id="nextUpText" text="Next Up" color="#FFFFFF" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="center" />
         <ScrollingText id="nextItemSeriesTitle" maxWidth="300" color="#FFFFFF" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="top" />
         <ScrollingText id="nextItemEpisodeTitle" maxWidth="300" color="#AAAAAA" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="top" />
       </LayoutGroup>

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -62,5 +62,9 @@
   {
     "description": "Fix SRT subtitles forcing video transcode during audio-only transcodes",
     "author": "VX-101"
+  },
+  {
+    "description": "Fix Next Up overlay text overflow with custom fonts",
+    "author": "ferezvi"
   }
 ]

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -38,9 +38,5 @@
   {
     "description": "Improve Down navigation in library grids with short last rows",
     "author": "VX-101"
-  },
-  {
-    "description": "Honor Roku text edge effects for custom subtitles",
-    "author": "ferezvi"
   }
 ]

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -38,5 +38,9 @@
   {
     "description": "Improve Down navigation in library grids with short last rows",
     "author": "VX-101"
+  },
+  {
+    "description": "Honor Roku text edge effects for custom subtitles",
+    "author": "ferezvi"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
Fix/next up text overflow
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
Set explicit height on Next Up overlay nodes to prevent text overflow when using fallback fonts

Note how in the screenshot, the episode title with Japanese characters is cut off at the bottom of the overlay
<img width="550" height="120" alt="before" src="https://github.com/user-attachments/assets/ca2869af-3ae4-4836-a159-784318fc584c" />

With the explicit height constraint applied via XML, the text fits correctly within the bounds
<img width="550" height="120" alt="after" src="https://github.com/user-attachments/assets/2f9b958c-f3ca-4186-a8bf-981b7f51979c" />




## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
#551