### PR TITLE
Fix no/incorrect subtitles being displayed bugs

### DIFF
--- a/components/manager/ViewCreator.bs
+++ b/components/manager/ViewCreator.bs
@@ -469,6 +469,9 @@ end sub
 ' This function translates between our internel selected subtitle index
 ' and the corresponding index in availableSubtitleTracks.
 function availSubtitleTrackIdx(tracknameToFind as string) as integer
+    ' Giving an empty substring to Instr will always return position 1
+    if not isValidAndNotEmpty(tracknameToFind) then return SubtitleSelection.NONE
+
     idx = 0
     for each availTrack in m.view.availableSubtitleTracks
         ' The TrackName must contain the URL we supplied originally, though

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -30,10 +30,12 @@ sub init()
     m.spinnerPercentTimer.observeField("fire", "onPercentTick")
 
     m.top.observeField("availableAudioTracks", "onAvailableAudioTracksChanged")
+    m.top.observeField("availableSubtitleTracks", "onAvailableSubtitleTracksChanged")
 
     m.attemptDirectPlaySetting = chainLookupReturn(m.global.session, "user.settings.attemptDirectPlay", false)
 
     m.subtitleOffset = 0
+    m.pendingSubtitle = invalid
 
     m.LoadProgramDetailsTask = createObject("roSGNode", "LoadProgramDetailsTask")
     m.LoadProgramDetailsTask.observeField("programDetails", "onProgramDetailsLoaded")
@@ -852,18 +854,15 @@ sub onVideoContentLoaded()
         m.top.subtitleTrack = ""
     end if
 
-    if isValid(selectedSubtitle)
-        availableSubtitleTrackIndex = availSubtitleTrackIdx(selectedSubtitle.Track.TrackName)
-        if availableSubtitleTrackIndex <> SubtitleSelection.NONE
-            if not selectedSubtitle.IsEncoded
-                if selectedSubtitle.IsForced
-                    ' If IsForced, make sure to remember the Roku global setting so we can set it back when the video is done playing.
-                    m.originalClosedCaptionState = m.top.globalCaptionMode
-                end if
-                m.top.globalCaptionMode = "On"
-                m.top.subtitleTrack = m.top.availableSubtitleTracks[availableSubtitleTrackIndex].TrackName
-            end if
-        end if
+    ' availableSubtitleTracks is populated asynchronously. If it's not populated yet,
+    ' applyPendingSubtitleTrack will do nothing on this call and we have to wait for the observer to
+    ' be triggered. If it is already populated, then its observer has already fired and the manual
+    ' call here is necessary.
+    if isValid(selectedSubtitle) and not selectedSubtitle.IsEncoded
+        m.pendingSubtitle = selectedSubtitle
+        applyPendingSubtitleTrack()
+    else
+        m.pendingSubtitle = invalid
     end if
 
     ' Check if video content selected a subtitle
@@ -1650,6 +1649,29 @@ function availSubtitleTrackIdx(tracknameToFind as string) as integer
     end for
     return SubtitleSelection.NONE
 end function
+
+sub onAvailableSubtitleTracksChanged()
+    applyPendingSubtitleTrack()
+end sub
+
+' Tries to apply m.pendingSubtitle to the Video node if the target subtitle can be located in the
+' availableSubtitleTracks list. If it can't, no-op.
+sub applyPendingSubtitleTrack()
+    if not isValid(m.pendingSubtitle) then return
+    if not isValidAndNotEmpty(m.top.availableSubtitleTracks) then return
+
+    availableSubtitleTrackIndex = availSubtitleTrackIdx(m.pendingSubtitle.Track.TrackName)
+    if availableSubtitleTrackIndex = SubtitleSelection.NONE then return
+
+    if m.pendingSubtitle.IsForced and not isValid(m.originalClosedCaptionState)
+        ' If IsForced, make sure to remember the Roku global setting so we can set it back when the video is done playing.
+        m.originalClosedCaptionState = m.top.globalCaptionMode
+    end if
+
+    m.top.globalCaptionMode = "On"
+    m.top.subtitleTrack = m.top.availableSubtitleTracks[availableSubtitleTrackIndex].TrackName
+    m.pendingSubtitle = invalid
+end sub
 
 sub skipCurrentSegment()
     seekPosition = m.currentSegmentEndTicks / 10000000#

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -1635,6 +1635,9 @@ end function
 ' @param {string} tracknameToFind - TrackName for subtitle we're looking to match
 ' @return {integer} indicating Roku's index for requested subtitle track. Returns SubtitleSelection.NONE if not found
 function availSubtitleTrackIdx(tracknameToFind as string) as integer
+    ' Giving an empty substring to Instr will always return position 1
+    if not isValidAndNotEmpty(tracknameToFind) then return SubtitleSelection.NONE
+
     idx = 0
     for each availTrack in m.top.availableSubtitleTracks
         ' The TrackName must contain the URL we supplied originally, though


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->

This fixes two bugs with regard to subtitles:
 * Sometimes no subtitles would be displayed while the subtitle selection menu indicated that a subtitle track was selected. This was caused by a race condition in populating `availableSubtitleTracks` vs loading the video content. Fixed by adding an observer to make sure that the subtitle track is set after `availableSubtitleTracks` has loaded.
 * Fix an issue where when encoded subtitles were selected but not the first subtitle track. This was caused by `tracknameToFind` thus being `""` and incorrectly returning the first sub track. This was causing both the encoded subs to be displayed alongside whatever the first sub track was.

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
I made these changes because of my own experiences, but I believe this fixes #457. Although I would ask @dathbe to confirm with these changes if their issue is solved.
