### PR TITLE
Fix cursor highlight being enabled on search and library items

### DIFF
--- a/components/Libraries/MusicLibraryView.bs
+++ b/components/Libraries/MusicLibraryView.bs
@@ -1000,6 +1000,7 @@ sub onSearchTermChanged()
 
         m.dropdownOptionGroup@.setSearchHintText(string.EMPTY)
         m.top.alphaSelected = searchTerm
+        m.dropdownOptionGroup@.setSearchBackground(SearchButtonState.INACTIVE)
         return
     end if
 

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -1403,6 +1403,7 @@ sub onSearchTermChanged()
 
         m.dropdownOptionGroup@.setSearchHintText(string.EMPTY)
         m.top.alphaSelected = searchTerm
+        m.dropdownOptionGroup@.setSearchBackground(SearchButtonState.INACTIVE)
         return
     end if
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
When using search inside dropdown menu row, if you search for a single letter and it returns results, it causes the cursor highlight to show on both search box and item grid.

This PR fixes that bug.