### PR TITLE
Fix/caption top line percent offset

### DIFF
--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -416,7 +416,10 @@ end function
 function processLineCue(captionLine as string, captionLineHeight as float, captionTotalHeight as float) as integer
     ' A percentage
     if captionLine.Instr("%") <> -1
-        calculatedPosition = SCREEN_PADDING + VIEWABLE_AREA * (val(captionLine) / 100)
+        ' Map the percentage directly to full screen height, matching WebVTT's
+        ' expected behavior. The safe-area clamp below still prevents the
+        ' caption from touching the very top edge.
+        calculatedPosition = 1080 * (val(captionLine) / 100)
     else
         ' Note: Non-numeric values are treated as 0
         lineValue = val(captionLine)

--- a/source/static/whatsNew/3.2.2.json
+++ b/source/static/whatsNew/3.2.2.json
@@ -82,5 +82,9 @@
   {
     "description": "Fix crash on album view when use fallback font for entire app setting is enabled",
     "author": "1hitsong"
+  },
+  {
+    "description": "Fix top-positioned subtitles rendering with too much vertical margin",
+    "author": "ferezvi"
   }
 ]


### PR DESCRIPTION
Overview

Fixes incorrect vertical positioning of subtitles, which were rendering way too low on screen.