### PR TITLE
Reduce TV season screen load time by 80%

### DIFF
--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -652,7 +652,7 @@ function TVEpisodes(showId as string, seasonId as string) as dynamic
     results = []
     for each item in data.Items
         tmp = CreateObject("roSGNode", "TVEpisodeData")
-        tmp.posterURL = ImageURL(item.id, "Primary", { "maxWidth": 400, "maxHeight": 250 })
+        tmp.posterURL = api.items.GetImageURL(item.LookupCI("id"), ImageType.PRIMARY, 0, { "maxWidth": 400, "maxHeight": 250, "quality": "90" })
         tmp.json = item
         tmp.overview = item.overview
         results.push(tmp)

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -642,7 +642,9 @@ function TVEpisodes(showId as string, seasonId as string) as dynamic
     {
         "seasonId": seasonId,
         "UserId": m.global.session.user.id,
-        "fields": "MediaStreams,MediaSources"
+        ' Add overview to get episode overview without making additional calls
+        ' to ItemMetaData, which is very expensive when done for each episode in a season
+        "fields": "MediaStreams,MediaSources,Overview"
     })
 
     if data = invalid or data.Items = invalid then return invalid
@@ -650,17 +652,9 @@ function TVEpisodes(showId as string, seasonId as string) as dynamic
     results = []
     for each item in data.Items
         tmp = CreateObject("roSGNode", "TVEpisodeData")
-        tmp.image = PosterImage(item.id, { "maxWidth": 400, "maxheight": 250 })
-        if isValid(tmp.image)
-            tmp.image.posterDisplayMode = "scaleToZoom"
-        end if
+        tmp.posterURL = ImageURL(item.id, "Primary", { "maxWidth": 400, "maxHeight": 250 })
         tmp.json = item
-        tmpMetaData = ItemMetaData(item.id)
-
-        ' validate meta data
-        if isValid(tmpMetaData) and isValid(tmpMetaData.overview)
-            tmp.overview = tmpMetaData.overview
-        end if
+        tmp.overview = item.overview
         results.push(tmp)
     end for
     data.Items = results

--- a/source/static/whatsNew/3.2.1.json
+++ b/source/static/whatsNew/3.2.1.json
@@ -14,5 +14,9 @@
   {
     "description": "Jump to last item in incomplete row on library screen",
     "author": "1hitsong"
+  },
+  {
+    "description": "Reduce TV season screen load time by 80%",
+    "author": "ferezvi"
   }
 ]


### PR DESCRIPTION
## Problem
Loading a season was slow and scaled linearly with episode count (~15s for 30 episodes).

TVEpisodes() was making 2 extra API calls **per episode** inside a loop:
- `PosterImage()` internally calls `GetImages()` API to get the poster URL
- `ItemMetaData()` was called to get the episode overview

For 30 episodes = 60 extra API calls on every season load.

## Solution
- Replace `PosterImage()` with `ImageURL()` directly — poster URL can be constructed without an API call
- Include `Overview` in the initial `GetEpisodes` fields request instead of calling `ItemMetaData()` per episode

## Result
Load time reduced from ~15s to to under 3 spinner rotations regardless of episode count.

## Notes
Similar optimization opportunity exists in other loops using `PosterImage()` 
(SearchData, MusicAlbumData). Left for a follow-up PR after validation of this approach.

## Testing
- [ ] Season with many episodes loads faster
- [ ] Episode posters display correctly