### PR TITLE
AC3/EAC3/DTS passthrough support

### DIFF
--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -74,5 +74,9 @@
   {
     "description": "Fix Next Up overlay text overflow with custom fonts",
     "author": "ferezvi"
+  },
+  {
+    "description": "Support AC3/EAC3/DTS passthrough when system audio is set to 5.1 surround",
+    "author": "ferezvi"
   }
 ]

--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -135,9 +135,14 @@ function GetDirectPlayProfiles() as object
     end if
 
     ' check audio codecs for each container
+    ' if the user has configured surround sound output, assume passthrough codecs are supported
+    isSurround = di.GetAudioOutputChannel() = "5.1 surround"
+    passThroughCodecs = ["ac3", "eac3", "dts"]
     for each container in supportedCodecs
         for each audioCodec in audioCodecs
             if di.CanDecodeAudio({ Codec: audioCodec, Container: container }).Result
+                supportedCodecs[container]["audio"].push(audioCodec)
+            else if isSurround and inArray(passThroughCodecs, audioCodec)
                 supportedCodecs[container]["audio"].push(audioCodec)
             end if
         end for


### PR DESCRIPTION
AC3/EAC3/DTS passthrough support

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
When Settings → Audio → Digital output format → Custom → Dolby Digital or Dolby Digital Plus is set, honor the Roku system preference and declare AC3, EAC3 and DTS as supported for direct play.

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #894
