### PR TITLE
Fix crash when changing live TV view from schedule to channels

### DIFF
--- a/components/Libraries/LiveTVLibraryView.bs
+++ b/components/Libraries/LiveTVLibraryView.bs
@@ -447,7 +447,9 @@ sub optionsClosed()
     end if
 
     if reload
-        m.scheduleGrid.getParent().callFunc("loadChannelList")
+        if isValid(m.scheduleGrid)
+            m.scheduleGrid.getParent().callFunc("loadChannelList")
+        end if
         m.loadedRows = 0
         m.loadedItems = 0
         m.data = CreateObject("roSGNode", "ContentNode")

--- a/source/static/whatsNew/3.2.2.json
+++ b/source/static/whatsNew/3.2.2.json
@@ -2,5 +2,9 @@
   {
     "description": "Separate favorites on the home screen into type specific rows",
     "author": "VX-101"
+  },
+  {
+    "description": "Fix crash when changing live TV view from schedule to channels",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Currently if you go to live TV and change the view from schedule to channels the app will crash.  This PR fixes that issue by checking the schedule grid component exists before calling to it.