### PR TITLE
Fix clipped descenders on multiline captions with background boxes

### DIFF
--- a/components/captionShadow.bs
+++ b/components/captionShadow.bs
@@ -133,16 +133,32 @@ sub createCueBackgroundBox(rect as object, lg as object, styledText as string, d
     fontSize = drawingStyles["default"].fontSize
     bgPadding = Int(fontSize * OUTLINE_STEP_RATIO) + 1
 
-    ' Create background boxes - same height for all lines
-    for i = 0 to lineFragments.count() - 1
+    ' Last line uses singleLineHeight since there's no next line's leading to reserve
+    ' bgPadding applied vertically too (top of first line, bottom of last) so it covers shadow spillover on all sides, not just left/right
+    lastLineIndex = lineFragments.count() - 1
+
+    for i = 0 to lastLineIndex
+        isFirstLine = (i = 0)
+        isLastLine = (i = lastLineIndex)
+
+        boxHeight = lineHeight
+        if isLastLine and lineFragments.count() > 1
+            boxHeight = lineHeights.single
+        end if
+
+        extraTop = 0
+        if isFirstLine then extraTop = bgPadding
+
+        extraBottom = 0
+        if isLastLine then extraBottom = bgPadding
+
         bg = CreateObject("roSGNode", "Rectangle")
-        bg.height = lineHeight
+        bg.height = boxHeight + extraTop + extraBottom
         bg.color = bgColor
-        ' Padding matches outline step so background fully covers shadow labels
         bg.width = lineWidths[i] + (bgPadding * 2)
         bg.translation = [
             (maxWidth - lineWidths[i]) / 2 + BASE_OFFSET - bgPadding,
-            i * lineHeight + BASE_OFFSET
+            i * lineHeight + BASE_OFFSET - extraTop
         ]
         rect.insertChild(bg, 0)
     end for

--- a/components/captionShadow.bs
+++ b/components/captionShadow.bs
@@ -147,10 +147,14 @@ sub createCueBackgroundBox(rect as object, lg as object, styledText as string, d
         end if
 
         extraTop = 0
-        if isFirstLine then extraTop = bgPadding
+        if isFirstLine
+            extraTop = bgPadding
+        end if
 
         extraBottom = 0
-        if isLastLine then extraBottom = bgPadding
+        if isLastLine
+            extraBottom = bgPadding
+        end if
 
         bg = CreateObject("roSGNode", "Rectangle")
         bg.height = boxHeight + extraTop + extraBottom

--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -473,6 +473,6 @@ function getLineHeights() as object
 
     return {
         single: singleLineHeight,
-        multi: Int(twoLinesTotal / 2)
+        multi: twoLinesTotal - singleLineHeight
     }
 end function


### PR DESCRIPTION
Multiline captions with per-line background boxes were clipping descenders (g, y, p, j) starting at 3 lines, getting worse with each additional line.

The root cause was in getLineHeights(): it estimated per-line height by averaging twoLinesTotal / 2, which undercounts the real line-to-line step and compounds the error as lines increase. Fixed by using twoLinesTotal - singleLineHeight instead.

Also fixes the last line reserving extra unused space (leading meant for a next line that doesn't exist), and extends the existing shadow-spillover padding (bgPadding) to apply vertically as well, not just left/right.