### PR TITLE
Cast & Crew `Set Favorite` button did not update the UI or persist on the server.

### DIFF
--- a/components/PersonDetails.bs
+++ b/components/PersonDetails.bs
@@ -8,6 +8,7 @@ sub init()
     m.btnGrp = m.top.findNode("buttons")
     m.btnGrp.observeField("escape", "onButtonGroupEscaped")
     m.favBtn = m.top.findNode("favorite-button")
+    m.favBtn.observeField("buttonSelected", "onFavoriteButtonSelected")
     m.extrasGrp = m.top.findNode("extrasGrp")
     m.extrasGrp.opacity = 1.0
     m.top.optionsAvailable = false
@@ -15,6 +16,7 @@ end sub
 
 sub loadPerson()
     item = m.top.itemContent
+    item.observeField("favorite", "setFavoriteColor")
     itemData = item.json
     m.top.Id = itemData.id
     name = m.top.findNode("Name")
@@ -86,6 +88,10 @@ sub onButtonGroupEscaped()
         m.dscr.opacity = 1.0
         m.top.findNode("dscrBorder").color = "#d0d0d0ff"
     end if
+end sub
+
+sub onFavoriteButtonSelected()
+    m.top.buttonSelected = "favorite-button"
 end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean

--- a/components/PersonDetails.xml
+++ b/components/PersonDetails.xml
@@ -3,6 +3,7 @@
   <interface>
     <field id="itemContent" type="node" onChange="loadPerson" />
     <field id="image" type="node" />
+    <field id="buttonSelected" type="string" alwaysNotify="true" />
     <field id="selectedItem" type="node" alias="extrasGrid.selectedItem" alwaysNotify="true" />
   </interface>
   <children>

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -1106,7 +1106,7 @@ function CreatePersonView(personData as object) as dynamic
     person.setFocus(true)
     ' watch for button presses
     person.observeFieldScoped("selectedItem", m.port)
-    person.findNode("favorite-button").observeField("buttonSelected", m.port)
+    person.observeField("buttonSelected", m.port)
     ' finished building Person View
     stopLoadingSpinner()
     return person

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -62,5 +62,9 @@
   {
     "description": "Fix SRT subtitles forcing video transcode during audio-only transcodes",
     "author": "VX-101"
+  },
+  {
+    "description": "Fix Cast & Crew favorite button state and persistence",
+    "author": "VX-101"
   }
 ]


### PR DESCRIPTION
## Summary

On Cast & Crew person detail screens, selecting `Set Favorite` did not update the button state or persist on the server.

## Changes

- Fix Cast & Crew `Set Favorite` button clicks.
- Refresh the button state after favorite changes.

## Follow-up
- Favorite Cast & Crew do not appear in the Favorites row on the home screen #904 

## Testing

- Ran `npm run build` successfully.
- Built local stamped package `3.1.10.0897.0038`.
- Verified that toggling `Set Favorite` on a Cast & Crew person detail screen updates the Roku UI and persists the favorite state on the server.
