### PR TITLE
Fix crash on album view when use fallback font for entire app setting is enabled

### DIFF
--- a/components/labels/MultiStyleText.bs
+++ b/components/labels/MultiStyleText.bs
@@ -3,17 +3,48 @@ import "pkg:/source/enums/String.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
-    setFont()
-    m.top.observeFieldScoped("font", "onFontChanged")
+    m.top.observeFieldScoped("drawingStyles", "onDrawingStylesChanged")
 end sub
 
 sub setFont()
+    if not isValidAndNotEmpty(m.top.drawingStyles) then return
     if not isValidAndNotEmpty(m.global.fallbackFont) then return
     if not chainLookupReturn(m.global.session, "user.settings.useFallbackFont", false) then return
 
-    m.top.font.uri = m.global.fallbackFont.regular
+    drawingStyles = formatJson(m.top.drawingStyles)
+
+    regularFonts = [
+        "font:TinySystemFontFile",
+        "font:SmallerSystemFontFile",
+        "font:SmallestSystemFontFile",
+        "font:SmallSystemFontFile",
+        "font:MediumSystemFontFile",
+        "font:LargeSystemFontFile",
+        "font:LargestSystemFontFile",
+        "font:ExtraLargeSystemFontFile"
+    ]
+
+    boldFonts = [
+        "font:TinyBoldSystemFontFile",
+        "font:SmallerBoldSystemFontFile",
+        "font:SmallestBoldSystemFontFile",
+        "font:SmallBoldSystemFontFile",
+        "font:MediumBoldSystemFontFile",
+        "font:LargeBoldSystemFontFile",
+        "font:ExtraLargeBoldSystemFontFile"
+    ]
+
+    for each font in regularFonts
+        drawingStyles = drawingStyles.replace(font, m.global.fallbackFont.regular)
+    end for
+
+    for each font in boldFonts
+        drawingStyles = drawingStyles.replace(font, m.global.fallbackFont.bold)
+    end for
+
+    m.top.drawingStyles = ParseJSON(drawingStyles)
 end sub
 
-sub onFontChanged()
+sub onDrawingStylesChanged()
     setFont()
 end sub

--- a/source/static/whatsNew/3.2.2.json
+++ b/source/static/whatsNew/3.2.2.json
@@ -78,5 +78,9 @@
   {
     "description": "Fix user avatar circle on HD devices",
     "author": "ferezvi"
+  },
+  {
+    "description": "Fix crash on album view when use fallback font for entire app setting is enabled",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Fixes crash on album view when use fallback font for entire app user setting is enabled.

Changes code so fonts for multistyletext labels are set properly.

## Issues
Fixes #1019
