### PR TITLE
Fix play button on TV series screen

### DIFF
--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -958,21 +958,27 @@ sub onPlaySeriesFromStartEvent(msg)
     series = msg.getRoSGNode()
 
     if not isChainValid(series, "itemContent.id") then return
-    if not isChainValid(series, "seasonData.items") then return
-    if not isValidAndNotEmpty(series.seasonData.items) then return
+
+    seasonData = api.shows.GetSeasons(series.itemContent.id, {
+        userId: m.global.session.user.id,
+        enableImages: false
+    })
+
+    if not isChainValid(seasonData, "items") then return
+    if not isValidAndNotEmpty(seasonData.items) then return
 
     ' Fall back to playing specials if that's all that is available
     firstSeasonIndex = 0
 
     ' Loop through the season data and find the first season with a season number greater than 0
-    for i = 0 to series.seasonData.items.count() - 1
-        if series.seasonData.items[i].json.IndexNumber > 0
+    for i = 0 to seasonData.items.count() - 1
+        if chainLookupReturn(seasonData.items[i], "IndexNumber", 0) > 0
             firstSeasonIndex = i
             exit for
         end if
     end for
 
-    firstSeasonData = series.seasonData.items[firstSeasonIndex]
+    firstSeasonData = seasonData.items[firstSeasonIndex]
 
     if not isValidAndNotEmpty(firstSeasonData.LookupCI("id")) then return
 

--- a/source/static/whatsNew/3.2.2.json
+++ b/source/static/whatsNew/3.2.2.json
@@ -126,5 +126,9 @@
   {
     "description": "Improve reliability of loading the entire live TV guide",
     "author": "FractalBoy"
+  },
+  {
+    "description": "Fix Play button at series level does not play series",
+    "author": "brianpardy"
   }
 ]

--- a/source/static/whatsNew/3.2.2.json
+++ b/source/static/whatsNew/3.2.2.json
@@ -128,7 +128,7 @@
     "author": "FractalBoy"
   },
   {
-    "description": "Fix Play button at series level does not play series",
+    "description": "Fix play button on TV series screen",
     "author": "brianpardy"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Fix Play button at series level. Fetch `seasonData` from the API to populate uninitialized/invalid variable that was causing early return from `onPlaySeriesFromStartEvent`.
<!-- Describe your changes here in 1-5 sentences. -->

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #1031 