### PR TITLE
Add 'Date Added' sort option to 'Other' type media

### DIFF
--- a/components/Libraries/OtherLibrary.bs
+++ b/components/Libraries/OtherLibrary.bs
@@ -547,7 +547,8 @@ sub setDefaultOptions(options)
     ]
     options.sort = [
         { "Title": tr("TITLE"), "Name": "SortName" },
-        { "Title": tr("Folders"), "Name": "IsFolder,SortName" }
+        { "Title": tr("Folders"), "Name": "IsFolder,SortName" },
+        { "Title": tr("DATE_ADDED"), "Name": "DateCreated" },
     ]
 end sub
 

--- a/source/static/whatsNew/3.2.1.json
+++ b/source/static/whatsNew/3.2.1.json
@@ -6,5 +6,9 @@
   {
     "description": "Prevent skip segment button from taking focus when OSD is visible",
     "author": "Catmasterson"
+  },
+  {
+    "description": "Add 'Date Added' sort option to 'Other' type media",
+    "author": "UnitedGaucho"
   }
 ]


### PR DESCRIPTION
Media within a library of type 'Other' can only be sorted by Name or by Folders. This makes browsing sports or other manually organized libraries difficult and limited.

<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Add the option to sort by Date Added to round out the most basic sorting methods available for Other type media.

## Issues
Fixes #947
