### PR TITLE
Fix crash on movie details screen when media parts data is in an unexpected state

### DIFF
--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -206,7 +206,8 @@ sub additionalPartsChanged()
         end if
     end if
 
-    if m.top.additionalParts.parts.TotalRecordCount = 0
+    totalPartsCount = chainLookupReturn(m.top.additionalParts, "parts.TotalRecordCount", 0)
+    if totalPartsCount = 0
         if isValid(partButton)
             m.buttonGrp.content.removeChild(partButton)
             calculateButtonThumbProperties()

--- a/source/static/whatsNew/3.2.3.json
+++ b/source/static/whatsNew/3.2.3.json
@@ -2,5 +2,9 @@
   {
     "description": "Fix Resume Series skipping resumable first episode",
     "author": "brianpardy"
+  },
+  {
+    "description": "Fix crash when media parts data is in an unexpected state",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Confirms data is valid before using it. Fixes # 1 reported crash in Roku logs.