### PR TITLE
Clear stale artist presentation state when switching to Music genres

### DIFF
--- a/components/Libraries/MusicLibraryView.bs
+++ b/components/Libraries/MusicLibraryView.bs
@@ -370,8 +370,7 @@ sub loadInitialItems()
         m.loadItemsTask.itemType = ""
         m.loadItemsTask.recursive = true
         m.loadItemsTask.view = "Genres"
-        m.artistLogo.visible = false
-        m.selectedArtistName.visible = false
+        clearMusicArtistPresentation()
     end if
 
     setColumnSizes()
@@ -741,6 +740,24 @@ end sub
 'Set Selected Artist Genres
 sub SetGenres(artistGenres)
     m.selectedArtistGenres.text = artistGenres.join(", ")
+end sub
+
+sub clearMusicArtistPresentation()
+    m.loadLogoTask.unobserveField("content")
+    m.loadLogoTask.control = TaskControl.STOP
+    m.loadLogoTask.content = []
+
+    m.artistLogo.visible = false
+    m.artistLogo.uri = String.EMPTY
+    m.selectedArtistName.visible = false
+    m.selectedArtistName.text = String.EMPTY
+    m.selectedArtistGenres.visible = false
+    m.selectedArtistGenres.text = String.EMPTY
+    m.selectedArtistSongCount.visible = false
+    m.selectedArtistSongCount.text = String.EMPTY
+    m.selectedArtistAlbumCount.visible = false
+    m.selectedArtistAlbumCount.text = String.EMPTY
+    m.backdropImage@.clearImage()
 end sub
 
 '

--- a/source/static/whatsNew/3.2.4.json
+++ b/source/static/whatsNew/3.2.4.json
@@ -2,5 +2,9 @@
   {
     "description": "Improve playback of recordings that are currently in process",
     "author": "VTRunner"
+  },
+  {
+    "description": "Clear stale artist presentation state when switching to Music genres",
+    "author": "VX-101"
   }
 ]


### PR DESCRIPTION
## Summary

Clears stale Music Artist Presentation details after switching the Music library view to `Genres`. This change was separated from #980 so it can be reviewed and tested independently.

## Changes

- Clear the previous artist title, logo, genre label, song/album counts, and backdrop when loading the Music `Genres` view.
- Stop any pending artist logo load before the `Genres` view is displayed so stale logo data cannot reappear over genre results.

## Testing

- Ran `npm run build` successfully.
- Sideloaded local build `3.2.4.1058.0261`.
- Manually verified Artist Presentation → `Genres` on Roku.

**Visual evidence:** 
<img width="2768" height="597" alt="_roku_pr1058_stale_before_fixed_after_side_by_side_20260806-100048" src="https://github.com/user-attachments/assets/afba49ff-6a80-41a8-8616-d96ec3126188" />
