### PR TITLE
Change the home Favorites row default sort from Random to Name

### DIFF
--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -466,7 +466,7 @@ end function
 function loadFavorites() as object
     results = []
 
-    sortField = chainLookupReturn(m.global.session, "user.settings.`ui.home.favoritesSortField`", "random")
+    sortField = chainLookupReturn(m.global.session, "user.settings.`ui.home.favoritesSortField`", "SortName")
     sortOrder = chainLookupReturn(m.global.session, "user.settings.`ui.home.favoritesSortOrder`", "Ascending")
 
     params = {

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -698,7 +698,7 @@
                 "description": "Field to sort the row by.",
                 "settingName": "ui.home.favoritesSortField",
                 "type": "radio",
-                "default": "random",
+                "default": "SortName",
                 "options": [
                   {
                     "title": "Date Created",

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -70,5 +70,9 @@
   {
     "description": "Fix Cast & Crew favorite button state and persistence",
     "author": "VX-101"
+  },
+  {
+    "description": "Change the home Favorites row default sort from Random to Name",
+    "author": "VX-101"
   }
 ]


### PR DESCRIPTION
## Summary
Changes the home `Favorites` row default sort from `Random` to `Name`.

**Rationale:** The `Favorites` row reloads when returning to the home screen after opening an item. With `Random` as the default sort, that reload can reshuffle the row and make it look like the user's position or available favorites changed. Using `Name` as the default keeps the row predictable while preserving `Random` as an explicit user-selected option.

## Changes
- Defaults `ui.home.favoritesSortField` to `SortName`.

## Follow-up
- Add a clearer cue and/or `View All Favorites` path when the home row is showing only part of the user's favorites.
- Favorite people are loaded through the server `Persons` endpoint, which does not honor `Random` sorting; leave that broader `Favorites` sorting behavior for the split-row follow-up.
- Split the home `Favorites` section into separate rows by item type, matching the Web and iOS clients. See #907.

## Testing
- Ran `npm run build` successfully.
- Sideloaded local build `3.1.10.0906.0050`.
- Verified the home `Favorites` row keeps a stable order after returning from an item.
- Sideloaded combined local build `3.1.10.9999.0051` with #904 and verified the `Favorites` row still works with favorite songs and `Cast & Crew` people.
