### PR TITLE
Fix/caption empty cue guard

### DIFF
--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -114,6 +114,7 @@ sub updateCaption()
     for each entry in m.captionList
         if entry["start"] <= m.top.currentPos and m.top.currentPos < entry["end"]
 
+            if entry["text"].count() = 0 then continue for ' Guard against empty text blocks
             fullText = entry["text"].Join(Chr(10))
 
             ' look for style tags

--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -112,9 +112,9 @@ sub updateCaption()
     captions = []
 
     for each entry in m.captionList
+        if entry["text"].count() = 0 then continue for ' Guard against empty text blocks
         if entry["start"] <= m.top.currentPos and m.top.currentPos < entry["end"]
 
-            if entry["text"].count() = 0 then continue for ' Guard against empty text blocks
             fullText = entry["text"].Join(Chr(10))
 
             ' look for style tags

--- a/source/static/whatsNew/3.2.0.json
+++ b/source/static/whatsNew/3.2.0.json
@@ -98,5 +98,9 @@
   {
     "description": "Add support for songs and people to the favorites row on the home screen",
     "author": "VX-101"
+  },
+  {
+    "description": "Fix crash when subtitle cue has no text content",
+    "author": "ferezvi"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
Skip caption cues with empty text arrays early in the render loop in captionTask.bs. This prevents a divide-by-zero runtime crash that occurred when a malformed SRT/VTT file contained a cue with valid timestamps but no text content, causing lineCount to be 0 when passed to prepareStyles().

## How to reproduce

Add a video with an external subtitle file containing an empty cue block, for example:

1
00:00:00,000 --> 00:00:05,000

2
00:00:06,000 --> 00:00:10,000
Normal subtitle text

Play the video on a Roku device with subtitles enabled
When playback reaches the timestamp of the empty cue, the app crashes with a divide-by-zero runtime error in captionTask.bs:
## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
