### PR TITLE
Improve music album and artist placeholder images and titles

### DIFF
--- a/components/ItemGrid/LoadItemsTask2.bs
+++ b/components/ItemGrid/LoadItemsTask2.bs
@@ -355,8 +355,6 @@ sub loadItems()
                     tmp.type = "MusicAlbum"
                     if api.items.HeadImageURLByName(item.id, "primary")
                         tmp.posterURL = ImageURL(item.id, "Primary")
-                    else
-                        tmp.posterURL = ImageURL(item.id, "backdrop")
                     end if
                 else if item.Type = "MusicArtist"
                     tmp = CreateObject("roSGNode", "MusicArtistData")

--- a/components/ItemGrid/MusicArtistGridItem.bs
+++ b/components/ItemGrid/MusicArtistGridItem.bs
@@ -3,6 +3,7 @@ import "pkg:/source/utils/misc.bs"
 
 sub init()
     m.itemPoster = m.top.findNode("itemPoster")
+    m.placeholderBackground = m.top.findNode("placeholderBackground")
     m.postTextBackground = m.top.findNode("postTextBackground")
     m.posterText = m.top.findNode("posterText")
     m.posterText.font.size = 30
@@ -19,17 +20,21 @@ sub init()
     end if
 
     m.gridTitles = m.global.session.user.settings["itemgrid.gridTitles"]
+    m.hasPoster = false
+    m.forceTitleVisible = false
     m.posterText.visible = false
     m.postTextBackground.visible = false
 end sub
 
 sub onHeightChanged()
+    m.placeholderBackground.height = m.top.height
     m.backdrop.height = m.top.height
     m.itemPoster.height = m.top.height
     m.postTextBackground.translation = [5, m.top.height - 40]
 end sub
 
 sub onWidthChanged()
+    m.placeholderBackground.width = m.top.width
     m.backdrop.width = m.top.width
     m.itemPoster.width = m.top.width
     m.posterText.maxwidth = m.top.width
@@ -39,9 +44,11 @@ end sub
 sub itemContentChanged()
     m.posterText.visible = false
     m.postTextBackground.visible = false
+    m.placeholderBackground.visible = false
+    m.backdrop.visible = false
 
     if isValid(m.topParent.showItemTitles)
-        if LCase(m.topParent.showItemTitles) = "showalways"
+        if isStringEqual(m.topParent.showItemTitles, "showalways")
             m.posterText.visible = true
             m.postTextBackground.visible = true
         end if
@@ -51,19 +58,32 @@ sub itemContentChanged()
 
     if not isValid(itemData) then return
 
-    if LCase(itemData.type) = "musicalbum"
-        m.backdrop.uri = "pkg:/images/icons/album.png"
-    else if LCase(itemData.type) = "musicartist"
+    fallbackTitle = getFallbackTitle(itemData)
+    posterURL = itemData.PosterUrl
+    m.hasPoster = isValidAndNotEmpty(posterURL)
+    m.forceTitleVisible = not m.hasPoster or not isValidAndNotEmpty(itemData.LookupCI("title"))
+
+    if isStringEqual(itemData.type, "musicalbum")
+        m.backdrop.uri = "pkg:/images/icons/cd.png"
+    else if isStringEqual(itemData.type, "musicartist")
         m.backdrop.uri = "pkg:/images/missingArtist.png"
-    else if LCase(itemData.json.type) = "musicgenre"
+    else if isStringEqual(chainLookup(itemData, "json.type"), "musicgenre")
         m.backdrop.uri = "pkg:/images/icons/musicFolder.png"
     end if
 
-    m.itemPoster.uri = itemData.PosterUrl
-    m.posterText.text = itemData.title
+    m.posterText.text = fallbackTitle
 
-    'If Poster not loaded, ensure "blue box" is shown until loaded
-    if m.itemPoster.loadStatus <> "ready"
+    if m.hasPoster
+        m.itemPoster.uri = posterURL
+    else
+        m.itemPoster.uri = ""
+        showMissingPlaceholder()
+        showPosterText()
+    end if
+
+    ' Avoid flashing the missing-art background while a valid poster URL is still loading.
+    if m.hasPoster and m.itemPoster.loadStatus <> "ready"
+        m.placeholderBackground.visible = false
         m.backdrop.visible = true
     end if
     if m.top.itemHasFocus then focusChanged()
@@ -78,16 +98,48 @@ sub focusChanged()
     end if
 
     if isValid(m.topParent.showItemTitles)
-        if LCase(m.topParent.showItemTitles) = "showonhover"
+        if isStringEqual(m.topParent.showItemTitles, "showonhover")
             m.posterText.visible = m.top.itemHasFocus
             m.postTextBackground.visible = m.posterText.visible
         end if
+    end if
+
+    if m.forceTitleVisible
+        showPosterText()
     end if
 end sub
 
 'Hide backdrop and text when poster loaded
 sub onPosterLoadStatusChanged()
-    if m.itemPoster.loadStatus = "ready"
+    if m.hasPoster and m.itemPoster.loadStatus = "ready"
+        m.placeholderBackground.visible = false
         m.backdrop.visible = false
+    else if m.hasPoster and isStringEqual(m.itemPoster.loadStatus, "failed")
+        showMissingPlaceholder()
+    else if not m.hasPoster
+        showMissingPlaceholder()
     end if
 end sub
+
+sub showMissingPlaceholder()
+    m.placeholderBackground.visible = true
+    m.backdrop.visible = true
+end sub
+
+sub showPosterText()
+    m.posterText.visible = true
+    m.postTextBackground.visible = true
+end sub
+
+function getFallbackTitle(itemData as object) as string
+    title = itemData.LookupCI("title")
+    if isValidAndNotEmpty(title) then return title
+
+    if isStringEqual(itemData.LookupCI("type"), "musicartist")
+        return tr("Unknown Artist")
+    else if isStringEqual(itemData.LookupCI("type"), "musicalbum")
+        return tr("Unknown Album")
+    end if
+
+    return tr("Unknown")
+end function

--- a/components/ItemGrid/MusicArtistGridItem.bs
+++ b/components/ItemGrid/MusicArtistGridItem.bs
@@ -1,10 +1,13 @@
+import "pkg:/source/enums/ColorPalette.bs"
 import "pkg:/source/enums/ItemType.bs"
+import "pkg:/source/enums/PosterLoadStatus.bs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
     m.itemPoster = m.top.findNode("itemPoster")
     m.placeholderBackground = m.top.findNode("placeholderBackground")
+    m.placeholderBackground.color = ColorPalette.ELEMENTBACKGROUND
     m.postTextBackground = m.top.findNode("postTextBackground")
     m.posterText = m.top.findNode("posterText")
     m.posterText.font.size = 30
@@ -82,7 +85,7 @@ sub itemContentChanged()
     end if
 
     ' Avoid flashing the missing-art background while a valid poster URL is still loading.
-    if m.hasPoster and m.itemPoster.loadStatus <> "ready"
+    if m.hasPoster and not isStringEqual(m.itemPoster.loadStatus, PosterLoadStatus.READY)
         m.placeholderBackground.visible = false
         m.backdrop.visible = true
     end if
@@ -111,10 +114,10 @@ end sub
 
 'Hide backdrop and text when poster loaded
 sub onPosterLoadStatusChanged()
-    if m.hasPoster and m.itemPoster.loadStatus = "ready"
+    if m.hasPoster and isStringEqual(m.itemPoster.loadStatus, PosterLoadStatus.READY)
         m.placeholderBackground.visible = false
         m.backdrop.visible = false
-    else if m.hasPoster and isStringEqual(m.itemPoster.loadStatus, "failed")
+    else if m.hasPoster and isStringEqual(m.itemPoster.loadStatus, PosterLoadStatus.FAILED)
         m.forceTitleVisible = true
         showMissingPlaceholder()
     else if not m.hasPoster

--- a/components/ItemGrid/MusicArtistGridItem.bs
+++ b/components/ItemGrid/MusicArtistGridItem.bs
@@ -1,3 +1,4 @@
+import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/misc.bs"
 
@@ -63,9 +64,9 @@ sub itemContentChanged()
     m.hasPoster = isValidAndNotEmpty(posterURL)
     m.forceTitleVisible = not m.hasPoster or not isValidAndNotEmpty(itemData.LookupCI("title"))
 
-    if isStringEqual(itemData.type, "musicalbum")
+    if isStringEqual(itemData.type, ItemType.MUSICALBUM)
         m.backdrop.uri = "pkg:/images/icons/album.png"
-    else if isStringEqual(itemData.type, "musicartist")
+    else if isStringEqual(itemData.type, ItemType.MUSICARTIST)
         m.backdrop.uri = "pkg:/images/missingArtist.png"
     else if isStringEqual(chainLookup(itemData, "json.type"), "musicgenre")
         m.backdrop.uri = "pkg:/images/icons/musicFolder.png"
@@ -142,9 +143,9 @@ function getFallbackTitle(itemData as object) as string
     title = chainLookup(itemData, "json.name")
     if isValidAndNotEmpty(title) then return title
 
-    if isStringEqual(itemData.LookupCI("type"), "musicartist")
+    if isStringEqual(itemData.LookupCI("type"), ItemType.MUSICARTIST)
         return tr("Unknown Artist")
-    else if isStringEqual(itemData.LookupCI("type"), "musicalbum")
+    else if isStringEqual(itemData.LookupCI("type"), ItemType.MUSICALBUM)
         return tr("Unknown Album")
     end if
 

--- a/components/ItemGrid/MusicArtistGridItem.bs
+++ b/components/ItemGrid/MusicArtistGridItem.bs
@@ -64,7 +64,7 @@ sub itemContentChanged()
     m.forceTitleVisible = not m.hasPoster or not isValidAndNotEmpty(itemData.LookupCI("title"))
 
     if isStringEqual(itemData.type, "musicalbum")
-        m.backdrop.uri = "pkg:/images/icons/cd.png"
+        m.backdrop.uri = "pkg:/images/icons/album.png"
     else if isStringEqual(itemData.type, "musicartist")
         m.backdrop.uri = "pkg:/images/missingArtist.png"
     else if isStringEqual(chainLookup(itemData, "json.type"), "musicgenre")
@@ -78,7 +78,6 @@ sub itemContentChanged()
     else
         m.itemPoster.uri = ""
         showMissingPlaceholder()
-        showPosterText()
     end if
 
     ' Avoid flashing the missing-art background while a valid poster URL is still loading.
@@ -115,6 +114,7 @@ sub onPosterLoadStatusChanged()
         m.placeholderBackground.visible = false
         m.backdrop.visible = false
     else if m.hasPoster and isStringEqual(m.itemPoster.loadStatus, "failed")
+        m.forceTitleVisible = true
         showMissingPlaceholder()
     else if not m.hasPoster
         showMissingPlaceholder()
@@ -124,6 +124,7 @@ end sub
 sub showMissingPlaceholder()
     m.placeholderBackground.visible = true
     m.backdrop.visible = true
+    showPosterText()
 end sub
 
 sub showPosterText()
@@ -133,6 +134,12 @@ end sub
 
 function getFallbackTitle(itemData as object) as string
     title = itemData.LookupCI("title")
+    if isValidAndNotEmpty(title) then return title
+
+    title = itemData.LookupCI("name")
+    if isValidAndNotEmpty(title) then return title
+
+    title = chainLookup(itemData, "json.name")
     if isValidAndNotEmpty(title) then return title
 
     if isStringEqual(itemData.LookupCI("type"), "musicartist")

--- a/components/ItemGrid/MusicArtistGridItem.xml
+++ b/components/ItemGrid/MusicArtistGridItem.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="MusicArtistGridItem" extends="Group">
   <children>
-    <Poster id="backdrop" blendColor="#FFFFFF" opacity=".25" translation="[0,15]" width="270" height="270" loadDisplayMode="scaleToZoom" uri="pkg:/images/white.9.png" />
+    <Rectangle id="placeholderBackground" color="0x14505FFF" opacity=".85" translation="[0,15]" width="270" height="270" visible="false" />
+    <Poster id="backdrop" blendColor="#FFFFFF" opacity=".85" translation="[0,15]" width="270" height="270" loadDisplayMode="scaleToZoom" uri="pkg:/images/white.9.png" />
     <Poster id="itemPoster" translation="[0,15]" width="270" height="270" loadDisplayMode="scaleToZoom" />
     <Rectangle id="postTextBackground" height="50" width="260" color="0x000000DD" translation="[5, 230]">
       <ScrollingText id="posterText" color="#FFFFFF" maxWidth="260" height="50" horizAlign="center" vertAlign="center" />

--- a/components/ItemGrid/MusicArtistGridItem.xml
+++ b/components/ItemGrid/MusicArtistGridItem.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="MusicArtistGridItem" extends="Group">
   <children>
-    <Rectangle id="placeholderBackground" color="0x14505FFF" opacity=".85" translation="[0,15]" width="270" height="270" visible="false" />
+    <Rectangle id="placeholderBackground" opacity=".85" translation="[0,15]" width="270" height="270" visible="false" />
     <Poster id="backdrop" blendColor="#FFFFFF" opacity=".85" translation="[0,15]" width="270" height="270" loadDisplayMode="scaleToZoom" uri="pkg:/images/white.9.png" />
     <Poster id="itemPoster" translation="[0,15]" width="270" height="270" loadDisplayMode="scaleToZoom" />
     <Rectangle id="postTextBackground" height="50" width="260" color="0x000000DD" translation="[5, 230]">

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -524,6 +524,14 @@
             <extracomment>Title for a cast member for which we have no information for</extracomment>
         </message>
         <message>
+            <source>Unknown Artist</source>
+            <translation>Unknown Artist</translation>
+        </message>
+        <message>
+            <source>Unknown Album</source>
+            <translation>Unknown Album</translation>
+        </message>
+        <message>
             <source>The requested content does not exist on the server</source>
             <translation>The requested content does not exist on the server</translation>
             <extracomment>Content of message box when the requested content is not found on the server</extracomment>

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -317,18 +317,12 @@ function MusicAlbumList(id as string)
 
         tmp.image = PosterImage(item.id)
         tmp.id = item.LookupCI("id")
-        tmp.title = item.LookupCI("name")
+        tmp.title = getMusicAlbumGridTitle(item)
         tmp.type = item.LookupCI("type")
         tmp.RunTimeTicks = item.LookupCI("RunTimeTicks")
 
-        tmp.shortdescriptionline1 = item.LookupCI("name")
-
-        if isChainValid(tmp, "image.url")
-            tmp.HDGRIDPOSTERURL = tmp.image.url
-            tmp.hdposterurl = tmp.image.url
-            tmp.SDGRIDPOSTERURL = tmp.image.url
-            tmp.sdposterurl = tmp.image.url
-        end if
+        tmp.shortdescriptionline1 = tmp.title
+        setMusicAlbumGridPoster(tmp)
 
         results.push(tmp)
     end for
@@ -362,18 +356,12 @@ function AppearsOnList(id as string)
 
         tmp.image = PosterImage(item.id)
         tmp.id = item.LookupCI("id")
-        tmp.title = item.LookupCI("name")
+        tmp.title = getMusicAlbumGridTitle(item)
         tmp.type = item.LookupCI("type")
         tmp.RunTimeTicks = item.LookupCI("RunTimeTicks")
 
-        tmp.shortdescriptionline1 = item.LookupCI("name")
-
-        if isChainValid(tmp, "image.url")
-            tmp.HDGRIDPOSTERURL = tmp.image.url
-            tmp.hdposterurl = tmp.image.url
-            tmp.SDGRIDPOSTERURL = tmp.image.url
-            tmp.sdposterurl = tmp.image.url
-        end if
+        tmp.shortdescriptionline1 = tmp.title
+        setMusicAlbumGridPoster(tmp)
 
         results.push(tmp)
     end for
@@ -382,6 +370,26 @@ function AppearsOnList(id as string)
 
     return row
 end function
+
+function getMusicAlbumGridTitle(item as object) as string
+    title = item.LookupCI("name")
+    if isValidAndNotEmpty(title) then return title
+
+    return tr("Unknown Album")
+end function
+
+sub setMusicAlbumGridPoster(album as object)
+    posterURL = "pkg:/images/icons/cd.png"
+
+    if isChainValid(album, "image.url")
+        posterURL = album.image.url
+    end if
+
+    album.HDGRIDPOSTERURL = posterURL
+    album.hdposterurl = posterURL
+    album.SDGRIDPOSTERURL = posterURL
+    album.sdposterurl = posterURL
+end sub
 
 ' Get list of songs belonging to an artist
 function GetSongsByArtist(id as string, params = {} as object)

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -379,11 +379,7 @@ function getMusicAlbumGridTitle(item as object) as string
 end function
 
 sub setMusicAlbumGridPoster(album as object)
-    posterURL = "pkg:/images/icons/album.png"
-
-    if isChainValid(album, "image.url")
-        posterURL = album.image.url
-    end if
+    posterURL = chainLookupReturn(album, "image.url", "pkg:/images/icons/album.png")
 
     album.HDGRIDPOSTERURL = posterURL
     album.hdposterurl = posterURL

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -379,7 +379,7 @@ function getMusicAlbumGridTitle(item as object) as string
 end function
 
 sub setMusicAlbumGridPoster(album as object)
-    posterURL = "pkg:/images/icons/cd.png"
+    posterURL = "pkg:/images/icons/album.png"
 
     if isChainValid(album, "image.url")
         posterURL = album.image.url

--- a/source/static/whatsNew/3.2.2.json
+++ b/source/static/whatsNew/3.2.2.json
@@ -2,5 +2,9 @@
   {
     "description": "Separate favorites on the home screen into type specific rows",
     "author": "VX-101"
+  },
+  {
+    "description": "Show placeholders for music albums and artists with missing artwork or names",
+    "author": "VX-101"
   }
 ]


### PR DESCRIPTION
## Summary
Fix music album and artist tiles that can render as black-on-black squares when artwork or names are missing.

Before the change
<img width="859" height="674" alt="image" src="https://github.com/user-attachments/assets/bddfa592-32ab-4cd9-be71-3e3a26ff6e50" />

After the change
<img width="610" height="548" alt="image" src="https://github.com/user-attachments/assets/00dafab4-562f-4a6c-bf88-bd9c9707e6ce" />

<img width="1270" height="416" alt="image" src="https://github.com/user-attachments/assets/b2065925-f026-4e79-a95f-1b303d344397" />

- Show visible placeholders for missing music album, artist, and genre artwork.
- Keep album, artist, and genre names visible when artwork is missing or fails to load.
- Fall back to unknown album/artist text only when no usable name is available.
- Show the placeholder when an album has no primary artwork.
- Use the album placeholder icon in artist detail album rows.

## Follow-up

- Additional music library UI improvements, including clearer album list labels and richer artist/composer details.

## Testing

- Ran `npm run build` successfully.
- Sideloaded local build `3.2.2.0973.0231`.
- Manually verified missing-artwork album tiles in music album grids and artist detail album lists show visible placeholders and album names.
- Manually verified music genre placeholders show genre names.
- Manually verified normal album artwork still appears where available.
