### PR TITLE
Fix possible crash on home screen On Now row

### DIFF
--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -396,7 +396,7 @@ function loadLiveTVOnNow() as object
     for each item in data.Items
         tmp = CreateObject("roSGNode", "HomeData")
         imageTags = item.LookupCI("ImageTags")
-        isThumbImage = chainLookupReturn(imageTags, ImageType.THUMB, false)
+        isThumbImage = isValidAndNotEmpty(chainLookup(imageTags, ImageType.THUMB))
 
         tmp.addField("FHDItemWidth", "float", false)
         tmp.FHDItemWidth = calculateOnNowItemWidth(item.LookupCI("PrimaryImageAspectRatio"), isThumbImage)

--- a/source/static/whatsNew/3.2.3.json
+++ b/source/static/whatsNew/3.2.3.json
@@ -10,5 +10,9 @@
   {
     "description": "Stop OSD dismissal by keypress from unpausing playback",
     "author": "Catmasterson"
+  },
+  {
+    "description": "Fix possible crash on home screen On Now row",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION


<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Fix logic checking if image is thumb.

@ferezvi Do the on now images still work for you with this change?

## Issues
Fixes #1044