### PR TITLE
Stop OSD dismissal by keypress from unpausing playback

### DIFF
--- a/components/video/OSD.bs
+++ b/components/video/OSD.bs
@@ -542,10 +542,10 @@ function onKeyEvent(key as string, press as boolean) as boolean
         return true
     end if
 
-    ' All other keys resume play and hide the menu
+    ' All other keys hide the menu
     m.top.isSeeking = false
     checkDisplaySiblingItem("")
-    m.top.action = "play"
+    m.top.action = "hide"
 
     return true
 end function

--- a/source/static/whatsNew/3.2.3.json
+++ b/source/static/whatsNew/3.2.3.json
@@ -6,5 +6,9 @@
   {
     "description": "Fix crash when media parts data is in an unexpected state",
     "author": "1hitsong"
+  },
+  {
+    "description": "Stop OSD dismissal by keypress from unpausing playback",
+    "author": "Catmasterson"
   }
 ]


### PR DESCRIPTION
## Changes
With this change, dismissing the OSD using a keypress no longer unpauses video playback. This includes dismissal via the back button, or using the arrow keys to navigate off of the OSD interface. As discussed in #997, this behavior is in line with other popular Roku apps.

## Issues
Discussed in #997

## Testing
I tested this briefly since it's a minor change; each method of dismissing the OSD mentioned above still dismisses the OSD but now no longer unpauses playback.