### PR TITLE
Add playback duration check to direct play setting check.

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -101,6 +101,7 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
         ' Live TV is under CurrentProgram.Overview
         video.overview = meta.json.CurrentProgram.overview
     end if
+    video.runtimeticks = meta.json.RunTimeTicks
     video.trickplay = meta.json.Trickplay
     video.chapters = meta.json.Chapters
     video.content.title = meta.title

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -17,7 +17,7 @@ import "pkg:/source/utils/misc.bs"
 
 const REPLAY_RETRIES = 3
 const BUFFERING_LOGO_RIGHT_PADDING = 30
-const ACCEPTED_DURACTION_DELTA = 30
+const ACCEPTED_DURATION_DELTA = 30
 
 sub init()
     m.top.enableUI = false
@@ -1187,8 +1187,8 @@ sub playbackFailureTest()
 
     runtimeSeconds = m.runtimeticks / 10000000&
 
-    ' Jellyfin's reported duration must be within 30 seconds of Roku's duraction
-    if Abs(m.top.duration - runtimeSeconds) < ACCEPTED_DURACTION_DELTA
+    ' Jellyfin's reported duration must be within 30 seconds of Roku's duration
+    if Abs(m.top.duration - runtimeSeconds) < ACCEPTED_DURATION_DELTA
         m.playbackTestComplete = true
         return
     end if
@@ -1202,7 +1202,7 @@ sub playbackFailureTest()
         m.playbackTestComplete = true
     end if
 
-    m.global.queueManager.callFunc("setTranscodeReason", tr("Roku thought it could direct play this media, but the playback duraction was incorrect."))
+    m.global.queueManager.callFunc("setTranscodeReason", tr("Roku thought it could direct play this media, but the playback duration was incorrect."))
 
     ' Stop playback and exit player
     m.top.control = VideoControl.STOP

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -17,9 +17,11 @@ import "pkg:/source/utils/misc.bs"
 
 const REPLAY_RETRIES = 3
 const BUFFERING_LOGO_RIGHT_PADDING = 30
+const ACCEPTED_DURACTION_DELTA = 30
 
 sub init()
     m.top.enableUI = false
+    m.playbackTestComplete = false
 
     m.spinner = m.top.getScene().findNode("Spinner")
     m.spinnerPercentLabel = m.top.findNode("spinnerPercent")
@@ -703,10 +705,12 @@ sub onVideoContentLoaded()
     burnInSubtitles = chainLookupReturn(m.global, "session.user.settings.`playback.subs.burnin`", true)
     subtitlesBurnedIn = m.isTranscoded and burnInSubtitles and chainLookupReturn(videoContent[0], "subtitlesBurnedIn", true)
 
-
     if subtitlesBurnedIn
         videoContent[0].content.SubtitleTracks = []
     end if
+
+    ' If content is live, consider playback test completed
+    m.playbackTestComplete = videoContent[0].content.live
 
     m.top.content = videoContent[0].content
     m.top.PlaySessionId = videoContent[0].PlaySessionId
@@ -722,6 +726,7 @@ sub onVideoContentLoaded()
     m.trickplay = videoContent[0].trickplay
     m.top.showID = videoContent[0].showID
     m.mediaSegments = videoContent[0].mediaSegments
+    m.runtimeticks = videoContent[0].runtimeticks
 
     m.osd.itemTitleText = m.top.content.title
     m.bufferingItemTitle.text = m.top.content.title
@@ -1169,8 +1174,54 @@ sub checkSegmentSkipButton(position as double)
     end if
 end sub
 
+sub playbackFailureTest()
+    if not isValid(m.runtimeticks)
+        m.playbackTestComplete = true
+        return
+    end if
+
+    if not isValid(m.top.duration)
+        m.playbackTestComplete = true
+        return
+    end if
+
+    runtimeSeconds = m.runtimeticks / 10000000&
+
+    ' Jellyfin's reported duration must be within 30 seconds of Roku's duraction
+    if Abs(m.top.duration - runtimeSeconds) < ACCEPTED_DURACTION_DELTA
+        m.playbackTestComplete = true
+        return
+    end if
+
+    startSpinnerWithPercent(0)
+
+    if isStringEqual(PlaybackMethod.PLAYNORMALLY, m.global.queueManager.callFunc("getForceTranscode"))
+        m.global.queueManager.callFunc("setForceTranscode", PlaybackMethod.FORCETRANSCODEALLOWREMUX)
+    else if isStringEqual(PlaybackMethod.FORCETRANSCODEALLOWREMUX, m.global.queueManager.callFunc("getForceTranscode"))
+        m.global.queueManager.callFunc("setForceTranscode", PlaybackMethod.FORCETRANSCODEDISABLEREMUX)
+        m.playbackTestComplete = true
+    end if
+
+    m.global.queueManager.callFunc("setTranscodeReason", tr("Roku thought it could direct play this media, but the playback duraction was incorrect."))
+
+    ' Stop playback and exit player
+    m.top.control = VideoControl.STOP
+
+    m.LoadMetaDataTask.mustTranscode = true
+    m.LoadMetaDataTask.observeField("content", "onVideoContentLoaded")
+    m.LoadMetaDataTask.control = TaskControl.RUN
+end sub
+
 ' When Video Player state changes
 sub onPositionChanged()
+    if not m.playbackTestComplete
+        if m.attemptDirectPlaySetting
+            if not m.isTranscoded
+                playbackFailureTest()
+            end if
+        end if
+    end if
+
     ' Pass video position data into OSD
     if m.osd.progressDuration = 0
         m.osd.progressPercentage = 0

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2459,5 +2459,9 @@
             <source>Forces Jellyfin to try direct playing video media, Live TV excluded. Enabling this ignores all other playback support settings and will always first attempt direct playback. It also changes how transcode reason is displayed.</source>
             <translation>Forces Jellyfin to try direct playing video media, Live TV excluded. Enabling this ignores all other playback support settings and will always first attempt direct playback. It also changes how transcode reason is displayed.</translation>
         </message>
+        <message>
+            <source>Roku thought it could direct play this media, but the playback duration was incorrect.</source>
+            <translation>Roku thought it could direct play this media, but the playback duration was incorrect.</translation>
+        </message>
     </context>
 </TS>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Sometimes Roku believes it can play a file, loads it into the video player, and only once it starts playback does it fail. Not with an error message, but by showing only a blank screen and a duration that doesn't match the media's real duration.

This PR adds a check that confirms Jellyfin's reported duration is within 30 seconds of Roku video player's reported duration. If it is not, it triggers the transcode logic.
