### PR TITLE
fix: Honor subtitle selection beyond current episode

### DIFF
--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -216,6 +216,7 @@ sub onSelectSubtitlePressed()
     ' Manually create the None option and place at top
     subtitleData.data.Unshift({
         "Index": SubtitleSelection.NONE,
+        "StreamIndex": SubtitleSelection.NONE,
         "IsExternal": false,
         "Track": {
             "description": "None"

--- a/source/static/whatsNew/3.2.2.json
+++ b/source/static/whatsNew/3.2.2.json
@@ -14,5 +14,9 @@
   {
     "description": "Reduce music library album view load time",
     "author": "ferezvi"
+  },
+  {
+    "description": "Honor subtitle selection beyond current episode",
+    "author": "tjps"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Change the "None" subtitles option to also explicitly set the StreamIndex to NONE. 

Prior to this fix, disabling subtitles on one file in a stream would not persist to the next file in the stream, where StreamIndex would be unchanged (0) and subtitles would appear again.

After this fix, turning off subtitles on one file in a stream causes it to remain off for subsequent files.

## Issues
Possibly related issue: #941 

There are other open issues related to subtitles, but not directly related to this fix.
