### PR TITLE
Fix non-ASCII title corruption in full audio player.

### DIFF
--- a/components/music/AudioPlayerView.bs
+++ b/components/music/AudioPlayerView.bs
@@ -659,7 +659,7 @@ sub setOnScreenTextValues(json)
         end if
 
         if isValidAndNotEmpty(json.name)
-            setFieldTextValue("song", UCase(json.name))
+            setFieldTextValue("song", json.name.trim())
         end if
     end if
 end sub

--- a/source/static/whatsNew/3.2.2.json
+++ b/source/static/whatsNew/3.2.2.json
@@ -26,5 +26,9 @@
   {
     "description": "Add quickplay support to the TV season grid",
     "author": "michaelcresswell"
+  },
+  {
+    "description": "Avoid non-ASCII title corruption in the full audio player",
+    "author": "VX-101"
   }
 ]


### PR DESCRIPTION
## Summary
Avoid non-ASCII title corruption in the full audio player by removing the forced uppercase conversion.

 Original title in the song list renders correctly.
<img width="280" height="50" alt="image" src="https://github.com/user-attachments/assets/8d8d221a-4553-4dda-b7b1-e5841de2ee6f" />

The full audio player rendered the first uppercase Cyrillic letters incorrectly after uppercase conversion
<img width="391" height="47" alt="image" src="https://github.com/user-attachments/assets/7f44fa3e-2267-45d1-b4e6-1b233f1f8f92" />

## Changes
- Use the original trimmed song title on the full audio player instead of passing it through `UCase(...)`.
- This matches the MiniPlayer behavior, which already shows proper title casing and preserves Unicode characters.

After the change, the full audio player renders the same title with the original casing and character
<img width="392" height="60" alt="image" src="https://github.com/user-attachments/assets/4f0a034c-6586-4bb4-a083-58f89c9c0ebf" />

## Testing
- Ran `npm run build` successfully.
- Sideloaded local build `3.2.1.0970.0117`.
- Verified Cyrillic song titles keep their original casing and characters on the full audio player, album MiniPlayer, and current album song list.
