### PR TITLE
Fix full audio player controls after stop

### DIFF
--- a/components/music/AudioPlayerView.bs
+++ b/components/music/AudioPlayerView.bs
@@ -6,6 +6,7 @@ import "pkg:/source/enums/KeyCode.bs"
 import "pkg:/source/enums/MediaPlaybackState.bs"
 import "pkg:/source/enums/String.bs"
 import "pkg:/source/enums/TaskControl.bs"
+import "pkg:/source/enums/VideoControl.bs"
 import "pkg:/source/enums/ViewLoadStatus.bs"
 
 import "pkg:/source/utils/config.bs"
@@ -364,7 +365,7 @@ sub clearStopConfirmation()
 end sub
 
 function isStopButtonAction(key as string) as boolean
-    if key <> KeyCode.OK then return false
+    if not isStringEqual(key, KeyCode.OK) then return false
     if not m.buttons.hasFocus() then return false
 
     selectedButton = m.buttons.getChild(m.top.selectedButtonIndex)
@@ -386,8 +387,8 @@ function stopClicked() as boolean
     end if
 
     audioState = m.global.audioPlayer.state
-    if isStringEqual(audioState, MediaPlaybackState.PLAYING) or isStringEqual(audioState, MediaPlaybackState.BUFFERING)
-        m.global.audioPlayer.control = "pause"
+    if inArray([MediaPlaybackState.PLAYING, MediaPlaybackState.BUFFERING], audioState)
+        m.global.audioPlayer.control = VideoControl.PAUSE
     end if
 
     return true

--- a/components/music/AudioPlayerView.bs
+++ b/components/music/AudioPlayerView.bs
@@ -29,6 +29,7 @@ sub init()
     m.lastRecordedPositionTimestamp = 0
     m.scrubTimestamp = -1
     m.hasLyrics = false
+    m.stopConfirmPending = false
 
     m.playlistTypeCount = m.global.queueManager.callFunc("getQueueUniqueTypes").count()
 
@@ -191,6 +192,7 @@ sub setupInfoNodes()
     m.positionTimestamp = m.top.findNode("positionTimestamp")
     m.seekPosition = m.top.findNode("seekPosition")
     m.seekTimestamp = m.top.findNode("seekTimestamp")
+    m.stopConfirmMessage = m.top.findNode("stopConfirmMessage")
     m.totalLengthTimestamp = m.top.findNode("totalLengthTimestamp")
     m.nextItem = m.top.findNode("nextItem")
     m.previousItem = m.top.findNode("previousItem")
@@ -353,13 +355,49 @@ sub updatePlayButtonState()
     end if
 end sub
 
-function stopClicked() as boolean
-    m.global.queueManager.callFunc("clear")
-    m.global.audioPlayer.control = "stop"
-    if m.top.returnOnStop
-        unobserveAll()
-        m.global.sceneManager.callFunc("popScene")
+sub clearStopConfirmation()
+    m.stopConfirmPending = false
+
+    if isValid(m.stopConfirmMessage)
+        m.stopConfirmMessage.visible = false
     end if
+end sub
+
+function isStopButtonAction(key as string) as boolean
+    if key <> KeyCode.OK then return false
+    if not m.buttons.hasFocus() then return false
+
+    selectedButton = m.buttons.getChild(m.top.selectedButtonIndex)
+    if not isValid(selectedButton) then return false
+
+    return isStringEqual(selectedButton.id, "stop")
+end function
+
+function stopClicked() as boolean
+    if m.stopConfirmPending
+        clearStopConfirmation()
+        return closePlayerClicked()
+    end if
+
+    m.stopConfirmPending = true
+    if isValid(m.stopConfirmMessage)
+        m.stopConfirmMessage.text = tr("Press Stop again to close player")
+        m.stopConfirmMessage.visible = true
+    end if
+
+    audioState = m.global.audioPlayer.state
+    if isStringEqual(audioState, MediaPlaybackState.PLAYING) or isStringEqual(audioState, MediaPlaybackState.BUFFERING)
+        m.global.audioPlayer.control = "pause"
+    end if
+
+    return true
+end function
+
+function closePlayerClicked() as boolean
+    m.global.queueManager.callFunc("clear")
+    unobserveAll()
+    m.global.audioPlayer.control = "stop"
+    m.global.sceneManager.callFunc("popScene")
     return true
 end function
 
@@ -502,6 +540,7 @@ sub onAudioDataChanged()
     data = data[0]
     ' Reset buffer bar without animation
     m.bufferPosition.width = 0
+    clearStopConfirmation()
     m.hasLyrics = false
 
     exitScrubMode(m.buttons)
@@ -851,6 +890,10 @@ function onKeyEvent(key as string, press as boolean) as boolean
             return true
         end if
 
+        if m.stopConfirmPending and not isStopButtonAction(key)
+            clearStopConfirmation()
+        end if
+
         ' Key Event handler when m.song is in focus
         if m.song.hasFocus()
             if key = KeyCode.DOWN
@@ -1063,7 +1106,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
         if key = KeyCode.BACK
             if m.playlistTypeCount > 1
-                stopClicked()
+                return closePlayerClicked()
             else
                 displayMiniPlayer()
             end if

--- a/components/music/AudioPlayerView.xml
+++ b/components/music/AudioPlayerView.xml
@@ -29,6 +29,7 @@
         <Poster id="shuffle" width="64" height="64" uri="pkg:/images/icons/shuffle.png" opacity="0" />
       </LayoutGroup>
     </LayoutGroup>
+    <Text id="stopConfirmMessage" visible="false" width="1720" height="30" horizAlign="center" font="font:SmallestSystemFont" translation="[100,985]" color="#ffffff" />
 
     <LayoutGroup translation="[100,100]" layoutDirection="vert" horizAlignment="left" itemSpacings="[15]">
       <ScrollingText id="song" font="font:MediumBoldSystemFont" maxWidth="1800" height="50" />

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -53,6 +53,10 @@
             <translation>Play from beginning</translation>
         </message>
         <message>
+            <source>Press Stop again to close player</source>
+            <translation>Press Stop again to close player</translation>
+        </message>
+        <message>
             <source>Please sign in</source>
             <translation>Please sign in</translation>
         </message>

--- a/source/static/whatsNew/3.2.2.json
+++ b/source/static/whatsNew/3.2.2.json
@@ -2,5 +2,9 @@
   {
     "description": "Separate favorites on the home screen into type specific rows",
     "author": "VX-101"
+  },
+  {
+    "description": "Fix full audio player controls after stop",
+    "author": "VX-101"
   }
 ]


### PR DESCRIPTION
## Summary

Fix full audio player `Stop` so it no longer leaves controls stuck.

## Changes

- Treat the first full-player `Stop` as a pause and show `Press Stop again to close player`.
- Clear the message on any non-Stop key so the normal paused controls keep working.
- Let a second `Stop` close the full player and clear playback.

## Testing

- Ran `npm run build` successfully.
- Sideloaded local build `3.2.1.0969.0133`.
- Verified first full-player `Stop` pauses playback and shows `Press Stop again to close player`.
- Verified a non-Stop key clears the message and `Next` remains usable while paused.
- Verified pressing `Stop` again closes the full player.
