### PR TITLE
fix(video): enrich ContentNode title for Roku Voice "what's playing" command

### DIFF
--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -563,7 +563,7 @@ function handleTransportCommand(data as object) as object
         ret.status = TransportStatus.SUCCESS
 
     else if isStringEqual(cmd, TransportCommand.PAUSE) or isStringEqual(cmd, TransportCommand.STOP)
-        ret.cmd = { type: TransportCommand.PAUSE}
+        ret.cmd = { type: TransportCommand.PAUSE }
         ret.status = TransportStatus.SUCCESS
 
     else if isStringEqual(cmd, TransportCommand.PLAYPAUSE)
@@ -596,42 +596,12 @@ function handleTransportCommand(data as object) as object
     else if isStringEqual(cmd, TransportCommand.REPLAY)
         ret.status = TransportStatus.UNHANDLED
 
+    ' NOTE: Roku displays the title from the active Video node's ContentNode.Title field directly.
+    ' SetNowPlayingContentMetaData() is not needed and has no effect when a Video node is active.
+    ' The title is enriched in VideoPlayerView.bs after the ContentNode is assigned.
     else if isStringEqual(cmd, TransportCommand.NOWPLAYING)
         currentItem = m.global.queueManager.callFunc("getCurrentItem")
         if isValid(currentItem)
-            itemData = currentItem.json ?? currentItem
-            mediaItemType = LCase(itemData.Type)
-
-            ' Build a descriptive title including year (movies) or season/episode info (TV episodes).
-            ' NOTE: During testing (es-MX, Roku voice remote), Roku Voice only announced the base
-            ' title and did not read the year/season/episode suffix. This may be a limitation
-            ' of the locale/TTS, or may work correctly in other regions/languages. The full
-            ' title is still passed per the official spec, in case it is supported elsewhere.
-            if isStringEqual(mediaItemType, ItemType.MOVIE)
-                displayTitle = itemData.Name ?? itemData.title
-                if isValid(itemData.ProductionYear)
-                    displayTitle += `, ${itemData.ProductionYear}`
-                end if
-
-            else if isStringEqual(mediaItemType, ItemType.EPISODE)
-                season = isValid(itemData.ParentIndexNumber) ? StrI(itemData.ParentIndexNumber).trim() : "0"
-                episode = isValid(itemData.IndexNumber) ? StrI(itemData.IndexNumber).trim() : "0"
-                seasonStr = Left("0" + season, 2)
-                episodeStr = Left("0" + episode, 2)
-                displayTitle = `${itemData.SeriesName} - S${seasonStr}E${episodeStr} - ${itemData.Name ?? itemData.title}`
-                if isValid(itemData.ProductionYear)
-                    displayTitle += `, ${itemData.ProductionYear}`
-                end if
-
-            else
-                displayTitle = itemData.Name ?? itemData.title
-            end if
-
-            appMgr = CreateObject("roAppManager")
-            appMgr.SetNowPlayingContentMetaData({
-                title: displayTitle,
-                contentType: mediaItemType
-            })
             ret.status = TransportStatus.SUCCESS
         else
             ret.status = TransportStatus.ERROR_GENERIC

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -741,9 +741,12 @@ sub onVideoContentLoaded()
         if isStringEqual(mediaType, "episode")
             season = isValid(json.ParentIndexNumber) ? StrI(json.ParentIndexNumber).trim() : "0"
             episode = isValid(json.IndexNumber) ? StrI(json.IndexNumber).trim() : "0"
-            m.top.content.Title = `${json.SeriesName} - S${Left("0" + season, 2)}E${Left("0" + episode, 2)} - ${json.Name ?? json.title}`
+            seriesName = json.SeriesName ?? json.Name ?? json.title ?? ""
+            episodeName = json.Name ?? json.title ?? ""
+            m.top.content.Title = `${seriesName} - S${Left("0" + season, 2)}E${Left("0" + episode, 2)} - ${episodeName}`
         else if isValid(json.ProductionYear)
-            m.top.content.Title = `${json.Name ?? json.title} (${json.ProductionYear})`
+            contentName = json.Name ?? json.title ?? ""
+            m.top.content.Title = `${contentName} (${json.ProductionYear})`
         end if
     end if
 

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -437,7 +437,7 @@ sub handleShowVideoOverviewPopupAction()
         m.overview = "No overview data available"
     end if
 
-    overviewPopupTitle = m.top.content.title
+    overviewPopupTitle = m.originalTitle
 
     if m.top.content.live
         if isValidAndNotEmpty(m.osd.itemSubtitleText)
@@ -732,7 +732,7 @@ sub onVideoContentLoaded()
     m.playbackTestComplete = videoContent[0].content.live
 
     m.top.content = videoContent[0].content
-
+    m.originalTitle = m.top.content.Title
     ' Enrich the content title for Roku Voice "what's playing"
     itemData = m.global.queueManager.callFunc("getCurrentItem")
     if isValid(itemData)
@@ -766,8 +766,8 @@ sub onVideoContentLoaded()
     m.mediaSegments = videoContent[0].mediaSegments
     m.runtimeticks = videoContent[0].runtimeticks
 
-    m.osd.itemTitleText = m.top.content.title
-    m.bufferingItemTitle.text = m.top.content.title
+    m.osd.itemTitleText = m.originalTitle
+    m.bufferingItemTitle.text = m.originalTitle
     m.osd.playbackSpeed = m.top.playbackSpeed
 
     m.trickplayDataFinal = invalid

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -732,6 +732,21 @@ sub onVideoContentLoaded()
     m.playbackTestComplete = videoContent[0].content.live
 
     m.top.content = videoContent[0].content
+
+    ' Enrich the content title for Roku Voice "what's playing"
+    itemData = m.global.queueManager.callFunc("getCurrentItem")
+    if isValid(itemData)
+        json = itemData.json ?? itemData
+        mediaType = LCase(json.Type ?? "")
+        if isStringEqual(mediaType, "episode")
+            season = isValid(json.ParentIndexNumber) ? StrI(json.ParentIndexNumber).trim() : "0"
+            episode = isValid(json.IndexNumber) ? StrI(json.IndexNumber).trim() : "0"
+            m.top.content.Title = `${json.SeriesName} - S${Left("0" + season, 2)}E${Left("0" + episode, 2)} - ${json.Name ?? json.title}`
+        else if isValid(json.ProductionYear)
+            m.top.content.Title = `${json.Name ?? json.title} (${json.ProductionYear})`
+        end if
+    end if
+
     m.top.PlaySessionId = videoContent[0].PlaySessionId
     m.top.videoId = videoContent[0].id
     m.top.container = videoContent[0].container


### PR DESCRIPTION
## Description:
## Problem
When a user asks "what's playing" via Roku Voice during video playback, Roku displays only the base title from the active Video node's ContentNode. For movies, the year was missing. For episodes, the series name and episode number were missing.
The previous implementation used roAppManager.SetNowPlayingContentMetaData() to pass an enriched title, but this has no effect when a Video node is active — Roku reads ContentNode.Title directly and ignores the metadata set via roAppManager.
## Fix
After assigning the ContentNode to m.top.content in onVideoContentLoaded, enrich ContentNode.Title with additional context:

Movies: Title (Year) — e.g. The Dark Knight (2008)
Episodes: Series - SxxExx - Episode Title — e.g. Andor - S01E07 - Announcement

The handleTransportCommand NOWPLAYING block is simplified to just return SUCCESS, since the title is now handled at the ContentNode level.
Testing

- Play a movie → ask "what's playing" → Roku displays title with year
- Play an episode → ask "what's playing" → Roku displays series, season/episode, and title
- Play any other content type → ask "what's playing" → Roku displays base title as before