### PR TITLE
Jump to last item in incomplete row on library screen

### DIFF
--- a/components/ItemGrid/LibraryItemGrid.bs
+++ b/components/ItemGrid/LibraryItemGrid.bs
@@ -18,8 +18,8 @@ function onKeyEvent(key as string, press as boolean) as boolean
     sameColumnNextRowIndex = focusedIndex + numColumns
 
     if nextRowStart < itemCount and sameColumnNextRowIndex >= itemCount
-        ' Scroll directly to the last item in a short next row.
-        m.top.animateToItem = itemCount - 1
+        ' Jump directly to the last item in a short next row.
+        m.top.jumpToItem = itemCount - 1
         return true
     end if
 

--- a/source/static/whatsNew/3.2.1.json
+++ b/source/static/whatsNew/3.2.1.json
@@ -10,5 +10,9 @@
   {
     "description": "Add cast and crew popup to video OSD",
     "author": "TnUC-Creations"
+  },
+  {
+    "description": "Jump to last item in incomplete row on library screen",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Jump to last item instead of animating. Once you hit a certainly number of columns, the animation looks terrible.

ref: https://github.com/jellyfin/jellyfin-roku/pull/918#issuecomment-4627008212