### PR TITLE
Add optional home row for Playlist Up Next server plugin

### DIFF
--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -253,13 +253,13 @@ end sub
 
 sub displayTVChannelInfo(itemData as object)
     m.itemText.text = itemData.name
-    m.itemTextExtra.text = itemData.json.AlbumArtist
+    m.itemTextExtra.text = addPlaylistUpNextContext(itemData, itemData.json.AlbumArtist)
     m.itemPoster.uri = ImageURL(itemData.LookupCI("id"))
 end sub
 
 sub displayAudioInfo(itemData as object)
     m.itemText.text = itemData.name
-    m.itemTextExtra.text = itemData.json.AlbumArtist
+    m.itemTextExtra.text = addPlaylistUpNextContext(itemData, itemData.json.AlbumArtist)
     m.itemPoster.uri = ImageURL(itemData.LookupCI("id"))
 end sub
 
@@ -269,13 +269,13 @@ sub displayAudioBookInfo(itemData as object)
     end if
 
     m.itemText.text = itemData.name
-    m.itemTextExtra.text = itemData.json.AlbumArtist
+    m.itemTextExtra.text = addPlaylistUpNextContext(itemData, itemData.json.AlbumArtist)
     m.itemPoster.uri = ImageURL(itemData.LookupCI("id"))
 end sub
 
 sub displayMusicAlbumInfo(itemData as object)
     m.itemText.text = itemData.name
-    m.itemTextExtra.text = itemData.json.AlbumArtist
+    m.itemTextExtra.text = addPlaylistUpNextContext(itemData, itemData.json.AlbumArtist)
     m.itemPoster.uri = itemData.posterURL
 end sub
 
@@ -331,6 +331,7 @@ sub displayVideoInfo(itemData as object)
     end if
 
     m.itemPoster.uri = itemData.imageWidth = 180 ? itemData.posterURL : itemData.thumbnailURL
+    m.itemTextExtra.text = addPlaylistUpNextContext(itemData, "")
 end sub
 
 sub displayMovieInfo(itemData as object)
@@ -360,7 +361,7 @@ sub displayMovieInfo(itemData as object)
             textExtra = `${textExtra} - ${itemData.json.OfficialRating}`
         end if
     end if
-    m.itemTextExtra.text = textExtra
+    m.itemTextExtra.text = addPlaylistUpNextContext(itemData, textExtra)
 end sub
 
 sub displayProgramInfo(itemData as object)
@@ -421,9 +422,21 @@ sub displayEpisodeInfo(localGlobal as object, itemData as object)
     end if
 
     if isValid(m.itemTextExtra)
-        m.itemTextExtra.text = extraPrefix + itemData.LookupCI("name")
+        m.itemTextExtra.text = addPlaylistUpNextContext(itemData, extraPrefix + itemData.LookupCI("name"))
     end if
 end sub
+
+function addPlaylistUpNextContext(itemData as object, text as dynamic) as string
+    displayText = isValidAndNotEmpty(text) ? text : ""
+    playlistName = chainLookup(itemData, "json.PlaylistUpNextPlaylistName")
+    if not isValidAndNotEmpty(playlistName) then return displayText
+
+    if isValidAndNotEmpty(displayText)
+        return `[${playlistName}] ${displayText}`
+    end if
+
+    return `[${playlistName}]`
+end function
 
 '
 ' Draws and animates item progress bar

--- a/components/home/HomeRows.bs
+++ b/components/home/HomeRows.bs
@@ -42,6 +42,9 @@ sub init()
     m.LoadNextUpTask = createObject("roSGNode", "LoadItemsTask")
     m.LoadNextUpTask.itemsToLoad = "nextUp"
 
+    m.LoadPlaylistUpNextTask = createObject("roSGNode", "LoadItemsTask")
+    m.LoadPlaylistUpNextTask.itemsToLoad = "playlistUpNext"
+
     m.LoadOnNowTask = createObject("roSGNode", "LoadItemsTask")
     m.LoadOnNowTask.itemsToLoad = "onNow"
 
@@ -275,6 +278,12 @@ function addHomeSection(sectionType as string) as boolean
         return true
     end if
 
+    ' Playlist Continue / Up Next items
+    if sectionType = "playlistupnext"
+        createPlaylistUpNextRow()
+        return true
+    end if
+
     ' Latest items in each library
     if sectionType = "latestmedia"
         createLatestInRows()
@@ -494,6 +503,23 @@ sub createNextUpRow()
     ' Load the Next Up Data
     m.LoadNextUpTask.observeField("content", "updateNextUpItems")
     m.LoadNextUpTask.control = "RUN"
+end sub
+
+' createPlaylistUpNextRow: Creates a row displaying playlist-ordered up next items
+'
+sub createPlaylistUpNextRow()
+    sectionName = tr("Playlist Continue / Up Next")
+
+    if not sectionExists(sectionName)
+        nextUpRow = m.top.content.CreateChild("HomeRow")
+        nextUpRow.title = sectionName
+        nextUpRow.imageWidth = homeRowItemSizes.WIDE_POSTER[0]
+        nextUpRow.cursorSize = homeRowItemSizes.WIDE_POSTER
+    end if
+
+    ' Load the Playlist Continue / Up Next Data
+    m.LoadPlaylistUpNextTask.observeField("content", "updatePlaylistUpNextItems")
+    m.LoadPlaylistUpNextTask.control = "RUN"
 end sub
 
 ' createMyListRow: Creates a row displaying items from the user's personal list
@@ -747,6 +773,50 @@ sub updateNextUpItems()
 
     ' Row does not exist, insert it into the home view
     m.top.content.insertChild(row, getSectionIndex(sectionName))
+    setRowItemSize()
+end sub
+
+' updatePlaylistUpNextItems: Processes LoadPlaylistUpNextTask content. Removes, Creates, or Updates playlist up next row as needed
+'
+sub updatePlaylistUpNextItems()
+    m.processedRowCount++
+    itemData = m.LoadPlaylistUpNextTask.content
+    m.LoadPlaylistUpNextTask.unobserveField("content")
+    m.LoadPlaylistUpNextTask.content = []
+    m.LoadPlaylistUpNextTask.control = "STOP"
+
+    sectionName = tr("Playlist Continue / Up Next")
+
+    if not isValidAndNotEmpty(itemData)
+        removeHomeSection(sectionName)
+        return
+    end if
+
+    ' remake row using the new data
+    row = CreateObject("roSGNode", "HomeRow")
+    row.title = sectionName
+    row.imageWidth = homeRowItemSizes.WIDE_POSTER[0]
+    row.cursorSize = homeRowItemSizes.WIDE_POSTER
+
+    for each item in itemData
+        if isChainValid(item, "json.UserData.PlayedPercentage")
+            item.PlayedPercentage = item.json.UserData.PlayedPercentage
+        end if
+
+        item.usePoster = row.usePoster
+        item.imageWidth = row.imageWidth
+        row.appendChild(item)
+    end for
+
+    ' Row already exists, replace it with new content
+    if sectionExists(sectionName)
+        m.top.content.replaceChild(row, getSectionIndex(sectionName))
+        setRowItemSize()
+        return
+    end if
+
+    ' Row does not exist, insert it into the home view
+    m.top.content.insertChild(row, getOriginalSectionIndex("playlistupnext"))
     setRowItemSize()
 end sub
 

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -463,6 +463,40 @@ function loadNextUp() as object
     return results
 end function
 
+function loadPlaylistUpNext() as object
+    results = []
+
+    params = {
+        limit: 24
+    }
+
+    req = APIRequest(Substitute("PlaylistUpNext/{0}/Entries", m.global.session.user.id), params)
+    if not isValid(req) then return results
+
+    try
+        data = getJson(req)
+    catch e
+        return results
+    end try
+
+    if not isChainValid(data, "Items") then return results
+
+    for each entry in data.Items
+        item = entry.LookupCI("Item")
+        if not isValid(item) then continue for
+
+        item.AddReplace("PlaylistUpNextPlaylistId", entry.LookupCI("PlaylistId"))
+        item.AddReplace("PlaylistUpNextPlaylistName", entry.LookupCI("PlaylistName"))
+        item.AddReplace("PlaylistUpNextPlaylistIndex", entry.LookupCI("PlaylistIndex"))
+
+        tmp = CreateObject("roSGNode", "HomeData")
+        tmp.json = item
+        results.push(tmp)
+    end for
+
+    return results
+end function
+
 function loadFavorites() as object
     results = []
 
@@ -797,6 +831,11 @@ sub loadItems()
 
     if isStringEqual(m.top.itemsToLoad, "nextUp")
         m.top.content = loadNextUp()
+        return
+    end if
+
+    if isStringEqual(m.top.itemsToLoad, "playlistUpNext")
+        m.top.content = loadPlaylistUpNext()
         return
     end if
 

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -125,6 +125,10 @@
             <translation>Next Up</translation>
         </message>
         <message>
+            <source>Playlist Continue / Up Next</source>
+            <translation>Playlist Continue / Up Next</translation>
+        </message>
+        <message>
             <source>Recently Added in</source>
             <translation>Recently Added in</translation>
         </message>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -846,6 +846,10 @@
                 "id": "nextup"
               },
               {
+                "title": "Playlist Continue / Up Next",
+                "id": "playlistupnext"
+              },
+              {
                 "title": "None",
                 "id": "none"
               },
@@ -890,6 +894,10 @@
               {
                 "title": "Next Up",
                 "id": "nextup"
+              },
+              {
+                "title": "Playlist Continue / Up Next",
+                "id": "playlistupnext"
               },
               {
                 "title": "None",
@@ -938,6 +946,10 @@
                 "id": "nextup"
               },
               {
+                "title": "Playlist Continue / Up Next",
+                "id": "playlistupnext"
+              },
+              {
                 "title": "None",
                 "id": "none"
               },
@@ -982,6 +994,10 @@
               {
                 "title": "Next Up",
                 "id": "nextup"
+              },
+              {
+                "title": "Playlist Continue / Up Next",
+                "id": "playlistupnext"
               },
               {
                 "title": "None",
@@ -1030,6 +1046,10 @@
                 "id": "nextup"
               },
               {
+                "title": "Playlist Continue / Up Next",
+                "id": "playlistupnext"
+              },
+              {
                 "title": "None",
                 "id": "none"
               },
@@ -1074,6 +1094,10 @@
               {
                 "title": "Next Up",
                 "id": "nextup"
+              },
+              {
+                "title": "Playlist Continue / Up Next",
+                "id": "playlistupnext"
               },
               {
                 "title": "None",
@@ -1122,6 +1146,10 @@
                 "id": "nextup"
               },
               {
+                "title": "Playlist Continue / Up Next",
+                "id": "playlistupnext"
+              },
+              {
                 "title": "None",
                 "id": "none"
               },
@@ -1166,6 +1194,10 @@
               {
                 "title": "Next Up",
                 "id": "nextup"
+              },
+              {
+                "title": "Playlist Continue / Up Next",
+                "id": "playlistupnext"
               },
               {
                 "title": "None",


### PR DESCRIPTION
## Changes

Adds opt-in support for the Playlist Up Next Jellyfin plugin on the Roku home screen.

This adds a new `Playlist Continue / Up Next` home section option that loads playlist-aware entries from the plugin endpoint, unwraps the returned item DTOs, and displays the source playlist name in each home item subtitle, for example `[Star Trek - TNG Era] S1E7 - Q-Less`. If the plugin endpoint is unavailable or returns no items, the row fails closed and is removed from the home screen.

Plugin repository: https://github.com/naqadata/jellyfin-plugin-playlist-up-next

## Issues

None.