### PR TITLE
feat: Auto-advance focus between sign-in form fields

### DIFF
--- a/components/config/FormList.bs
+++ b/components/config/FormList.bs
@@ -24,6 +24,9 @@ end sub
 
 sub onItemSelected()
     i = m.top.itemSelected
+    ' Remember which index is being edited so we know where to jump
+    ' after confirming (next field, or out of the list if it's the last one)
+    m.currentIndex = i
     itemField = m.top.content.getchild(i)
 
     formListShowDialog(itemField)
@@ -36,6 +39,7 @@ function onDialogButton()
     if button_text = tr("OK")
         m.configField.value = d.text
         dismiss_dialog()
+        advanceFocus()
         return true
     else if button_text = tr("Cancel")
         dismiss_dialog()
@@ -44,6 +48,19 @@ function onDialogButton()
     return false
 end function
 
+' Moves focus to the next form field after confirming one.
+' If it was the last field, notify the outside world (SigninScene) via
+' allFieldsSubmitted instead of trying to navigate within the list.
+sub advanceFocus()
+    itemCount = m.top.content.getChildCount()
+    nextIndex = m.currentIndex + 1
+
+    if nextIndex < itemCount
+        m.top.jumpToItem = nextIndex
+    else
+        m.top.allFieldsSubmitted = not m.top.allFieldsSubmitted
+    end if
+end sub
 
 sub formListShowDialog(configField)
     dialog = createObject("roSGNode", "StandardKeyboardDialog")

--- a/components/config/FormList.xml
+++ b/components/config/FormList.xml
@@ -2,5 +2,8 @@
 <component name="FormList" extends="MarkupList">
   <interface>
     <field id="configItems" type="nodearray" onChange="setData" />
+    <!-- Toggled (not just set to true) to guarantee onChange fires every
+         time, even if the user re-edits the last field again -->
+    <field id="allFieldsSubmitted" type="boolean" alwaysNotify="true" value="false" />
   </interface>
 </component>

--- a/components/config/SigninScene.bs
+++ b/components/config/SigninScene.bs
@@ -53,6 +53,8 @@ sub init()
     m.config = m.top.findNode("configOptions")
     m.config.focusBitmapBlendColor = ColorPalette.HIGHLIGHT
     m.config.focusFootprintBlendColor = ColorPalette.TRANSPARENT
+    ' When the last form field is confirmed, jump focus straight to Submit
+    m.config.observeField("allFieldsSubmitted", "onAllFieldsSubmitted")
 
     username_field = CreateObject("roSGNode", "ConfigData")
     username_field.label = tr("Username")
@@ -201,3 +203,14 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     return false
 end function
+
+' Fired when FormList confirms the last field (Password).
+' Jumps focus directly to Submit, skipping the "Save Credentials" checkbox
+' -- UX decision: the user can still toggle it manually before submitting.
+sub onAllFieldsSubmitted()
+    m.submit.setFocus(true)
+    m.submit.focus = true
+
+    group = m.global.sceneManager.callFunc("getActiveScene")
+    group.lastFocus = m.submit
+end sub

--- a/source/static/whatsNew/3.2.1.json
+++ b/source/static/whatsNew/3.2.1.json
@@ -6,5 +6,9 @@
   {
     "description": "Prevent skip segment button from taking focus when OSD is visible",
     "author": "Catmasterson"
+  },
+  {
+    "description": "Auto-advance focus between sign-in form",
+    "author": "ferezvi"
   }
 ]


### PR DESCRIPTION
## Description

Adds automatic focus advancement to the sign-in form (`FormList`/`FormElement`), reducing the number of manual D-pad navigations needed to log in.

### Before
After confirming a field's keyboard dialog (OK), focus stayed on the same row. The user had to manually navigate down to the next field, and again down (past the "Save Credentials" checkbox) to reach Submit.

### After
- Confirming the **Username** field automatically moves focus to **Password**.
- Confirming the **Password** field automatically moves focus to **Submit**, skipping the "Save Credentials" checkbox (the user can still toggle it manually with the remote before submitting).
- Pressing Cancel in the keyboard dialog does not advance focus, as before.

## Implementation

- `FormList` gains a boolean `allFieldsSubmitted` field (`alwaysNotify="true"`), toggled whenever the last item in the list is confirmed. It's toggled rather than just set to `true` so the change fires every time, even if the user edits the last field again in the same screen session.
- `onDialogButton()` now calls `advanceFocus()` after saving the confirmed value, which either jumps to the next item in the list (`jumpToItem`) or toggles `allFieldsSubmitted` if it was the last one.
- `SigninScene` observes `allFieldsSubmitted` and moves focus to the Submit button when it fires.

`FormList`/`FormElement` are currently only used by `SigninScene`, so this change has no impact on other screens.

## Testing

Tested manually on device: Username → OK → Password auto-focused → OK → Submit auto-focused → OK submits the form. Cancel at any step leaves focus unchanged. Existing manual D-pad navigation (up/down through the form) still works as before.
<img width="1920" height="1080" alt="dev (7)" src="https://github.com/user-attachments/assets/09ce97ad-dedc-4821-bd7a-33ac18b83957" />
