### PR TITLE
Home `Favorites` row is missing favorite people and songs

### DIFF
--- a/components/data/HomeData.bs
+++ b/components/data/HomeData.bs
@@ -127,6 +127,18 @@ sub setData()
         m.top.thumbnailURL = ImageURL(datum.LookupCI("Id"), "Primary", params)
         m.top.widePosterUrl = m.top.thumbnailURL
         m.top.posterUrl = m.top.thumbnailURL
+    else if isStringEqual(datum.type, ItemType.PERSON)
+        params = { "maxHeight": 261, "maxWidth": 464 }
+
+        if datum.ImageTags <> invalid and datum.ImageTags.Primary <> invalid
+            params["Tag"] = datum.ImageTags.Primary
+        else if datum.PrimaryImageTag <> invalid
+            params["Tag"] = datum.PrimaryImageTag
+        end if
+
+        m.top.posterURL = ImageURL(datum.LookupCI("Id"), "Primary", params)
+        m.top.thumbnailURL = m.top.posterURL
+        m.top.widePosterUrl = m.top.posterURL
     else if datum.type = "TvChannel" or datum.type = "Channel"
         params = { "Tag": datum.ImageTags.Primary, "maxHeight": 261, "maxWidth": 464 }
         m.top.thumbnailURL = ImageURL(datum.LookupCI("Id"), "Primary", params)

--- a/components/data/HomeData.bs
+++ b/components/data/HomeData.bs
@@ -1,5 +1,7 @@
 import "pkg:/source/api/baserequest.bs"
 import "pkg:/source/api/Image.bs"
+import "pkg:/source/api/sdk.bs"
+import "pkg:/source/enums/ImageType.bs"
 import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/utils/config.bs"
 
@@ -130,13 +132,13 @@ sub setData()
     else if isStringEqual(datum.type, ItemType.PERSON)
         params = { "maxHeight": 261, "maxWidth": 464 }
 
-        if datum.ImageTags <> invalid and datum.ImageTags.Primary <> invalid
+        if isChainValid(datum, "ImageTags.Primary")
             params["Tag"] = datum.ImageTags.Primary
-        else if datum.PrimaryImageTag <> invalid
+        else if isChainValid(datum, "PrimaryImageTag")
             params["Tag"] = datum.PrimaryImageTag
         end if
 
-        m.top.posterURL = ImageURL(datum.LookupCI("Id"), "Primary", params)
+        m.top.posterURL = api.items.GetImageURL(datum.LookupCI("Id"), ImageType.PRIMARY, 0, params)
         m.top.thumbnailURL = m.top.posterURL
         m.top.widePosterUrl = m.top.posterURL
     else if datum.type = "TvChannel" or datum.type = "Channel"

--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -99,6 +99,7 @@ sub itemContentChanged()
     if not isValid(m.itemIcon) then initItemIcon()
 
     m.itemPoster.width = itemData.imageWidth
+    m.itemPoster.loadDisplayMode = "scaleToZoom"
 
     m.itemTextExtra.width = itemData.imageWidth
     m.itemTextExtra.visible = true
@@ -160,6 +161,11 @@ sub itemContentChanged()
 
     if itemDataType = ItemType.MUSICALBUM
         displayMusicAlbumInfo(itemData as object)
+        return
+    end if
+
+    if itemDataType = ItemType.PERSON
+        displayPersonInfo(itemData as object)
         return
     end if
 
@@ -270,6 +276,12 @@ end sub
 sub displayMusicAlbumInfo(itemData as object)
     m.itemText.text = itemData.name
     m.itemTextExtra.text = itemData.json.AlbumArtist
+    m.itemPoster.uri = itemData.posterURL
+end sub
+
+sub displayPersonInfo(itemData as object)
+    m.itemText.text = itemData.name
+    m.itemPoster.loadDisplayMode = "scaleToFit"
     m.itemPoster.uri = itemData.posterURL
 end sub
 

--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -78,9 +78,11 @@ sub itemContentChanged()
 
     if not isValid(itemData) then return
     localGlobal = m.global
+    itemDataType = isValid(itemData.type) ? LCase(itemData.type) : ""
 
     if isValid(m.playedIndicator)
         m.playedIndicator.data = {
+            showWatchedCheckmark: not isStringEqual(itemDataType, ItemType.AUDIO),
             played: chainLookupReturn(itemData, "json.UserData.Played", false),
             unplayedCount: chainLookupReturn(itemData, "json.UserData.UnplayedItemCount", 0)
         }
@@ -117,8 +119,6 @@ sub itemContentChanged()
     if isAllValid([m.itemIcon, itemData.iconUrl])
         m.itemIcon.uri = itemData.iconUrl
     end if
-
-    itemDataType = isValid(itemData.type) ? LCase(itemData.type) : ""
 
     if inArray([ItemType.COLLECTIONFOLDER, ItemType.USERVIEW, ItemType.CHANNEL, ItemType.FOLDER], itemDataType)
         displayCollectionInfo(itemData)

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -481,45 +481,82 @@ function loadFavorites() as object
 
     data = api.items.Get(params)
 
-    if not isChainValid(data, "Items") then return results
+    if isChainValid(data, "Items")
+        for each item in data.Items
+            if isStringEqual(item.LookupCI("Type"), ItemType.BOOK) then continue for
 
-    for each item in data.Items
-        if inArray([ItemType.BOOK, ItemType.AUDIO], item.type) then continue for
+            tmp = CreateObject("roSGNode", "HomeData")
 
-        tmp = CreateObject("roSGNode", "HomeData")
+            params = {
+                Tags: item.PrimaryImageTag,
+                MaxWidth: 234,
+                MaxHeight: 330
+            }
+            tmp.posterURL = ImageUrl(item.Id, "Primary", params)
+            tmp.json = {
+                Id: item.LookupCI("Id"),
+                name: item.LookupCI("name"),
+                Type: item.LookupCI("Type"),
+                SeriesName: item.LookupCI("SeriesName"),
+                SeriesId: item.LookupCI("SeriesId"),
+                SeasonId: item.LookupCI("SeasonId"),
+                ProductionYear: item.LookupCI("ProductionYear"),
+                Status: item.LookupCI("Status"),
+                EndDate: item.LookupCI("EndDate"),
+                ParentIndexNumber: item.LookupCI("ParentIndexNumber"),
+                IndexNumberEnd: item.LookupCI("IndexNumberEnd"),
+                IndexNumber: item.LookupCI("IndexNumber"),
+                OfficialRating: item.LookupCI("OfficialRating"),
+                Album: item.LookupCI("Album"),
+                AlbumArtist: item.LookupCI("AlbumArtist"),
+                CollectionType: item.LookupCI("CollectionType"),
+                ImageTags: item.LookupCI("ImageTags"),
+                UserData: item.LookupCI("UserData"),
+                ParentThumbItemId: item.LookupCI("ParentThumbItemId"),
+                ParentThumbImageTag: item.LookupCI("ParentThumbImageTag"),
+                ParentBackdropImageTags: item.LookupCI("ParentBackdropImageTags"),
+                ParentBackdropItemId: item.LookupCI("ParentBackdropItemId"),
+                SeriesPrimaryImageTag: item.LookupCI("SeriesPrimaryImageTag"),
+                BackdropImageTags: item.LookupCI("BackdropImageTags")
+            }
+            results.push(tmp)
+        end for
+    end if
 
-        params = {
-            Tags: item.PrimaryImageTag,
-            MaxWidth: 234,
-            MaxHeight: 330
-        }
-        tmp.posterURL = ImageUrl(item.Id, "Primary", params)
-        tmp.json = {
-            Id: item.LookupCI("Id"),
-            name: item.LookupCI("name"),
-            Type: item.LookupCI("Type"),
-            SeriesName: item.LookupCI("SeriesName"),
-            SeriesId: item.LookupCI("SeriesId"),
-            SeasonId: item.LookupCI("SeasonId"),
-            ProductionYear: item.LookupCI("ProductionYear"),
-            Status: item.LookupCI("Status"),
-            EndDate: item.LookupCI("EndDate"),
-            ParentIndexNumber: item.LookupCI("ParentIndexNumber"),
-            IndexNumberEnd: item.LookupCI("IndexNumberEnd"),
-            IndexNumber: item.LookupCI("IndexNumber"),
-            OfficialRating: item.LookupCI("OfficialRating"),
-            CollectionType: item.LookupCI("CollectionType"),
-            ImageTags: item.LookupCI("ImageTags"),
-            UserData: item.LookupCI("UserData"),
-            ParentThumbItemId: item.LookupCI("ParentThumbItemId"),
-            ParentThumbImageTag: item.LookupCI("ParentThumbImageTag"),
-            ParentBackdropImageTags: item.LookupCI("ParentBackdropImageTags"),
-            ParentBackdropItemId: item.LookupCI("ParentBackdropItemId"),
-            SeriesPrimaryImageTag: item.LookupCI("SeriesPrimaryImageTag"),
-            BackdropImageTags: item.LookupCI("BackdropImageTags")
-        }
-        results.push(tmp)
-    end for
+    peopleParams = {
+        userid: m.global.session.user.id,
+        Filters: "IsFavorite",
+        Limit: 25,
+        recursive: true,
+        sortby: sortField,
+        sortOrder: sortOrder,
+        EnableTotalRecordCount: false
+    }
+
+    peopleData = api.persons.Get(peopleParams)
+
+    if isChainValid(peopleData, "Items")
+        for each person in peopleData.Items
+            primaryImageTag = person.LookupCI("PrimaryImageTag")
+
+            tmp = CreateObject("roSGNode", "HomeData")
+            params = {
+                Tags: primaryImageTag,
+                MaxWidth: 234,
+                MaxHeight: 330
+            }
+            tmp.posterURL = ImageUrl(person.Id, "Primary", params)
+            tmp.json = {
+                Id: person.LookupCI("Id"),
+                name: person.LookupCI("name"),
+                Type: person.LookupCI("Type"),
+                PrimaryImageTag: primaryImageTag,
+                ImageTags: { Primary: primaryImageTag },
+                UserData: person.LookupCI("UserData")
+            }
+            results.push(tmp)
+        end for
+    end if
 
     return results
 end function

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -70,5 +70,9 @@
   {
     "description": "Fix Cast & Crew favorite button state and persistence",
     "author": "VX-101"
+  },
+  {
+    "description": "Show favorite songs and Cast & Crew people in the home Favorites row",
+    "author": "VX-101"
   }
 ]


### PR DESCRIPTION
## Summary
Favorite `Cast & Crew` people and songs do not appear in the home screen `Favorites` row.

## Changes
- Load and display favorite `Cast & Crew` people in the home screen `Favorites` row.
- Include favorite songs in the home screen `Favorites` row.
- Do not show the watched checkmark for favorite songs.

## Follow-up
- Split the home screen `Favorites` section into separate rows by item type to match the Web and iOS clients #907.
- Address the existing `Favorites` row reshuffle behavior caused by the random default sort order when the row reloads after returning from an item #906.
- `Persons` does not honor `Random` sorting; leave it for #907. 

## Testing
- Ran `npm run build` successfully.
- Sideloaded local build `3.1.10.0904.0052`.
- Verified favorite `Cast & Crew` people appear in the home screen `Favorites` row with uncropped portrait images and open the person detail screen.
- Verified a favorite song appears in the home screen `Favorites` row and starts audio playback when selected.
- Verified existing favorite movies, episodes, albums, and artists still appear in the `Favorites` row.
- Verified favorite songs do not have a watched checkmark.
