### PR TITLE
Route Play/Pause button presses to audio mini-player when cursor is on album details

### DIFF
--- a/components/music/AlbumView.bs
+++ b/components/music/AlbumView.bs
@@ -576,6 +576,23 @@ sub openMorePopup()
     m.global.sceneManager.callFunc("optionDialog", "libraryitem", m.top.pageContent.json.LookupCI("name") ?? tr("Options"), [], dialogData, paramData)
 end sub
 
+function isAlbumInfoInFocusChain() as boolean
+    if m.albumCoverBackground.isInFocusChain() then return true
+
+    if isValid(m.released)
+        if m.released.isInFocusChain() then return true
+    end if
+
+    if isValid(m.genres)
+        if m.genres.isInFocusChain() then return true
+    end if
+
+    if m.artistName.hasFocus() then return true
+    if m.overview.hasFocus() then return true
+
+    return false
+end function
+
 function onKeyEvent(key as string, press as boolean) as boolean
     if m.buttonGrp.isInFocusChain()
         if press and isStringEqual(key, KeyCode.PLAY)
@@ -673,6 +690,10 @@ function onKeyEvent(key as string, press as boolean) as boolean
     if m.zoomCoverBackground.visible
         hideZoomCover()
         return true
+    end if
+
+    if isStringEqual(key, KeyCode.PLAY) and isAlbumInfoInFocusChain()
+        if toggleAudioMiniPlayerPlayback() then return true
     end if
 
     if m.albumCoverBackground.isInFocusChain()

--- a/source/static/whatsNew/3.2.2.json
+++ b/source/static/whatsNew/3.2.2.json
@@ -56,7 +56,7 @@
     "author": "VX-101"
   },
   {
-    "description": "Fix mini-player Play/Pause above album actions",
+    "description": "Route Play/Pause button presses to audio mini-player when cursor is on album details",
     "author": "VX-101"
   }
 ]

--- a/source/static/whatsNew/3.2.2.json
+++ b/source/static/whatsNew/3.2.2.json
@@ -54,5 +54,9 @@
   {
     "description": "Prevent the audio mini-player from covering short music album song lists",
     "author": "VX-101"
+  },
+  {
+    "description": "Fix mini-player Play/Pause above album actions",
+    "author": "VX-101"
   }
 ]


### PR DESCRIPTION
## Summary

Follow-up to #905. Fix remote `Play/Pause` not controlling the visible mini-player when focus is above the album action row.

## Changes

- Route remote `Play/Pause` from album information focus to the visible mini-player.
- Preserve existing album action-row and song-list behavior.

## Follow-up

- Fix full audio player `Play/Pause` on song title and artist name focus. ([#1015](https://github.com/jellyfin/jellyfin-roku/pull/1015))
- Fix paused mini-player audio preventing video playback and trapping users in a persistent playback-error loop. ([#1014](https://github.com/jellyfin/jellyfin-roku/pull/1014))
- Route remote `Play/Pause` from the home screen to the visible audio mini-player. ([#1024](https://github.com/jellyfin/jellyfin-roku/pull/1024))

## Testing

- Ran `npm run build` successfully.
- Sideloaded local build `3.2.2.0971.0238`.
- Verified remote `Play/Pause` pauses and resumes the visible mini-player with focus above the album action row.
- Regression-checked album and playlist song-list `Play/Pause`, `OK`, `Back`, and mini-player focus.

