### PR TITLE
Improved "Options" popup in Movie menu

### DIFF
--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -40,6 +40,8 @@ sub init()
     m.movieExtras.observeField("hasItems", "onMovieExtrasHasItems")
 
     m.options = m.top.findNode("movieOptions")
+    m.options.observeField("videoStreamId", "onOptionsVideoStreamChanged")
+    m.options.observeField("audioStreamIndex", "onOptionsAudioStreamChanged")
     m.infoGroup = m.top.findNode("infoGroup")
 
     m.buttonGrp = m.top.findNode("buttons")
@@ -859,21 +861,48 @@ end function
 '
 'Check if options updated and any reloading required
 sub audioOptionsClosed()
-    if m.options.audioStreamIndex <> m.top.selectedAudioStreamIndex
-        m.top.selectedAudioStreamIndex = m.options.audioStreamIndex
-        m.global.queueManager.callFunc("setPreferredAudioTrackIndex", m.options.audioStreamIndex)
-        m.global.queueManager.callFunc("setPreferredAudioTrackName", m.options.audioStreamName)
-        setFieldText("audio_codec", tr("Audio") + ": " + m.top.itemContent.json.mediaStreams[m.top.selectedAudioStreamIndex].displayTitle)
-    end if
+    applyAudioSelection()
 
     m.buttonGrp.setFocus(true)
     group = m.global.sceneManager.callFunc("getActiveScene")
     group.lastFocus = m.buttonGrp
 end sub
 
-'
-' Check if options were updated and if any reloding is needed...
+sub onOptionsAudioStreamChanged()
+    applyAudioSelection()
+end sub
+
+sub applyAudioSelection()
+    if m.options.audioStreamIndex <> m.top.selectedAudioStreamIndex
+        m.top.selectedAudioStreamIndex = m.options.audioStreamIndex
+        m.global.queueManager.callFunc("setPreferredAudioTrackIndex", m.options.audioStreamIndex)
+        m.global.queueManager.callFunc("setPreferredAudioTrackName", m.options.audioStreamName)
+        setFieldText("audio_codec", tr("Audio") + ": " + m.top.itemContent.json.mediaStreams[m.top.selectedAudioStreamIndex].displayTitle)
+    end if
+end sub
+
 sub videoOptionsClosed()
+    applyVideoSelection()
+
+    m.buttonGrp.setFocus(true)
+
+    ' If user manually disables force transcode, disable rotation check
+    m.performRotationCheck = not isStringEqual(m.global.queueManager.callFunc("getForceTranscode"), PlaybackMethod.PLAYNORMALLY)
+    if not m.performRotationCheck
+        setFieldText("rotationWarning", string.EMPTY)
+    end if
+
+    group = m.global.sceneManager.callFunc("getActiveScene")
+    group.lastFocus = m.buttonGrp
+end sub
+
+' Live callback when the video version is changed from the options dialog
+sub onOptionsVideoStreamChanged()
+    applyVideoSelection()
+end sub
+
+' Reload the audio/subtitle/video option lists when a new video source is selected
+sub applyVideoSelection()
     if m.options.videoStreamId <> m.top.selectedVideoStreamId
         m.top.selectedVideoStreamId = m.options.videoStreamId
         setFieldText("video_codec", tr("Video") + ": " + m.options.video_codec)
@@ -887,6 +916,7 @@ sub videoOptionsClosed()
                     itemData.mediaStreams.push(mediaSource.mediaStreams[i])
                 end for
                 SetDefaultAudioTrack(itemData)
+                SetUpVideoOptions(itemData.mediaSources)
                 SetUpAudioOptions(itemData)
                 exit for
             end if
@@ -894,16 +924,6 @@ sub videoOptionsClosed()
         m.top.itemContent.json = itemData
         m.top.observeField("itemContent", "itemContentChanged")
     end if
-    m.buttonGrp.setFocus(true)
-
-    ' If user manually disables force transcode, disable rotation check
-    m.performRotationCheck = not isStringEqual(m.global.queueManager.callFunc("getForceTranscode"), PlaybackMethod.PLAYNORMALLY)
-    if not m.performRotationCheck
-        setFieldText("rotationWarning", string.EMPTY)
-    end if
-
-    group = m.global.sceneManager.callFunc("getActiveScene")
-    group.lastFocus = m.buttonGrp
 end sub
 
 sub onButtonGroupEscape()
@@ -966,9 +986,6 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 m.top.buttonSelected = button.id
                 if button.id = "options-button"
                     m.options.visible = true
-                    m.options.setFocus(true)
-                    group = m.global.sceneManager.callFunc("getActiveScene")
-                    group.lastFocus = m.options
                 end if
                 exit for
             end if

--- a/components/movies/MovieOptions.bs
+++ b/components/movies/MovieOptions.bs
@@ -1,4 +1,3 @@
-import "pkg:/source/enums/AnimationControl.bs"
 import "pkg:/source/enums/ColorPalette.bs"
 import "pkg:/source/enums/KeyCode.bs"
 import "pkg:/source/enums/PlaybackMethod.bs"
@@ -6,48 +5,78 @@ import "pkg:/source/enums/String.bs"
 import "pkg:/source/enums/SubtitleSelection.bs"
 import "pkg:/source/utils/misc.bs"
 
+' Category indexes shared by the row list and the m.menus array
+const CATEGORY_SUBTITLE = 0
+const CATEGORY_AUDIO = 1
+const CATEGORY_VIDEO = 2
+const CATEGORY_PLAYBACK = 3
+
 sub init()
+    m.optionsMenu = m.top.findNode("optionsMenu")
+    m.detailPopup = m.top.findNode("detailPopup")
+    m.detailTitle = m.top.findNode("detailTitle")
+    m.top.findNode("optionsHeader").text = tr("Options")
 
-    m.buttons = m.top.findNode("buttons")
-    m.buttons.buttons = [tr("Subtitles"), tr("Audio"), tr("Video"), tr("Options")]
-    m.buttons.selectedIndex = 0
-    m.buttons.setFocus(true)
-
-
-    m.selectedItem = 0
     m.selectedAudioIndex = 0
     m.selectedVideoIndex = 0
     m.selectedSubtitleIndex = SubtitleSelection.NONE
+    m.activeCategory = -1
+    m.playbackLocked = false
+
+    ' Concise labels shown on the Playback Mode row (the sub-popup may relabel disabled entries)
+    m.playbackTitles = [tr("Play Normally"), tr("Force Transcode (Allow Remux)"), tr("Force Transcode (Remux Disabled)")]
 
     m.optionMenu = m.top.findNode("optionMenu")
-    m.optionMenu.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
-    m.optionMenu.focusedColor = ColorPalette.WHITE
-
     m.menus = [m.top.findNode("subtitleMenu"), m.top.findNode("audioMenu"), m.top.findNode("videoMenu"), m.optionMenu]
+
+    cursorColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+    m.optionsMenu.focusBitmapBlendColor = cursorColor
+    for each menu in m.menus
+        menu.focusBitmapBlendColor = cursorColor
+        menu.focusedColor = ColorPalette.WHITE
+        ' Auto-close the sub-popup as soon as the user confirms a choice
+        menu.observeField("itemSelected", "onDetailItemSelected")
+    end for
 
     m.videoNames = []
     m.audioNames = []
 
-    m.top.findNode("videoMenu").focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
-    m.top.findNode("videoMenu").focusedColor = ColorPalette.WHITE
+    ' Build the single-page rows once, their values are filled in by optionsSet()
+    m.rowContent = CreateObject("roSGNode", "ContentNode")
+    m.rowSubtitle = m.rowContent.createChild("ContentNode")
+    m.rowSubtitle.title = tr("Subtitles")
+    m.rowAudio = m.rowContent.createChild("ContentNode")
+    m.rowAudio.title = tr("Audio")
+    m.rowVideo = m.rowContent.createChild("ContentNode")
+    m.rowVideo.title = tr("Video")
+    m.rowPlayback = m.rowContent.createChild("ContentNode")
+    m.rowPlayback.title = tr("Playback Mode")
+    ' optionCount drives whether the left/right chevrons are shown for a row
+    for each row in [m.rowSubtitle, m.rowAudio, m.rowVideo, m.rowPlayback]
+        row.addField("optionCount", "integer", false)
+        row.optionCount = 0
+    end for
+    m.optionsMenu.content = m.rowContent
 
-    m.top.findNode("audioMenu").focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
-    m.top.findNode("audioMenu").focusedColor = ColorPalette.WHITE
+    m.top.observeField("visible", "onVisibleChange")
+end sub
 
-    m.top.findNode("subtitleMenu").focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
-    m.top.findNode("subtitleMenu").focusedColor = ColorPalette.WHITE
-
-    ' Animation
-    m.fadeAnim = m.top.findNode("fadeAnim")
-    m.fadeOutAnimOpacity = m.top.findNode("outOpacity")
-    m.fadeInAnimOpacity = m.top.findNode("inOpacity")
-
-    m.buttons.observeField("focusedIndex", "buttonFocusChanged")
-    m.buttons.focusedIndex = m.selectedItem
+' Move focus onto the rows whenever the dialog becomes visible
+sub onVisibleChange()
+    if m.top.visible
+        m.detailPopup.visible = false
+        m.activeCategory = -1
+        m.optionsMenu.setFocus(true)
+        group = m.global.sceneManager.callFunc("getActiveScene")
+        group.lastFocus = m.optionsMenu
+    end if
 end sub
 
 sub optionsSet()
     forceTranscodeSetting = chainLookupReturn(m.global.session, "user.settings.`playback.media.forceTranscode`", PlaybackMethod.PLAYNORMALLY)
+
+    ' When force transcoding is dictated by a global setting, Playback Mode row is read-only
+    m.playbackLocked = not isStringEqual(PlaybackMethod.PLAYNORMALLY, forceTranscodeSetting)
 
     if not isStringEqual(PlaybackMethod.PLAYNORMALLY, forceTranscodeSetting)
         normalOption = m.optionMenu.content.getChild(0)
@@ -73,11 +102,15 @@ sub optionsSet()
         m.optionMenu.checkedItem = 0
     end if
 
-    '  subtitle Tab
+    m.rowPlayback.description = m.playbackTitles[m.optionMenu.checkedItem]
+    m.rowPlayback.optionCount = m.playbackLocked ? 1 : m.playbackTitles.count()
+
+    '  Subtitle list
     if isValid(m.top.Options.subtitles)
         subtitleContent = CreateObject("roSGNode", "ContentNode")
         index = 0
         selectedSubtitleIndex = 0
+        selectedSubtitleTitle = tr("None")
 
         for each subtitle in m.top.options.subtitles
             entry = subtitleContent.CreateChild("SubtitleTrackListData")
@@ -88,49 +121,59 @@ sub optionsSet()
             if isValid(subtitle.Selected) and subtitle.Selected
                 selectedSubtitleIndex = index
                 entry.selected = true
+                selectedSubtitleTitle = subtitle.Title
             end if
             index = index + 1
         end for
 
-        m.menus[0].content = subtitleContent
-        m.menus[0].jumpToItem = selectedSubtitleIndex
-        m.menus[0].checkedItem = selectedSubtitleIndex
+        m.menus[CATEGORY_SUBTITLE].content = subtitleContent
+        m.menus[CATEGORY_SUBTITLE].jumpToItem = selectedSubtitleIndex
+        m.menus[CATEGORY_SUBTITLE].checkedItem = selectedSubtitleIndex
         m.selectedSubtitleIndex = selectedSubtitleIndex
+        m.rowSubtitle.description = selectedSubtitleTitle
+        m.rowSubtitle.optionCount = subtitleContent.getChildCount()
     end if
 
-    '  audio Tab
+    '  Audio list
     if isValid(m.top.Options.audios)
         audioContent = CreateObject("roSGNode", "ContentNode")
         index = 0
         selectedAudioIndex = 0
+        selectedAudioTitle = string.EMPTY
 
         for each audio in m.top.options.audios
             entry = audioContent.CreateChild("AudioTrackListData")
-            entry.title = audio.Title
-            entry.description = audio.Description
+            ' Some sources expose unnamed audio tracks, show "Default" so the row/list isn't blank
+            audioTitle = isValidAndNotEmpty(audio.Title) ? audio.Title : tr("Default")
+            entry.title = audioTitle
+            entry.description = isValidAndNotEmpty(audio.Description) ? audio.Description : audioTitle
             entry.streamIndex = audio.StreamIndex
             entry.streamName = audio.RokuTrackName
             m.audioNames.push(audio.Name)
             if audio.Selected <> invalid and audio.Selected
                 selectedAudioIndex = index
                 entry.selected = true
+                selectedAudioTitle = audioTitle
                 m.top.audioStreamName = audio.LookupCI("RokuTrackName")
                 m.top.audioStreamIndex = audio.LookupCI("streamIndex")
             end if
             index = index + 1
         end for
 
-        m.menus[1].content = audioContent
-        m.menus[1].jumpToItem = selectedAudioIndex
-        m.menus[1].checkedItem = selectedAudioIndex
+        m.menus[CATEGORY_AUDIO].content = audioContent
+        m.menus[CATEGORY_AUDIO].jumpToItem = selectedAudioIndex
+        m.menus[CATEGORY_AUDIO].checkedItem = selectedAudioIndex
         m.selectedAudioIndex = selectedAudioIndex
+        m.rowAudio.description = isValidAndNotEmpty(selectedAudioTitle) ? selectedAudioTitle : tr("Default")
+        m.rowAudio.optionCount = audioContent.getChildCount()
     end if
 
-    '  Videos Tab
+    '  Video list
     if isValid(m.top.options.videos)
         viewContent = CreateObject("roSGNode", "ContentNode")
         index = 0
         selectedViewIndex = 0
+        selectedViewTitle = string.EMPTY
 
         for each view in m.top.options.videos
             entry = viewContent.CreateChild("VideoTrackListData")
@@ -143,124 +186,166 @@ sub optionsSet()
             if isValid(view.Selected) and view.Selected
                 selectedViewIndex = index
                 entry.selected = true
+                selectedViewTitle = view.Title
                 m.top.videoStreamId = view.streamId
             end if
             index = index + 1
         end for
 
-        m.menus[2].content = viewContent
-        m.menus[2].jumpToItem = selectedViewIndex
-        m.menus[2].checkedItem = selectedViewIndex
+        m.menus[CATEGORY_VIDEO].content = viewContent
+        m.menus[CATEGORY_VIDEO].jumpToItem = selectedViewIndex
+        m.menus[CATEGORY_VIDEO].checkedItem = selectedViewIndex
         m.selectedVideoIndex = selectedViewIndex
+        m.rowVideo.description = selectedViewTitle
+        m.rowVideo.optionCount = viewContent.getChildCount()
     end if
 end sub
 
-' Switch menu shown when button focus changes
-sub buttonFocusChanged()
-    if m.buttons.focusedIndex = m.selectedItem then return
-    m.fadeOutAnimOpacity.fieldToInterp = m.menus[m.selectedItem].id + ".opacity"
-    m.fadeInAnimOpacity.fieldToInterp = m.menus[m.buttons.focusedIndex].id + ".opacity"
-    m.fadeAnim.control = AnimationControl.START
-    m.selectedItem = m.buttons.focusedIndex
+' Index of the currently selected entry for a given category
+function currentIndexFor(category as integer) as integer
+    if category = CATEGORY_SUBTITLE then return m.selectedSubtitleIndex
+    if category = CATEGORY_AUDIO then return m.selectedAudioIndex
+    if category = CATEGORY_VIDEO then return m.selectedVideoIndex
+    return m.optionMenu.checkedItem
+end function
+
+' Open the full-list sub-popup for the focused row
+sub openDetail(category as integer)
+    m.activeCategory = category
+
+    for i = 0 to m.menus.count() - 1
+        m.menus[i].opacity = (i = category) ? 1 : 0
+    end for
+
+    m.detailTitle.text = m.rowContent.getChild(category).title
+    m.detailPopup.visible = true
+
+    selMenu = m.menus[category]
+    selMenu.itemSelected = -1
+    m.optionsMenu.setFocus(false)
+    selMenu.setFocus(true)
+    selMenu.drawFocusFeedback = true
+    selMenu.jumpToItem = currentIndexFor(category)
+
+    group = m.global.sceneManager.callFunc("getActiveScene")
+    group.lastFocus = selMenu
 end sub
 
+' Close the sub-popup and return focus to the rows
+sub closeDetail()
+    if m.activeCategory >= 0
+        m.menus[m.activeCategory].drawFocusFeedback = false
+    end if
+    m.detailPopup.visible = false
+    m.activeCategory = -1
+    m.optionsMenu.setFocus(true)
+    group = m.global.sceneManager.callFunc("getActiveScene")
+    group.lastFocus = m.optionsMenu
+end sub
+
+' Scroll the focused row's value left/right
+sub cycleRow(category as integer, delta as integer)
+    if category = CATEGORY_PLAYBACK and m.playbackLocked then return
+
+    selMenu = m.menus[category]
+    if category = CATEGORY_PLAYBACK
+        count = 3
+    else if isValid(selMenu.content)
+        count = selMenu.content.getChildCount()
+    else
+        count = 0
+    end if
+    if count <= 1 then return
+
+    newIndex = currentIndexFor(category) + delta
+    if newIndex < 0 then newIndex = count - 1
+    if newIndex >= count then newIndex = 0
+
+    applyCategorySelection(category, newIndex)
+end sub
+
+sub applyCategorySelection(category as integer, selIndex as integer)
+    selMenu = m.menus[category]
+
+    if category = CATEGORY_SUBTITLE
+        if m.selectedSubtitleIndex <> selIndex
+            selMenu.content.getChild(m.selectedSubtitleIndex).selected = false
+            newSelection = selMenu.content.getChild(selIndex)
+            newSelection.selected = true
+            m.selectedSubtitleIndex = selIndex
+            m.top.subtitleStream = newSelection
+            m.global.queueManager.callFunc("setPreferredSubtitleTrack", newSelection)
+            m.rowSubtitle.description = newSelection.title
+            selMenu.checkedItem = selIndex
+        end if
+    else if category = CATEGORY_AUDIO
+        if m.selectedAudioIndex <> selIndex
+            selMenu.content.getChild(m.selectedAudioIndex).selected = false
+            newSelection = selMenu.content.getChild(selIndex)
+            newSelection.selected = true
+            m.selectedAudioIndex = selIndex
+            m.top.audioStreamName = newSelection.LookupCI("streamName")
+            m.top.audioStreamIndex = newSelection.LookupCI("streamIndex")
+            m.rowAudio.description = newSelection.title
+            selMenu.checkedItem = selIndex
+        end if
+    else if category = CATEGORY_VIDEO
+        if m.selectedVideoIndex <> selIndex
+            selMenu.content.getChild(m.selectedVideoIndex).selected = false
+            newSelection = selMenu.content.getChild(selIndex)
+            newSelection.selected = true
+            m.selectedVideoIndex = selIndex
+            m.rowVideo.description = newSelection.title
+            selMenu.checkedItem = selIndex
+            ' Setting videoStreamId triggers MovieDetails to rebuild the audio/subtitle lists
+            m.top.video_codec = newSelection.video_codec
+            m.top.codec = newSelection.codec
+            m.top.videoStreamId = newSelection.streamId
+        end if
+    else if category = CATEGORY_PLAYBACK
+        if m.playbackLocked then return
+        m.optionMenu.checkedItem = selIndex
+        if selIndex = 0
+            m.global.queueManager.callFunc("setForceTranscode", PlaybackMethod.PLAYNORMALLY)
+        else if selIndex = 1
+            m.global.queueManager.callFunc("setForceTranscode", PlaybackMethod.FORCETRANSCODEALLOWREMUX, string.EMPTY)
+        else if selIndex = 2
+            m.global.queueManager.callFunc("setForceTranscode", PlaybackMethod.FORCETRANSCODEDISABLEREMUX, m.top.codec)
+        end if
+        m.rowPlayback.description = m.playbackTitles[selIndex]
+    end if
+end sub
+
+' Confirming a choice in the sub-popup applies it and returns to the rows
+sub onDetailItemSelected()
+    if not m.detailPopup.visible or m.activeCategory < 0 then return
+    selMenu = m.menus[m.activeCategory]
+    if selMenu.itemSelected < 0 then return
+    applyCategorySelection(m.activeCategory, selMenu.itemSelected)
+    closeDetail()
+end sub
 
 function onKeyEvent(key as string, press as boolean) as boolean
-    ' Prevent the OK release that opens this menu from moving focus off the top row
-    if not press and key = KeyCode.OK and m.top.findNode("buttons").hasFocus()
-        return true
-    end if
+    if not press then return false
 
-    if key = KeyCode.DOWN or (key = KeyCode.OK and m.top.findNode("buttons").hasFocus())
-        m.top.findNode("buttons").setFocus(false)
-        m.menus[m.selectedItem].setFocus(true)
-        group = m.global.sceneManager.callFunc("getActiveScene")
-        group.lastFocus = m.menus[m.selectedItem]
-        m.menus[m.selectedItem].drawFocusFeedback = true
-
-        'If user presses down from button menu, focus first item.  If OK, focus checked item
-        if key = KeyCode.DOWN
-            m.menus[m.selectedItem].jumpToItem = 0
-        else
-            m.menus[m.selectedItem].jumpToItem = m.menus[m.selectedItem].itemSelected
-        end if
-
-        return true
-    end if
-
-    if key = KeyCode.OK
-        if m.menus[m.selectedItem].isInFocusChain()
-            selMenu = m.menus[m.selectedItem]
-            selIndex = selMenu.itemSelected
-
-            'Handle Videos menu
-            if m.selectedItem = 2
-                if m.selectedVideoIndex = selIndex
-                else
-                    selMenu.content.GetChild(m.selectedVideoIndex).selected = false
-                    newSelection = selMenu.content.GetChild(selIndex)
-                    newSelection.selected = true
-                    m.selectedVideoIndex = selIndex
-                    m.top.videoStreamId = newSelection.streamId
-                    m.top.video_codec = newSelection.video_codec
-                    m.top.codec = newSelection.codec
-                end if
-                ' Then it is Audio options
-            else if m.selectedItem = 1
-                if m.selectedAudioIndex = selIndex
-                else
-                    selMenu.content.GetChild(m.selectedAudioIndex).selected = false
-                    newSelection = selMenu.content.GetChild(selIndex)
-                    newSelection.selected = true
-                    m.selectedAudioIndex = selIndex
-                    m.top.audioStreamName = newSelection.LookupCI("streamName")
-                    m.top.audioStreamIndex = newSelection.LookupCI("streamIndex")
-                end if
-                ' Then it is Subtitle options
-            else if m.selectedItem = 0
-                if m.selectedSubtitleIndex = selIndex
-                else
-                    selMenu.content.GetChild(m.selectedSubtitleIndex).selected = false
-                    newSelection = selMenu.content.GetChild(selIndex)
-                    newSelection.selected = true
-                    m.selectedSubtitleIndex = selIndex
-                    m.top.subtitleStream = newSelection
-                    m.global.queueManager.callFunc("setPreferredSubtitleTrack", newSelection)
-                end if
-            else if m.selectedItem = 3 ' Options Menu
-                if isStringEqual(PlaybackMethod.FORCETRANSCODEALLOWREMUX, chainLookupReturn(m.global.session, "user.settings.`playback.media.forceTranscode`", PlaybackMethod.PLAYNORMALLY))
-                    m.optionMenu.checkedItem = 1
-                end if
-                if isStringEqual(PlaybackMethod.FORCETRANSCODEDISABLEREMUX, chainLookupReturn(m.global.session, "user.settings.`playback.media.forceTranscode`", PlaybackMethod.PLAYNORMALLY))
-                    m.optionMenu.checkedItem = 2
-                end if
-
-                if m.optionMenu.checkedItem = 0
-                    m.global.queueManager.callFunc("setForceTranscode", PlaybackMethod.PLAYNORMALLY)
-                else if m.optionMenu.checkedItem = 1
-                    m.global.queueManager.callFunc("setForceTranscode", PlaybackMethod.FORCETRANSCODEALLOWREMUX, string.EMPTY)
-                else if m.optionMenu.checkedItem = 2
-                    m.global.queueManager.callFunc("setForceTranscode", PlaybackMethod.FORCETRANSCODEDISABLEREMUX, m.top.codec)
-                end if
-            end if
-
-        end if
-        return true
-    end if
-
-    if key = KeyCode.BACK or key = KeyCode.UP
-        if m.menus[m.selectedItem].isInFocusChain()
-            m.buttons.setFocus(true)
-            group = m.global.sceneManager.callFunc("getActiveScene")
-            group.lastFocus = m.buttons
-            m.menus[m.selectedItem].drawFocusFeedback = false
+    if m.detailPopup.visible
+        if key = KeyCode.BACK
+            closeDetail()
             return true
         end if
+        return false
     end if
 
-    if key = KeyCode.OPTIONS
-        m.menus[m.selectedItem].drawFocusFeedback = false
-        return false
+    ' Main single-page rows
+    if key = KeyCode.OK
+        openDetail(m.optionsMenu.itemFocused)
+        return true
+    else if key = KeyCode.LEFT
+        cycleRow(m.optionsMenu.itemFocused, -1)
+        return true
+    else if key = KeyCode.RIGHT
+        cycleRow(m.optionsMenu.itemFocused, 1)
+        return true
     end if
 
     return false

--- a/components/movies/MovieOptions.bs
+++ b/components/movies/MovieOptions.bs
@@ -63,13 +63,13 @@ end sub
 
 ' Move focus onto the rows whenever the dialog becomes visible
 sub onVisibleChange()
-    if m.top.visible
-        m.detailPopup.visible = false
-        m.activeCategory = -1
-        m.optionsMenu.setFocus(true)
-        group = m.global.sceneManager.callFunc("getActiveScene")
-        group.lastFocus = m.optionsMenu
-    end if
+    if not m.top.visible then return
+    
+    m.detailPopup.visible = false
+    m.activeCategory = -1
+    m.optionsMenu.setFocus(true)
+    group = m.global.sceneManager.callFunc("getActiveScene")
+    group.lastFocus = m.optionsMenu
 end sub
 
 sub optionsSet()

--- a/components/movies/MovieOptions.xml
+++ b/components/movies/MovieOptions.xml
@@ -4,31 +4,44 @@
     <Rectangle width="1920" height="1080" color="#000000" opacity="0.75" />
     <Group translation="[100,100]">
       <Poster width="1720" height="880" uri="pkg:/images/dialog.9.png" />
-      <LayoutGroup horizAlignment="center" translation="[860,50]" itemSpacings="[50]">
-        <JFButtons id="buttons" />
-        <Group>
-          <RadiobuttonList id="subtitleMenu" itemspacing="[0,10]" opacity="1" vertFocusAnimationStyle="floatingFocus" drawFocusFeedback="false" itemSize="[1500, 70]" numRows="8" />
-          <RadiobuttonList id="audioMenu" itemspacing="[0,10]" opacity="0" vertFocusAnimationStyle="floatingFocus" drawFocusFeedback="false" itemSize="[1500, 70]" numRows="8" />
-          <RadiobuttonList id="videoMenu" itemspacing="[0,10]" opacity="0" vertFocusAnimationStyle="floatingFocus" drawFocusFeedback="false" itemSize="[1500, 70]" numRows="8" />
-          <RadiobuttonList id="optionMenu" itemspacing="[0,10]" opacity="0" vertFocusAnimationStyle="floatingFocus" drawFocusFeedback="false" itemSize="[1500, 70]" numRows="8">
-            <ContentNode role="content">
-              <ContentNode title="Play Normally" id="playNormally" />
-              <ContentNode title="Force Transcode (Allow Remux)" id="forceTranscodeAllowRemux" />
-              <ContentNode title="Force Transcode (Remux Disabled)" id="forceTranscodeDisableRemux" />
-            </ContentNode>
-          </RadiobuttonList>
-        </Group>
+      <LayoutGroup horizAlignment="center" translation="[860,90]" itemSpacings="[60]">
+        <Label id="optionsHeader" text="Options" horizAlign="center" font="font:LargeSystemFont" />
+        <MarkupList
+          id="optionsMenu"
+          itemComponentName="OptionsRow"
+          itemSize="[1500, 80]"
+          itemSpacing="[0, 20]"
+          numRows="4"
+          vertFocusAnimationStyle="floatingFocus"
+          focusBitmapUri="pkg:/images/white.9.png"
+          focusFootprintBitmapUri="" />
       </LayoutGroup>
     </Group>
-
-    <Animation id="fadeAnim" duration="0.5" repeat="false">
-      <FloatFieldInterpolator id="outOpacity" key="[0.0, 0.5, 1.0]" keyValue="[ 1, 0, 0 ]" fieldToInterp="focus.opacity" />
-      <FloatFieldInterpolator id="inOpacity" key="[0.0, 0.5, 1.0]" keyValue="[ 0, 0, 1 ]" fieldToInterp="focus.opacity" />
-    </Animation>
+    
+    <Group id="detailPopup" visible="false">
+      <Rectangle width="1920" height="1080" color="#000000" opacity="0.75" />
+      <Group translation="[210,150]">
+        <Poster width="1500" height="780" uri="pkg:/images/dialog.9.png" />
+        <LayoutGroup horizAlignment="center" translation="[750,60]" itemSpacings="[40]">
+          <Label id="detailTitle" horizAlign="center" font="font:LargeSystemFont" />
+          <Group>
+            <RadiobuttonList id="subtitleMenu" itemspacing="[0,10]" opacity="1" vertFocusAnimationStyle="floatingFocus" drawFocusFeedback="false" itemSize="[1300, 70]" numRows="8" />
+            <RadiobuttonList id="audioMenu" itemspacing="[0,10]" opacity="0" vertFocusAnimationStyle="floatingFocus" drawFocusFeedback="false" itemSize="[1300, 70]" numRows="8" />
+            <RadiobuttonList id="videoMenu" itemspacing="[0,10]" opacity="0" vertFocusAnimationStyle="floatingFocus" drawFocusFeedback="false" itemSize="[1300, 70]" numRows="8" />
+            <RadiobuttonList id="optionMenu" itemspacing="[0,10]" opacity="0" vertFocusAnimationStyle="floatingFocus" drawFocusFeedback="false" itemSize="[1300, 70]" numRows="8">
+              <ContentNode role="content">
+                <ContentNode title="Play Normally" id="playNormally" />
+                <ContentNode title="Force Transcode (Allow Remux)" id="forceTranscodeAllowRemux" />
+                <ContentNode title="Force Transcode (Remux Disabled)" id="forceTranscodeDisableRemux" />
+              </ContentNode>
+            </RadiobuttonList>
+          </Group>
+        </LayoutGroup>
+      </Group>
+    </Group>
 
   </children>
   <interface>
-    <field id="buttons" type="nodearray" />
     <field id="options" type="assocarray" onChange="optionsSet" />
     <field id="videoStreamId" type="string" />
     <field id="video_codec" type="string" />

--- a/components/movies/OptionsRow.bs
+++ b/components/movies/OptionsRow.bs
@@ -1,0 +1,43 @@
+import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/utils/misc.bs"
+
+sub init()
+    m.categoryLabel = m.top.findNode("categoryLabel")
+    m.valueLabel = m.top.findNode("valueLabel")
+    m.leftArrow = m.top.findNode("leftArrow")
+    m.rightArrow = m.top.findNode("rightArrow")
+
+    focusChanged()
+end sub
+
+sub itemContentChanged()
+    itemData = m.top.itemContent
+    if not isValid(itemData) then return
+
+    m.categoryLabel.text = itemData.title
+    m.valueLabel.text = itemData.description
+    updateArrows()
+end sub
+
+sub focusChanged()
+    m.categoryLabel.color = ColorPalette.WHITE
+    m.valueLabel.color = ColorPalette.WHITE
+    if m.top.itemHasFocus
+        m.categoryLabel.font = "font:MediumBoldSystemFont"
+        m.valueLabel.font = "font:MediumBoldSystemFont"
+        m.valueLabel.repeatCount = -1
+    else
+        m.categoryLabel.font = "font:MediumSystemFont"
+        m.valueLabel.font = "font:MediumSystemFont"
+        m.valueLabel.repeatCount = 0
+    end if
+    updateArrows()
+end sub
+
+sub updateArrows()
+    itemData = m.top.itemContent
+    hasMultiple = isValid(itemData) and itemData.optionCount > 1
+    arrowOpacity = (m.top.itemHasFocus and hasMultiple) ? 1 : 0
+    m.leftArrow.opacity = arrowOpacity
+    m.rightArrow.opacity = arrowOpacity
+end sub

--- a/components/movies/OptionsRow.xml
+++ b/components/movies/OptionsRow.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component name="OptionsRow" extends="Group">
+  <children>
+    <Label id="categoryLabel" translation="[40, 0]" width="430" height="80" horizAlign="left" vertAlign="center" font="font:MediumSystemFont" />
+    <Label id="leftArrow" text="‹" translation="[500, 0]" width="60" height="80" horizAlign="center" vertAlign="center" font="font:MediumBoldSystemFont" />
+    <ScrollingText id="valueLabel" translation="[570, 0]" maxWidth="800" height="80" horizAlign="center" vertAlign="center" font="font:MediumSystemFont" repeatCount="0" />
+    <Label id="rightArrow" text="›" translation="[1400, 0]" width="60" height="80" horizAlign="center" vertAlign="center" font="font:MediumBoldSystemFont" />
+  </children>
+  <interface>
+    <field id="itemContent" type="node" onChange="itemContentChanged" />
+    <field id="itemHasFocus" type="boolean" onChange="focusChanged" />
+  </interface>
+</component>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -189,6 +189,10 @@
             <translation>Audio</translation>
         </message>
         <message>
+            <source>Default</source>
+            <translation>Default</translation>
+        </message>
+        <message>
             <source>Subtitles</source>
             <translation>Subtitles</translation>
         </message>
@@ -2243,6 +2247,10 @@
         <message>
             <source>Play Normally</source>
             <translation>Play Normally</translation>
+        </message>
+        <message>
+            <source>Playback Mode</source>
+            <translation>Playback Mode</translation>
         </message>
         <message>
             <source>Force Transcode (Allow Remux)</source>

--- a/source/static/whatsNew/3.2.2.json
+++ b/source/static/whatsNew/3.2.2.json
@@ -14,5 +14,9 @@
   {
     "description": "Reduce music library album view load time",
     "author": "ferezvi"
+  },
+  {
+    "description": "Revamped the Options menu for movies, showing all options in a single list instead of a tabbed view",
+    "author": "CarsonKompon"
   }
 ]


### PR DESCRIPTION
The `MovieOptions` menu requires far too many button presses when trying to change anything more than just subtitles.

The current tab-based approach is cumbersome, AND it requires you to fully close the Options menu once you've changed the Video before you can select the subtitles/audio tracks of the new video (because it still shows the tracks for the previous video file)

## Changes

Now, all 4 options are shown on a single menu, instead of 4 separate tabs. Pressing up/down to select an option, and then pressing left/right to cycle between the options. You can also press OK to see the full list (similar to how it was before) in the event a user has a ton to sift through.

- Added `OptionsRow`, which shows the category label, current value (scrolling text), and left/right chevrons when hovered.
- Removed the tab bar and 4 overlapping lists from `MovieOptions`, replaced with a single `MarkupList` of 4 rows (`OptionsRow`)
- Added hidden `detailPopup` to `MovieOptions`, containing the original RadiobuttonList for full list selection
- Replaced all the hardcoded category integers (0..3) with constants (`CATEGORY_SUBTITLE/AUDIO/VIDEO/PLAYBACK`)
- Cycling through options changes the selection immediately, so changing the Video will instantly update Subtitles and Audio to show the tracks from the selected video
- The previous "Options" tab (the 4th tab within MovieOptions) has been renamed to "Playback Mode"
- When a video contains a single unnamed audio track, it will fallback to displaying "Default" instead of displaying nothing
- Added strings "Playback Mode" and "Default" to the EN_US `translations.ts`. Hopefully I'm doing that right 😅 

## Issues

Couldn't find any github issues, but this fixes the following which can all be seen in my "before" video:
- Fixes options menu being too cumbersome/requiring too many buttons to navigate
- Fixes issue where Subtitle and Audio tracks don't update when changing Video (would show the tracks from the previously selected Video until the Options Menu was closed and re-opened)
- Fixes issue where changing the Video would not actually change the video until you closed and re-opened and changed it again

## Videos

### BEFORE:

https://github.com/user-attachments/assets/c7ea628a-a041-4dcd-9d06-aac558c9e997

1. I open the options menu and change the subtitles to "Canadian | Forced - English - Default"
2. I go to the Video tab and change the video from "4K Surround" to "Prime Video CA"
3. I go back to the Subtitles tab and notice **it still has the same options as before**, with the selection I made for the previous video
4. I **close and re-open** the Options menu and now the Subtitles page has all the correct subtitles loaded for the video I selected
5. I also see that the Audio tab **has all the correct audio tracks after re-opening** (when scrolling by it previously showed 1 track)
6. When I go back to the Video tab, **"4K Surround" is selected again for some reason**, so I re-select "Prime Video CA"
7. My selections are **finally complete**, but I close and re-open to scroll through and double-check (just in case)

### AFTER:

https://github.com/user-attachments/assets/9c47adc4-91bc-45c9-8431-dfaf5801bde8

In this video I quickly change the subtitles by cycling to the right, then press OK on the Video settings to showcase the full list selection, and then quickly change the subtitles again by cycling right (without me having to close and re-open).

Then I cycle left/right and press OK on the Playback Mode option to show how it is just a single option now as well :)

(And for good measure i close and re-open it at the very end to show that none of my options got reset)