### PR TITLE
Fix `Back` navigation loop from item details.

### DIFF
--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -1300,6 +1300,7 @@ end function
 'Genre Item Selected
 sub onGenreItemSelected()
     m.top.selectedItem = m.genreList.content.getChild(m.genreList.rowItemSelected[0]).getChild(m.genreList.rowItemSelected[1])
+    m.top.selectedItem = invalid
 end sub
 
 '

--- a/source/static/whatsNew/3.2.2.json
+++ b/source/static/whatsNew/3.2.2.json
@@ -26,5 +26,9 @@
   {
     "description": "Add quickplay support to the TV season grid",
     "author": "michaelcresswell"
+  },
+  {
+    "description": "Fix Back navigation loop from item details",
+    "author": "VX-101"
   }
 ]


### PR DESCRIPTION
## Summary

Fixes a navigation loop where pressing `Back` from item details could briefly return to the library, then immediately reopen the same item. This was reproducible after choosing a genre and opening an item directly.

## Changes

- Clears `selectedItem` after genre row selection, matching the normal item grid selection path.
   Thanks to @1hitsong for identifying the minimal fix.
## Testing

- Ran `npm run build` successfully.
- Sideloaded local build `3.2.2.0978.0202`.
- Manually verified `Back` returns to the library from several genre-row item details screens, regular item details, and item details opened through `View All <genre>`.
