### PR TITLE
Add cast and crew popup to video OSD

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -97,6 +97,7 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
     end if
 
     video.overview = meta.json.overview
+    video.people = meta.json.people
     if not isValid(video.overview) and isValid(meta.json.CurrentProgram)
         ' Live TV is under CurrentProgram.Overview
         video.overview = meta.json.CurrentProgram.overview

--- a/components/video/OSD.xml
+++ b/components/video/OSD.xml
@@ -17,6 +17,7 @@
     <ButtonGroup id="optionControls" itemSpacings="[20]" layoutDirection="horiz" horizAlignment="left" translation="[103,120]">
       <IconButton id="showVideoInfoPopup" padding="16" icon="pkg:/images/icons/videoInfo.png" height="65" width="100" />
       <IconButton id="showVideoOverviewPopup" padding="25" icon="pkg:/images/icons/info.png" height="65" width="100" />
+      <IconButton id="showCastCrewPopup" padding="16" icon="pkg:/images/icons/userGroup.png" height="65" width="100" />
       <IconButton id="chapterList" padding="16" icon="pkg:/images/icons/numberList.png" height="65" width="100" />
       <IconButton id="showSubtitleMenu" padding="0" icon="pkg:/images/icons/subtitle.png" height="65" width="100" />
       <IconButton id="showAudioMenu" padding="27" icon="pkg:/images/icons/musicNote.png" height="65" width="100" />

--- a/components/video/PlaybackCastItem.xml
+++ b/components/video/PlaybackCastItem.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component name="PlaybackCastItem" extends="JFGroup">
+  <script type="text/brightscript" uri="pkg:/components/extras/ExtrasItem.bs" />
+  <children>
+    <LayoutGroup layoutDirection="vert" itemSpacings="[10, 0]">
+      <Poster id="posterImg" width="234" height="300" translation="[8,243]" failedBitmapUri="pkg:/images/baseline_person_white_48dp.png" />
+      <ScrollingText
+        id="pLabel"
+        horizAlign="left"
+        vertAlign="bottom"
+        height="48"
+        font="font:SmallestBoldSystemFont"
+        repeatCount="0" />
+      <ScrollingText
+        id="SubTitle"
+        horizAlign="left"
+        vertAlign="center"
+        height="32"
+        font="font:SmallestBoldSystemFont"
+        color="#777777FF"
+        repeatCount="0" />
+    </LayoutGroup>
+  </children>
+  <interface>
+    <field id="itemContent" type="node" onChange="showContent" />
+    <field id="itemHasFocus" type="boolean" onChange="focusChanged" />
+  </interface>
+</component>

--- a/components/video/PlaybackCastPopup.bs
+++ b/components/video/PlaybackCastPopup.bs
@@ -206,9 +206,7 @@ end sub
 sub appendLibraryItems(items as object)
     if not isValidAndNotEmpty(items) then return
 
-    for each item in items
-        m.libraryItems.push(item)
-    end for
+    m.libraryItems.append(items)
 end sub
 
 sub renderLibraryItems()

--- a/components/video/PlaybackCastPopup.bs
+++ b/components/video/PlaybackCastPopup.bs
@@ -1,0 +1,294 @@
+import "pkg:/source/api/Image.bs"
+import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/enums/KeyCode.bs"
+import "pkg:/source/enums/PersonType.bs"
+import "pkg:/source/enums/TaskControl.bs"
+import "pkg:/source/utils/misc.bs"
+
+sub init()
+    m.title = m.top.findNode("title")
+    m.title.text = tr("Cast & Crew")
+
+    m.castList = m.top.findNode("castList")
+    m.castList.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+    m.castList.observeField("rowItemSelected", "onPersonSelected")
+
+    m.personDetails = m.top.findNode("personDetails")
+    m.personImage = m.top.findNode("personImage")
+    m.personName = m.top.findNode("personName")
+    m.personRole = m.top.findNode("personRole")
+    m.personOverview = m.top.findNode("personOverview")
+    m.libraryTitle = m.top.findNode("libraryTitle")
+    m.libraryLoading = m.top.findNode("libraryLoading")
+    m.libraryList = m.top.findNode("libraryList")
+    m.libraryList.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+    m.libraryList.observeField("rowItemSelected", "onLibraryItemSelected")
+
+    m.selectedPersonId = ""
+    m.lastLibraryPersonId = ""
+end sub
+
+sub showCast(people as object)
+    m.detailFocus = "person"
+    m.selectedPersonId = ""
+    m.lastLibraryPersonId = ""
+    m.personDetails.visible = false
+    m.castList.visible = true
+    content = CreateObject("roSGNode", "ContentNode")
+    row = content.createChild("ContentNode")
+
+    for each person in people
+        personNode = row.createChild("ExtrasData")
+        personNode.id = person.Id
+        personNode.labelText = person.Name
+        personNode.posterURL = ImageUrl(person.Id, "Primary", {
+            Tags: person.PrimaryImageTag,
+            MaxWidth: 234,
+            MaxHeight: 330
+        })
+
+        castRoleType = person.LookupCI("type")
+        if not isValidAndNotEmpty(castRoleType)
+            castRoleType = tr("Unknown")
+        end if
+
+        personRole = person.LookupCI("role")
+        if isStringEqual(castRoleType, PersonType.ACTOR) and isValidAndNotEmpty(personRole)
+            personNode.subTitle = tr("as %1").Replace("%1", personRole)
+        else
+            personNode.subTitle = castRoleType
+        end if
+
+        personNode.json = {
+            id: person.Id,
+            Id: person.Id,
+            Name: person.Name,
+            type: capitalize(PersonType.PERSON),
+            Type: capitalize(PersonType.PERSON),
+            PersonType: castRoleType,
+            Role: personRole
+        }
+        personNode.Type = capitalize(PersonType.PERSON)
+    end for
+
+    m.castList.content = content
+    m.top.visible = true
+    m.castList.setFocus(true)
+end sub
+
+sub hideCast()
+    cancelPersonTasks()
+    m.selectedPersonId = ""
+    m.castList.setFocus(false)
+    m.libraryList.setFocus(false)
+    m.personDetails.visible = false
+    m.top.visible = false
+    m.top.setFocus(false)
+
+    videoPlayer = m.top.getParent()
+    if isValid(videoPlayer)
+        videoPlayer.setFocus(true)
+    end if
+end sub
+
+sub cancelPersonTasks()
+    if isValid(m.loadPersonTask)
+        m.loadPersonTask.unobserveField("content")
+        m.loadPersonTask.control = TaskControl.STOP
+    end if
+    if isValid(m.loadPersonMoviesTask)
+        m.loadPersonMoviesTask.unobserveField("content")
+        m.loadPersonMoviesTask.control = TaskControl.STOP
+    end if
+    if isValid(m.loadPersonSeriesTask)
+        m.loadPersonSeriesTask.unobserveField("content")
+        m.loadPersonSeriesTask.control = TaskControl.STOP
+    end if
+end sub
+
+sub handleBack()
+    if m.personDetails.visible
+        cancelPersonTasks()
+        m.selectedPersonId = ""
+        m.libraryList.setFocus(false)
+        m.personDetails.visible = false
+        m.castList.visible = true
+        m.castList.setFocus(true)
+        return
+    end if
+
+    hideCast()
+end sub
+
+sub onPersonSelected()
+    selectedPerson = m.castList.content.getChild(m.castList.rowItemSelected[0]).getChild(m.castList.rowItemSelected[1])
+    if not isValid(selectedPerson) then return
+    if not isValidAndNotEmpty(selectedPerson.id) then return
+
+    m.selectedPersonId = selectedPerson.id
+    m.castList.setFocus(false)
+    m.castList.visible = false
+    m.personDetails.visible = true
+    m.detailFocus = "person"
+    m.personImage.uri = selectedPerson.posterURL
+    m.personName.text = selectedPerson.labelText
+    m.personRole.text = selectedPerson.subTitle
+    m.personOverview.text = tr("Loading...")
+    m.libraryTitle.text = tr("More with %1 in Your Library").Replace("%1", selectedPerson.labelText)
+    m.libraryLoading.text = tr("Loading...")
+    m.libraryList.visible = false
+    m.libraryItems = []
+    m.top.setFocus(true)
+
+    m.loadPersonTask = CreateObject("roSGNode", "LoadItemsTask")
+    m.loadPersonTask.itemsToLoad = "metaData"
+    m.loadPersonTask.itemId = m.selectedPersonId
+    m.loadPersonTask.observeField("content", "onPersonLoaded")
+    m.loadPersonTask.control = TaskControl.RUN
+
+    m.loadPersonMoviesTask = CreateObject("roSGNode", "LoadItemsTask")
+    m.loadPersonMoviesTask.itemsToLoad = "personMovies"
+    m.loadPersonMoviesTask.itemId = m.selectedPersonId
+    m.loadPersonMoviesTask.observeField("content", "onPersonMoviesLoaded")
+    m.loadPersonMoviesTask.control = TaskControl.RUN
+end sub
+
+sub onPersonLoaded(event as object)
+    personTask = event.getRoSGNode()
+    if not isValid(personTask) then return
+    if not isStringEqual(personTask.itemId, m.selectedPersonId) then return
+
+    personData = personTask.content
+    personTask.control = TaskControl.STOP
+
+    if not isValidAndNotEmpty(personData) or not isValid(personData[0])
+        m.personOverview.text = tr("Biographical information for this person is not currently available.")
+        return
+    end if
+
+    person = personData[0]
+    if isValidAndNotEmpty(person.posterURL)
+        m.personImage.uri = person.posterURL
+    end if
+
+    if isChainValid(person, "json.Overview") and isValidAndNotEmpty(person.json.Overview)
+        m.personOverview.text = person.json.Overview
+    else
+        m.personOverview.text = tr("Biographical information for this person is not currently available.")
+    end if
+end sub
+
+sub onPersonMoviesLoaded(event as object)
+    moviesTask = event.getRoSGNode()
+    if not isValid(moviesTask) then return
+    if not isStringEqual(moviesTask.itemId, m.selectedPersonId) then return
+
+    appendLibraryItems(moviesTask.content)
+    moviesTask.control = TaskControl.STOP
+
+    m.loadPersonSeriesTask = CreateObject("roSGNode", "LoadItemsTask")
+    m.loadPersonSeriesTask.itemsToLoad = "personSeries"
+    m.loadPersonSeriesTask.itemId = moviesTask.itemId
+    m.loadPersonSeriesTask.observeField("content", "onPersonSeriesLoaded")
+    m.loadPersonSeriesTask.control = TaskControl.RUN
+end sub
+
+sub onPersonSeriesLoaded(event as object)
+    seriesTask = event.getRoSGNode()
+    if not isValid(seriesTask) then return
+    if not isStringEqual(seriesTask.itemId, m.selectedPersonId) then return
+
+    appendLibraryItems(seriesTask.content)
+    seriesTask.control = TaskControl.STOP
+    renderLibraryItems()
+end sub
+
+sub appendLibraryItems(items as object)
+    if not isValidAndNotEmpty(items) then return
+
+    for each item in items
+        m.libraryItems.push(item)
+    end for
+end sub
+
+sub renderLibraryItems()
+    if not isValidAndNotEmpty(m.libraryItems)
+        m.libraryLoading.text = tr("No other titles found in your library.")
+        m.libraryList.visible = false
+        return
+    end if
+
+    content = CreateObject("roSGNode", "ContentNode")
+    row = content.createChild("ContentNode")
+    for each item in m.libraryItems
+        item.id = item.json.LookupCI("Id")
+        item.Id = item.json.LookupCI("Id")
+        item.labelText = item.json.LookupCI("Name")
+        item.subTitle = ""
+        if isValid(item.json.LookupCI("ProductionYear"))
+            item.subTitle = item.json.LookupCI("ProductionYear")
+        end if
+        item.type = item.json.LookupCI("Type")
+        item.Type = item.json.LookupCI("Type")
+        item.imageWidth = 234
+        row.appendChild(item)
+    end for
+
+    m.libraryList.content = content
+    if not isStringEqual(m.selectedPersonId, m.lastLibraryPersonId)
+        m.libraryList.jumpToRowItem = [0, 0]
+    end if
+    m.lastLibraryPersonId = m.selectedPersonId
+    m.libraryList.visible = true
+    m.libraryLoading.text = ""
+    m.detailFocus = "library"
+    m.libraryList.setFocus(true)
+end sub
+
+sub onLibraryItemSelected()
+    selectedItem = m.libraryList.content.getChild(m.libraryList.rowItemSelected[0]).getChild(m.libraryList.rowItemSelected[1])
+    if not isValid(selectedItem) then return
+    if not isValidAndNotEmpty(selectedItem.id) then return
+
+    selectedItemType = selectedItem.type
+    if not isValidAndNotEmpty(selectedItemType)
+        selectedItemType = selectedItem.Type
+    end if
+    if not isValidAndNotEmpty(selectedItemType) then return
+
+    m.global.jumpTo = {
+        selectiontype: "playbackSelectedItem",
+        selectedItem: {
+            id: selectedItem.id,
+            type: selectedItemType,
+            json: selectedItem.json
+        }
+    }
+end sub
+
+function handleKey(key as string) as boolean
+    if key = KeyCode.BACK
+        handleBack()
+        return true
+    end if
+
+    if not m.personDetails.visible then return false
+
+    if key = KeyCode.DOWN and isStringEqual(m.detailFocus, "person") and m.libraryList.visible
+        m.detailFocus = "library"
+        m.libraryList.setFocus(true)
+        return true
+    end if
+
+    if key = KeyCode.UP and m.libraryList.isInFocusChain()
+        return true
+    end if
+
+    return false
+end function
+
+function onKeyEvent(key as string, press as boolean) as boolean
+    if not press then return false
+
+    return handleKey(key)
+end function

--- a/components/video/PlaybackCastPopup.xml
+++ b/components/video/PlaybackCastPopup.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component name="PlaybackCastPopup" extends="Group" initialFocus="castList">
+  <children>
+    <Rectangle color="0x000000DD" width="1920" height="1080" />
+    <Text id="title" translation="[103, 100]" font="font:LargeBoldSystemFont" />
+    <RowList
+      id="castList"
+      translation="[103, 200]"
+      itemComponentName="PlaybackCastItem"
+      itemSize="[1710, 396]"
+      itemSpacing="[0, 0]"
+      numRows="1"
+      rowFocusAnimationStyle="fixedFocusWrap"
+      rowItemSize="[[234, 376]]"
+      rowItemSpacing="[[40, 0]]"
+      showRowCounter="false"
+      showRowLabel="false" />
+    <Group id="personDetails" visible="false">
+      <Rectangle color="0x101420FF" width="1714" height="875" translation="[103, 145]" />
+      <Poster id="personImage" width="250" height="375" translation="[145, 190]" failedBitmapUri="pkg:/images/baseline_person_white_48dp.png" />
+      <Text id="personName" width="1310" translation="[450, 190]" font="font:LargeBoldSystemFont" />
+      <Text id="personRole" width="1310" translation="[450, 265]" font="font:MediumSystemFont" color="#aaaaaa" />
+      <Text id="personOverview" width="1310" height="210" translation="[450, 335]" wrap="true" maxLines="6" ellipsisText="..." font="font:SmallestSystemFont" />
+      <Text id="libraryTitle" width="1600" translation="[145, 572]" font="font:MediumBoldSystemFont" />
+      <Text id="libraryLoading" width="1600" translation="[145, 640]" font="font:SmallSystemFont" color="#aaaaaa" />
+      <RowList
+        id="libraryList"
+        visible="false"
+        translation="[145, 638]"
+        itemComponentName="PlaybackCastItem"
+        itemSize="[1630, 396]"
+        itemSpacing="[0, 0]"
+        numRows="1"
+        rowFocusAnimationStyle="fixedFocusWrap"
+        rowItemSize="[[234, 376]]"
+        rowItemSpacing="[[40, 0]]"
+        showRowCounter="false"
+        showRowLabel="false" />
+    </Group>
+  </children>
+  <interface>
+    <function name="showCast" />
+    <function name="hideCast" />
+    <function name="handleBack" />
+    <function name="handleKey" />
+  </interface>
+</component>

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -76,6 +76,7 @@ sub init()
     m.chapterContent = m.top.findNode("chapterContent")
     m.osd = m.top.findNode("osd")
     m.osd.observeField("action", "onOSDAction")
+    m.castPopup = m.top.findNode("castPopup")
     m.clock = m.osd.findNode("clock")
     if isValid(m.clock)
         m.clockTimer = m.clock.findNode("currentTimeTimer")
@@ -446,6 +447,16 @@ sub handleShowVideoOverviewPopupAction()
     m.global.sceneManager.callFunc("standardDialog", overviewPopupTitle, { data: ["<p>" + m.overview + "</p>"] })
 end sub
 
+sub handleShowCastCrewPopupAction()
+    if not isValidAndNotEmpty(m.castPeople)
+        m.global.sceneManager.callFunc("standardDialog", tr("Cast & Crew"), { data: ["<p>" + tr("No cast data available.") + "</p>"] })
+        return
+    end if
+
+    handleHideAction(false)
+    m.castPopup.callFunc("showCast", m.castPeople)
+end sub
+
 ' onOSDAction: Process action events from OSD to their respective handlers
 '
 sub onOSDAction()
@@ -498,6 +509,11 @@ sub onOSDAction()
 
     if isStringEqual(action, "showvideooverviewpopup")
         handleShowVideoOverviewPopupAction()
+        return
+    end if
+
+    if isStringEqual(action, "showcastcrewpopup")
+        handleShowCastCrewPopupAction()
         return
     end if
 
@@ -723,6 +739,7 @@ sub onVideoContentLoaded()
     m.top.transcodeParams = videoContent[0].transcodeparams
     m.chapters = videoContent[0].chapters
     m.overview = videoContent[0].overview
+    m.castPeople = videoContent[0].people
     m.trickplay = videoContent[0].trickplay
     m.top.showID = videoContent[0].showID
     m.mediaSegments = videoContent[0].mediaSegments
@@ -1068,6 +1085,8 @@ sub displaySegmentSkipButton(segmentType as string, endticks as double)
         end if
     end if
 
+    if m.castPopup.visible then return
+
     ' Check if button is already showing
     if isStringEqual(m.skipSegmentButton.text, tr(`Skip ${segmentType}`)) then return
 
@@ -1140,6 +1159,14 @@ end sub
 
 sub checkSegmentSkipButton(position as double)
     if not isValidAndNotEmpty(m.mediaSegments) then return
+    if m.castPopup.visible and m.skipSegmentButton.visible
+        m.skipSegmentButton.visible = false
+        m.skipSegmentButton.text = string.EMPTY
+        m.skipSegmentButton.setFocus(false)
+        m.skipSegmentButton.focus = false
+        hideNextItem()
+    end if
+
     matchFound = false
 
     currentPositionTicks = int(position) * 10000000&
@@ -1627,6 +1654,9 @@ sub skipCurrentSegment()
     startSpinnerWithPercent(0)
     m.top.seek = seekPosition
     m.osd.isSeeking = false
+
+    if m.castPopup.visible then return
+
     handleHideAction(false)
 end sub
 
@@ -1718,6 +1748,13 @@ sub changeSubtitleTimeOffset(offsetAmount as integer)
 end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean
+    if m.castPopup.visible
+        if press and m.castPopup.callFunc("handleKey", key)
+            if not m.castPopup.visible then m.top.setFocus(true)
+        end if
+        return true
+    end if
+
     if m.subtitleTimingButtons.visible
         if m.subtitleTimingButtons.isInFocusChain()
             if not press then return false

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -16,6 +16,7 @@
     <field id="systemOverlay" type="boolean" value="false" />
     <field id="showID" type="string" />
     <field id="lastFocus" type="node" />
+    <field id="returnOnStop" type="boolean" value="false" />
 
     <field id="transcodeParams" type="assocarray" />
     <field id="transcodeAvailable" type="boolean" value="false" />
@@ -46,6 +47,7 @@
     <timer id="bufferStuckTimer" repeat="true" duration="3" />
     <timer id="bufferCheckTimer" repeat="true" />
     <OSD id="osd" visible="false" inactiveTimeout="5" />
+    <PlaybackCastPopup id="castPopup" visible="false" />
 
     <Rectangle id="chapterList" visible="false" color="0x00000098" width="400" height="380" translation="[103,210]">
       <LabelList id="chapterMenu" itemSpacing="[0,20]" numRows="5" font="font:SmallSystemFont" itemSize="[315,40]" translation="[40,20]">

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -330,6 +330,22 @@
             <translation>Cast &amp; Crew</translation>
         </message>
         <message>
+            <source>No cast data available.</source>
+            <translation>No cast data available.</translation>
+        </message>
+        <message>
+            <source>as %1</source>
+            <translation>as %1</translation>
+        </message>
+        <message>
+            <source>More with %1 in Your Library</source>
+            <translation>More with %1 in Your Library</translation>
+        </message>
+        <message>
+            <source>No other titles found in your library.</source>
+            <translation>No other titles found in your library.</translation>
+        </message>
+        <message>
             <source>More Like This</source>
             <translation>More Like This</translation>
         </message>

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -186,6 +186,29 @@ sub onJumpToEvent(msg)
         m.global.sceneManager.callFunc("clearPreviousScene")
     end if
 
+    if isStringEqual(jumpToData.selectiontype, "playbackSelectedItem")
+        selectedItem = jumpToData.LookupCI("selectedItem")
+        if not isValid(selectedItem) then return
+
+        if isValid(currentView) and currentView.isSubType("VideoPlayerView")
+            m.pendingPlaybackSelectedItem = {
+                selectedItem: selectedItem,
+                videoNodeId: currentView.id
+            }
+            currentView.returnOnStop = true
+            currentView.observeField("state", m.port)
+            m.global.queueManager.callFunc("bypassNextPreferredAudioTrackIndexReset")
+            m.global.queueManager.callFunc("clear")
+            m.global.sceneManager.callFunc("clearPreviousScene")
+            currentView.control = VideoControl.STOP
+            return
+        end if
+
+        openPlaybackSelectedItem(selectedItem)
+
+        return
+    end if
+
     if isStringEqual(jumpToData.selectiontype, "search")
         startLoadingSpinner()
 
@@ -261,6 +284,23 @@ sub onJumpToEvent(msg)
 
         group = CreateMusicLibraryView(libraryContent)
         m.global.sceneManager.callFunc("pushScene", group)
+    end if
+end sub
+
+sub openPlaybackSelectedItem(selectedItem as object)
+    if not isValid(selectedItem) then return
+
+    selectedItemType = selectedItem.LookupCI("type")
+    if not isValidAndNotEmpty(selectedItemType) then return
+    selectedItemType = LCase(selectedItemType)
+
+    if inArray([ItemType.MOVIE, ItemType.EPISODE, ItemType.RECORDING], selectedItemType)
+        CreateMovieDetailsGroup(selectedItem)
+    else if isStringEqual(selectedItemType, ItemType.SERIES)
+        selectedItemId = chainLookup(selectedItem, "json.id")
+        if isValidAndNotEmpty(selectedItemId)
+            CreateSeriesDetailsGroup(selectedItemId)
+        end if
     end if
 end sub
 
@@ -1373,6 +1413,8 @@ sub onStateEvent(msg)
     node = msg.getRoSGNode()
     if not isChainValid(node, "state") then return
 
+    if handlePendingPlaybackSelectedItemState(node) then return
+
     if isStringEqual(node.state, "finished")
         if isStringEqual(node.selectedItemType, ItemType.TVCHANNEL)
             thisItem = {
@@ -1391,6 +1433,28 @@ sub onStateEvent(msg)
         end if
     end if
 end sub
+
+function handlePendingPlaybackSelectedItemState(node as object) as boolean
+    if not isValid(m.pendingPlaybackSelectedItem) then return false
+    if not node.isSubType("VideoPlayerView") then return false
+    if node.id <> m.pendingPlaybackSelectedItem.videoNodeId then return false
+
+    if not inArray(["finished", "stopped"], LCase(node.state)) then return true
+
+    node.unobserveField("state")
+
+    pendingPlaybackSelectedItem = m.pendingPlaybackSelectedItem
+    m.pendingPlaybackSelectedItem = invalid
+
+    currentView = m.global.sceneManager.callFunc("getActiveScene")
+    if isValid(currentView) and currentView.isSubType("VideoPlayerView")
+        m.global.sceneManager.callFunc("clearPreviousScene")
+    end if
+
+    openPlaybackSelectedItem(pendingPlaybackSelectedItem.selectedItem)
+
+    return true
+end function
 
 ' https://developer.roku.com/en-ca/docs/references/brightscript/events/rodeviceinfoevent.md
 sub onRoDeviceInfoEvent(msg)

--- a/source/static/whatsNew/3.2.1.json
+++ b/source/static/whatsNew/3.2.1.json
@@ -6,5 +6,9 @@
   {
     "description": "Prevent skip segment button from taking focus when OSD is visible",
     "author": "Catmasterson"
+  },
+  {
+    "description": "Add cast and crew popup to video OSD",
+    "author": "TnUC-Creations"
   }
 ]


### PR DESCRIPTION
## Changes

Added in-playback Cast & Crew overlay to the Roku video player. The overlay shows cast and crew from the current media, opens an in-playback person details panel with biography and includes a local-library row for movies and series featuring that person. Selecting a local title exits playback and opens Jellyfin's existing details page for that item.

## Testing

- Ran `npm run build`.
- Sideloaded the generated Roku package.
- Tested Cast & Crew during playback, actor biography view, Back navigation to cast list, Back navigation to playback, video controls after closing the popup, and title navigation from the local-library row.

## Issues

No issue linked.
