### PR TITLE
Keep end time up-to-date with clock while OSD is visible

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -73,6 +73,12 @@ sub init()
     m.osd = m.top.findNode("osd")
     m.osd.observeField("action", "onOSDAction")
     m.clock = m.osd.findNode("clock")
+    if isValid(m.clock)
+        m.clockTimer = m.clock.findNode("currentTimeTimer")
+        if isValid(m.clockTimer)
+            m.clockTimer.observeField("fire", "onClockTick")
+        end if
+    end if
 
     m.videocontrols = m.osd.findNode("videoControls")
     m.optioncontrols = m.osd.findNode("optionControls")
@@ -1319,7 +1325,7 @@ sub onState(msg)
     end if
 end sub
 
-sub setVideoEndingTime(videoSeekPosition = 0 as integer)
+sub setVideoEndingTime(videoSeekPosition = invalid as dynamic)
     m.clock = m.osd.findNode("clock")
     if not isValid(m.clock) then return
     if not isValid(m.top.content) then return
@@ -1327,40 +1333,14 @@ sub setVideoEndingTime(videoSeekPosition = 0 as integer)
     if m.top.content.live then return
 
     currentTime = m.clock.callFunc("getCurrentTime")
-    remainingTime = getremainingTime(videoSeekPosition)
+    remainingTime = getRemainingTime(videoSeekPosition)
     videoEndingTime = m.clock.callFunc("getFormattedTime", (currentTime + remainingTime), false, false)
 
     m.osd.videoEndingTime = videoEndingTime
 end sub
 
-function getRemainingTime(videoSeekPosition = 0 as integer)
-    if not isChainValid(m.positionText, "text")
-        return m.osd.progressDuration - m.top.position
-    end if
-
-    seekTime = 0#
-    seekPosition = m.positionText.text.split(":")
-
-    if seekPosition.count() = 3
-        ' hours -> seconds
-        seekTime += seekPosition[0].toint() * 3600
-        ' minutes -> seconds
-        seekTime += seekPosition[1].toint() * 60
-    end if
-
-    ' minutes -> seconds
-    if seekPosition.count() = 2
-        seekTime += seekPosition[0].toint() * 60
-    end if
-
-    ' add seconds
-    seekTime += seekPosition[seekPosition.count() - 1].toint()
-
-    if videoSeekPosition > 0
-        seekTime = videoSeekPosition
-    end if
-
-    seekTime = seekTime = 0 ? m.top.position : seekTime
+function getRemainingTime(videoSeekPosition = invalid as dynamic)
+    seekTime = isValid(videoSeekPosition) ? videoSeekPosition : m.top.position
 
     return m.osd.progressDuration - seekTime
 end function
@@ -1531,6 +1511,7 @@ end sub
 ' @param {string} whichfocus - indicates which element should be focused when showing the OSD. Accepts "videoControls" or "progressBar"
 sub showOSD(whichfocus as string)
     hideNextItem() ' Hide next up info display when OSD is visible
+    setVideoEndingTime()
     m.osd.visible = true
     m.osd.hasFocus = true
     if whichfocus = "videoControls"
@@ -1548,6 +1529,13 @@ sub showOSD(whichfocus as string)
     m.skipSegmentButton.focus = false
     m.scrubberOldPosition.visible = true
     m.osd.setFocus(true)
+end sub
+
+sub onClockTick()
+    if not isValid(m.osd) then return
+    if not m.osd.visible then return
+
+    setVideoEndingTime()
 end sub
 
 sub positionChapterList()

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1535,7 +1535,11 @@ sub onClockTick()
     if not isValid(m.osd) then return
     if not m.osd.visible then return
 
-    setVideoEndingTime()
+    if m.osd.isSeeking
+        setVideoEndingTime(m.previewPos)
+    else
+        setVideoEndingTime()
+    end if
 end sub
 
 sub positionChapterList()

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -74,5 +74,9 @@
   {
     "description": "Fix Next Up overlay text overflow with custom fonts",
     "author": "ferezvi"
+  },
+  {
+    "description": "Update end time on initially showing OSD and on clock tick while OSD is visible",
+    "author": "michaellee94"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
This PR adds a call to `setVideoEndingTime` in `showOSD` and in a new `onClockTick` sub that is called per second when the OSD is visible. This PR also simplifies `getRemainingTime` to use the player position or explicit seek preview position directly instead of parsing the displayed timestamp text.

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
https://github.com/jellyfin/jellyfin-roku/issues/908
