### PR TITLE
Fix Live TV Guide Sort

### DIFF
--- a/components/Libraries/LiveTVLibraryView.bs
+++ b/components/Libraries/LiveTVLibraryView.bs
@@ -51,13 +51,8 @@ sub init()
     'set voice help text
     m.voiceBox.hintText = tr("Use voice remote to search")
 
-    channelOrder = chainLookupReturn(m.global.session, "display.livetv.sortField", LiveTVChannelSortOrder.NUMBER)
-    if isStringEqual(channelOrder, LiveTVChannelSortOrder.DATEPLAYED)
-        m.sortField = "DatePlayed"
-    else
-        m.sortField = "SortName"
-    end if
-    m.sortAscending = true
+    m.sortField = chainLookupReturn(m.global.session, "user.settings.`display.livetv.sortField`", "SortName")
+    m.sortAscending = chainLookupReturn(m.global.session, "user.settings.`display.livetv.sortAscending`", true)
 
     m.filter = "All"
 
@@ -123,21 +118,11 @@ sub loadInitialItems()
         m.alpha.visible = true
         m.itemGrid.opacity = 1
     end if
-    m.sortField = m.global.session.user.settings["display.livetv.sortField"]
-    sortAscendingStr = m.global.session.user.settings["display.livetv.sortAscending"]
+    m.sortField = chainLookupReturn(m.global.session, "user.settings.`display.livetv.sortField`", "SortName")
+    m.sortAscending = chainLookupReturn(m.global.session, "user.settings.`display.livetv.sortAscending`", true)
     m.filter = m.global.session.user.settings["display.livetv.filter"]
 
     if not isValidAndNotEmpty(m.filter) then m.filter = "All"
-
-    if not isValidAndNotEmpty(m.sortField)
-        m.sortField = "SortName"
-    end if
-
-    if sortAscendingStr = invalid or sortAscendingStr = true
-        m.sortAscending = true
-    else
-        m.sortAscending = false
-    end if
 
     m.loadItemsTask.itemId = m.top.parentItem.Id
 

--- a/components/liveTv/schedule.bs
+++ b/components/liveTv/schedule.bs
@@ -62,7 +62,7 @@ sub init()
     m.LoadChannelsTask = createObject("roSGNode", "LoadChannelsTask")
     m.LoadChannelsTask.observeField("channels", "onChannelListLoaded")
 
-    m.LoadChannelsTask.sortField = chainLookupReturn(m.global.session, "user.settings.`display.livetv.sortField`", LiveTVChannelSortOrder.NUMBER)
+    m.LoadChannelsTask.sortField = chainLookupReturn(m.global.session, "user.settings.`display.livetv.sortField`", "SortName")
     m.LoadChannelsTask.sortAscending = chainLookupReturn(m.global.session, "user.settings.`display.livetv.sortAscending`", true)
     m.LoadChannelsTask.favoritesAtTop = chainLookupReturn(m.global.session, "user.settings.`ui.guide.favorites.at.top`", false)
 

--- a/source/static/whatsNew/3.2.3.json
+++ b/source/static/whatsNew/3.2.3.json
@@ -14,5 +14,9 @@
   {
     "description": "Fix possible crash on home screen On Now row",
     "author": "1hitsong"
+  },
+  {
+    "description": "Fix TV Guide sort",
+    "author": "michaelcresswell"
   }
 ]

--- a/source/utils/session.bs
+++ b/source/utils/session.bs
@@ -269,7 +269,7 @@ namespace session
             displayLive = "true"
             displayRepeat = "false"
             displayScreen = LiveTVScreen.Guide
-            liveTvChannelOrder = LiveTVChannelSortOrder.Number
+            liveTvChannelOrder = "SortName"
             liveTvFavoritesAtTop = "false"
 
             if isValid(customPrefs)
@@ -290,7 +290,11 @@ namespace session
                     displayScreen = userPreferenceDisplayScreen
                 end if
                 if isValidAndNotEmpty(userPreferenceLiveTvChannelOrder)
-                    liveTvChannelOrder = userPreferenceLiveTvChannelOrder
+                    if isStringEqual(userPreferenceLiveTvChannelOrder, LiveTVChannelSortOrder.DATEPLAYED)
+                        liveTvChannelOrder = "DatePlayed"
+                    else
+                        liveTvChannelOrder = "SortName"
+                    end if
                 end if
                 if isValidAndNotEmpty(userPreferenceLiveTvFavoritesAtTop)
                     liveTvFavoritesAtTop = userPreferenceLiveTvFavoritesAtTop
@@ -303,6 +307,10 @@ namespace session
             set_user_setting("display.livetv.landing", displayScreen)
             set_user_setting("display.livetv.sortField", liveTvChannelOrder)
             set_user_setting("ui.guide.favorites.at.top", liveTvFavoritesAtTop)
+
+            ' Always start off ascending when sorted by channel number, descending when sorted by date played
+            print "Setting ascending to " + isStringEqual(liveTvChannelOrder, "SortName").tostr()
+            set_user_setting("display.livetv.sortAscending", (isStringEqual(liveTvChannelOrder, "SortName")).tostr())
         end sub
 
         ' Saves user's web client home sections as Roku user settings.


### PR DESCRIPTION
## Changes

- Map user setting to sort field once when read from session instead of throughout code.
Previously one of the three places it needed to happen was correct, one was close but incorrect, and one was missing.

- Set initial ascending/descending based on sort field. 
This prevents manually changing ascending/descending from affecting the initial sort next time the client loads.

## Issues
Fixes #1049
