### PR TITLE
Add favorite indicators to album track lists

### DIFF
--- a/components/data/MusicSongData.xml
+++ b/components/data/MusicSongData.xml
@@ -5,6 +5,7 @@
     <field id="title" type="string" />
     <field id="trackNumber" type="integer" />
     <field id="playCount" type="integer" />
+    <field id="favoriteStatus" type="string" />
     <field id="RunTimeTicks" type="float" />
     <field id="ArtistItems" type="array" />
     <field id="AlbumId" type="string" />

--- a/components/music/AlbumView.bs
+++ b/components/music/AlbumView.bs
@@ -1,4 +1,5 @@
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/enums/FavoriteStatus.bs"
 import "pkg:/source/enums/KeyCode.bs"
 import "pkg:/source/enums/MediaPlaybackState.bs"
 import "pkg:/source/enums/String.bs"
@@ -203,15 +204,6 @@ sub adjustForMiniPlayer(audioMiniPlayerVisible = false)
     if m.songList.numRows <> newNumberOfRows
         focusedItem = m.songList.itemFocused
         m.songList.numRows = newNumberOfRows
-
-        tempData = CreateObject("roSGNode", "ContentNode")
-        tempData.appendChildren(m.top.albumData.getChildren(-1, 0))
-
-        data = CreateObject("roSGNode", "ContentNode")
-        m.top.albumData = data
-        m.songList.content = data
-        data.appendChildren(tempData.getChildren(-1, 0))
-
         m.songList.jumpToItem = focusedItem
     end if
 end sub
@@ -334,21 +326,39 @@ end sub
 sub refreshAlbumTrackList()
     if not isChainValid(m.top.pageContent, "id") then return
 
-    m.focusedItem = m.songList.itemFocused
     m.LoadAlbumTask = CreateObject("roSGNode", "LoadAlbumTask")
     m.LoadAlbumTask.id = m.top.pageContent.id
     m.LoadAlbumTask.observeField("albumDetails", "onAlbumDetailsLoaded")
     m.LoadAlbumTask.control = TaskControl.RUN
 end sub
 
+sub updateAlbumTrackPlayCounts(albumDetails as dynamic)
+    if not isValid(albumDetails) or not isValid(m.top.albumData) then return
+
+    existingSongsByID = {}
+    for each existingSong in m.top.albumData.getChildren(-1, 0)
+        songID = chainLookupReturn(existingSong, "id", string.EMPTY)
+        if isValidAndNotEmpty(songID)
+            existingSongsByID.AddReplace(songID, existingSong)
+        end if
+    end for
+
+    for each refreshedSong in albumDetails.getChildren(-1, 0)
+        songID = chainLookupReturn(refreshedSong, "id", string.EMPTY)
+        existingSong = existingSongsByID.LookupCI(songID)
+        if isValid(existingSong)
+            existingSong.playCount = refreshedSong.playCount
+        end if
+    end for
+end sub
+
 sub onAlbumDetailsLoaded()
     m.LoadAlbumTask.unobserveField("albumDetails")
     m.LoadAlbumTask.control = TaskControl.STOP
 
-    m.songList.doneLoading = false
-    m.songList.observeField("doneLoading", "onDoneLoading")
-    albumDetails = m.LoadAlbumTask.albumDetails
-    m.top.albumData = albumDetails
+    ' Update the rendered rows in place so refreshes preserve list focus.
+    updateAlbumTrackPlayCounts(m.LoadAlbumTask.albumDetails)
+    stopLoadingSpinner()
 end sub
 
 ' Populate on screen text variables
@@ -717,11 +727,12 @@ function onKeyEvent(key as string, press as boolean) as boolean
     end if
 
     if m.songList.hasFocus()
-        if key = KeyCode.OPTIONS
+        if isStringEqual(key, KeyCode.OPTIONS)
             focusedSong = m.songList.content.getChild(m.songList.itemFocused)
             if not isValidAndNotEmpty(focusedSong) then return false
 
-            dialogData = [tr("Add To Playlist")]
+            favoriteOptionText = chainLookupReturn(focusedSong, "favorite", false) ? tr("Remove From Favorites") : tr("Add To Favorites")
+            dialogData = [favoriteOptionText, tr("Add To Playlist")]
             m.global.sceneManager.callFunc("optionDialog", "libraryitem", focusedSong.LookupCI("title") ?? tr("Options"), [], dialogData, { id: focusedSong.LookupCI("id") })
 
             return true
@@ -951,11 +962,6 @@ sub onDoneLoading()
 
     if m.loadStatus = ViewLoadStatus.INIT
         m.loadStatus = ViewLoadStatus.FIRSTLOAD
-    end if
-
-    if isValid(m.focusedItem)
-        m.songList.jumpToItem = m.focusedItem
-        m.focusedItem = invalid
     end if
 
     scene = m.top.getScene()

--- a/components/music/AlbumView.xml
+++ b/components/music/AlbumView.xml
@@ -53,7 +53,8 @@
 
           <LayoutGroup id="tableHeading" layoutDirection="horiz" itemSpacings="[20]" translation="[45, 20]">
             <Text id="trackHeading" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="center" text="Track" width="80" />
-            <Text id="titleHeading" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="center" text="Title" width="1280" />
+            <Rectangle width="32" height="30" color="0x00000000" />
+            <Text id="titleHeading" font="font:SmallBoldSystemFont" horizAlign="left" vertAlign="center" text="Title" width="1238" />
             <Text id="lengthHeading" font="font:SmallBoldSystemFont" horizAlign="right" vertAlign="center" text="Length" width="120" />
             <Text id="playsHeading" font="font:SmallBoldSystemFont" horizAlign="right" vertAlign="center" text="Plays" width="80" />
           </LayoutGroup>

--- a/components/music/SongItem.bs
+++ b/components/music/SongItem.bs
@@ -1,3 +1,6 @@
+import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/enums/FavoriteStatus.bs"
+import "pkg:/source/enums/String.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
@@ -9,6 +12,17 @@ sub init()
     m.trackNumber = m.top.findNode("trackNumber")
     if isValid(m.trackNumber)
         m.trackNumber.font.size = 28
+    end if
+
+    m.favoriteIcon = m.top.findNode("favoriteIcon")
+    if isValid(m.favoriteIcon)
+        m.favoriteIcon.blendColor = ColorPalette.RED
+    end if
+
+    m.favoriteStatusUnknown = m.top.findNode("favoriteStatusUnknown")
+    if isValid(m.favoriteStatusUnknown)
+        m.favoriteStatusUnknown.color = ColorPalette.RED
+        m.favoriteStatusUnknown.font.size = 28
     end if
 
     m.tracklength = m.top.findNode("tracklength")
@@ -23,8 +37,30 @@ sub init()
 end sub
 
 sub itemContentChanged()
-    itemData = m.top.itemContent
-    if itemData = invalid then return
+    if isValid(m.itemData)
+        m.itemData.unobserveFieldScoped("favorite")
+        m.itemData.unobserveFieldScoped("favoriteStatus")
+        m.itemData.unobserveFieldScoped("playCount")
+    end if
+
+    m.itemData = m.top.itemContent
+    if not isValid(m.itemData)
+        if isValid(m.favoriteIcon)
+            m.favoriteIcon.visible = false
+        end if
+        if isValid(m.favoriteStatusUnknown)
+            m.favoriteStatusUnknown.visible = false
+        end if
+        return
+    end if
+
+    m.itemData.observeFieldScoped("favorite", "onFavoriteChanged")
+    m.itemData.observeFieldScoped("favoriteStatus", "onFavoriteChanged")
+    m.itemData.observeFieldScoped("playCount", "onPlayCountChanged")
+    onFavoriteChanged()
+    onPlayCountChanged()
+
+    itemData = m.itemData
 
     title = []
 
@@ -50,8 +86,35 @@ sub itemContentChanged()
         m.tracklength.text = ticksToHuman(itemData.LookupCI("RunTimeTicks"))
     end if
 
-    playCount = itemData.LookupCI("playCount")
-    if isValid(playCount)
-        m.playCount.text = `${playCount}`
+end sub
+
+sub onFavoriteChanged()
+    if not isValid(m.favoriteIcon) or not isValid(m.favoriteStatusUnknown) or not isValid(m.itemData) then return
+
+    itemFavoriteStatus = chainLookupReturn(m.itemData, "favoriteStatus", string.EMPTY)
+    if isStringEqual(itemFavoriteStatus, FavoriteStatus.UNKNOWN)
+        m.favoriteIcon.visible = false
+        m.favoriteStatusUnknown.visible = true
+        return
     end if
+
+    m.favoriteStatusUnknown.visible = false
+    if isStringEqual(itemFavoriteStatus, FavoriteStatus.FAVORITE)
+        m.favoriteIcon.visible = true
+        return
+    end if
+
+    if isStringEqual(itemFavoriteStatus, FavoriteStatus.NOT_FAVORITE)
+        m.favoriteIcon.visible = false
+        return
+    end if
+
+    m.favoriteIcon.visible = chainLookupReturn(m.itemData, "favorite", false)
+end sub
+
+sub onPlayCountChanged()
+    if not isValid(m.playCount) or not isValid(m.itemData) then return
+
+    playCount = chainLookupReturn(m.itemData, "playCount", invalid)
+    m.playCount.text = isValid(playCount) ? `${playCount}` : string.EMPTY
 end sub

--- a/components/music/SongItem.xml
+++ b/components/music/SongItem.xml
@@ -3,7 +3,11 @@
   <children>
     <LayoutGroup layoutDirection="horiz" horizAlignment="left" itemSpacings="[20]" translation="[0, 0]">
       <Text id="trackNumber" horizAlign="left" vertAlign="center" font="font:SmallSystemFont" width="80" height="50" />
-      <ScrollingText id="itemText" horizAlign="left" vertAlign="center" font="font:SmallSystemFont" maxWidth="1280" height="50" />
+      <Rectangle width="32" height="50" color="0x00000000">
+        <Poster id="favoriteIcon" translation="[2, 11]" uri="pkg:/images/icons/heart.png" width="28" height="28" visible="false" />
+        <Text id="favoriteStatusUnknown" horizAlign="center" vertAlign="center" font="font:SmallBoldSystemFont" width="32" height="50" text="?" visible="false" />
+      </Rectangle>
+      <ScrollingText id="itemText" horizAlign="left" vertAlign="center" font="font:SmallSystemFont" maxWidth="1238" height="50" />
       <Text id="tracklength" horizAlign="right" vertAlign="center" font="font:SmallSystemFont" width="120" height="50" />
       <Text id="playCount" horizAlign="right" vertAlign="center" font="font:SmallSystemFont" width="80" height="50" />
     </LayoutGroup>

--- a/components/music/task/LoadAlbumTask.bs
+++ b/components/music/task/LoadAlbumTask.bs
@@ -11,9 +11,9 @@ sub loadAlbum()
         "UserId": m.global.session.user.id,
         "parentId": m.top.id,
         "includeitemtypes": "Audio",
+        "enableUserData": true,
         "sortBy": "SortName"
     })
-
     results = []
     row = CreateObject("roSGNode", "ContentNode")
 
@@ -30,13 +30,6 @@ sub loadAlbum()
     for each item in data.Items
         tmp = CreateObject("roSGNode", "MusicSongData")
         tmp.id = item.LookupCI("id")
-        tmp.title = item.LookupCI("name")
-        tmp.type = item.LookupCI("type")
-        tmp.AlbumId = item.LookupCI("AlbumId")
-        tmp.ArtistItems = item.LookupCI("ArtistItems")
-        tmp.artists = item.LookupCI("artists")
-        tmp.RunTimeTicks = item.LookupCI("RunTimeTicks")
-        tmp.trackNumber = item.LookupCI("IndexNumber")
         tmp.playCount = chainLookupReturn(item, "UserData.PlayCount", 0)
         results.push(tmp)
     end for

--- a/source/MainActions.bs
+++ b/source/MainActions.bs
@@ -273,7 +273,10 @@ namespace MainAction
                 return
             end if
             if isStringEqual(group.subtype(), "albumView")
-                group.IsFavorite = true
+                pageItemID = chainLookupReturn(group, "pageContent.id", String.EMPTY)
+                if isStringEqual(pageItemID, itemID)
+                    group.IsFavorite = true
+                end if
             end if
         end if
     end sub
@@ -288,7 +291,10 @@ namespace MainAction
                 return
             end if
             if isStringEqual(group.subtype(), "albumView")
-                group.IsFavorite = false
+                pageItemID = chainLookupReturn(group, "pageContent.id", String.EMPTY)
+                if isStringEqual(pageItemID, itemID)
+                    group.IsFavorite = false
+                end if
             end if
         end if
     end sub

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -1,5 +1,6 @@
 import "pkg:/components/manager/ViewCreator.bs"
 import "pkg:/source/enums/CollectionType.bs"
+import "pkg:/source/enums/FavoriteStatus.bs"
 import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/enums/KeyCode.bs"
 import "pkg:/source/enums/MediaPlaybackState.bs"
@@ -1880,6 +1881,23 @@ sub processPlaylistPopup(selectedPopupButton as string, itemID as string)
     end if
 end sub
 
+sub updateAlbumTrackFavoriteState(itemID as string, isFavorite as boolean)
+    activeScene = m.global.sceneManager.callFunc("getActiveScene")
+    if not isValid(activeScene) or not isStringEqual(activeScene.subtype(), "AlbumView") then return
+
+    songList = activeScene.findNode("songList")
+    if not isValid(songList) or not isValid(songList.content) then return
+
+    for each song in songList.content.getChildren(-1, 0)
+        songID = chainLookupReturn(song, "id", String.EMPTY)
+        if isStringEqual(songID, itemID)
+            song.favorite = isFavorite
+            song.favoriteStatus = isFavorite ? FavoriteStatus.FAVORITE : FavoriteStatus.NOT_FAVORITE
+            return
+        end if
+    end for
+end sub
+
 sub processLibraryItemPopup(selectedPopupButton as string, itemID as string, params as object)
     if isStringEqual(selectedPopupButton, tr("Play Track"))
         quickplay.audio({
@@ -1967,11 +1985,13 @@ sub processLibraryItemPopup(selectedPopupButton as string, itemID as string, par
 
     if isStringEqual(selectedPopupButton, tr("Add To Favorites"))
         MainAction.addItemToFavorites(itemID)
+        updateAlbumTrackFavoriteState(itemID, true)
         return
     end if
 
     if isStringEqual(selectedPopupButton, tr("Remove From Favorites"))
         MainAction.removeItemFromFavorites(itemID)
+        updateAlbumTrackFavoriteState(itemID, false)
         return
     end if
 

--- a/source/api/FavoriteItems.bs
+++ b/source/api/FavoriteItems.bs
@@ -1,0 +1,46 @@
+import "pkg:/source/api/sdk.bs"
+import "pkg:/source/enums/FavoriteStatus.bs"
+import "pkg:/source/enums/String.bs"
+import "pkg:/source/utils/misc.bs"
+
+' Split large favorite-status lookups into manageable requests while still loading every track.
+const FAVORITE_LOOKUP_BATCH_SIZE = 50
+
+function GetFavoriteAudioItemStatuses(items as object, userID as string) as object
+    itemIDs = []
+    favoriteItemStatuses = {}
+    for each item in items
+        itemID = chainLookupReturn(item, "id", string.EMPTY)
+        if isValidAndNotEmpty(itemID)
+            itemIDs.push(itemID)
+            favoriteItemStatuses.AddReplace(itemID, FavoriteStatus.UNKNOWN)
+        end if
+    end for
+
+    if itemIDs.count() = 0 then return favoriteItemStatuses
+
+    for batchOffset = 0 to itemIDs.count() - 1 step FAVORITE_LOOKUP_BATCH_SIZE
+        batchIDs = itemIDs.slice(batchOffset, batchOffset + FAVORITE_LOOKUP_BATCH_SIZE)
+        favoriteData = api.items.Get({
+            UserId: userID,
+            Ids: batchIDs.join(","),
+            enableUserData: true
+        })
+
+        ' Leave only this batch unknown when its ID-scoped lookup fails.
+        if isChainValid(favoriteData, "Items")
+            for each itemID in batchIDs
+                favoriteItemStatuses.AddReplace(itemID, FavoriteStatus.NOT_FAVORITE)
+            end for
+
+            for each item in favoriteData.Items
+                itemID = chainLookupReturn(item, "id", string.EMPTY)
+                if isValidAndNotEmpty(itemID) and chainLookupReturn(item, "UserData.IsFavorite", false)
+                    favoriteItemStatuses.AddReplace(itemID, FavoriteStatus.FAVORITE)
+                end if
+            end for
+        end if
+    end for
+
+    return favoriteItemStatuses
+end function

--- a/source/api/Items.bs
+++ b/source/api/Items.bs
@@ -1,4 +1,6 @@
 import "pkg:/source/api/sdk.bs"
+import "pkg:/source/api/FavoriteItems.bs"
+import "pkg:/source/enums/FavoriteStatus.bs"
 import "pkg:/source/enums/PlaybackMethod.bs"
 import "pkg:/source/enums/SubtitleSelection.bs"
 
@@ -393,6 +395,7 @@ function GetSongsByArtist(id as string, params = {} as object)
         "UserId": m.global.session.user.id,
         "AlbumArtistIds": id,
         "includeitemtypes": "Audio",
+        "enableUserData": true,
         "sortBy": "SortName",
         "Recursive": true
     }
@@ -403,7 +406,7 @@ function GetSongsByArtist(id as string, params = {} as object)
     end for
 
     data = api.items.Get(paramArray)
-
+    favoriteItemStatuses = GetFavoriteAudioItemStatuses(chainLookupReturn(data, "Items", []), m.global.session.user.id)
     results = []
     row = CreateObject("roSGNode", "ContentNode")
 
@@ -417,6 +420,9 @@ function GetSongsByArtist(id as string, params = {} as object)
         tmp.type = item.LookupCI("type")
         tmp.RunTimeTicks = item.LookupCI("RunTimeTicks")
         tmp.trackNumber = item.LookupCI("IndexNumber")
+        itemFavoriteStatus = chainLookupReturn(favoriteItemStatuses, item.LookupCI("id"), FavoriteStatus.UNKNOWN)
+        tmp.favoriteStatus = itemFavoriteStatus
+        tmp.favorite = isStringEqual(itemFavoriteStatus, FavoriteStatus.FAVORITE)
         results.push(tmp)
     end for
 
@@ -493,11 +499,12 @@ function MusicSongList(id as string)
         "UserId": m.global.session.user.id,
         "parentId": id,
         "includeitemtypes": "Audio",
+        "enableUserData": true,
         "sortBy": "SortName"
     }
 
     data = api.items.Get(params)
-
+    favoriteItemStatuses = GetFavoriteAudioItemStatuses(chainLookupReturn(data, "Items", []), m.global.session.user.id)
     results = []
     row = CreateObject("roSGNode", "ContentNode")
 
@@ -515,6 +522,9 @@ function MusicSongList(id as string)
         tmp.RunTimeTicks = item.LookupCI("RunTimeTicks")
         tmp.trackNumber = item.LookupCI("IndexNumber")
         tmp.playCount = chainLookupReturn(item, "UserData.PlayCount", 0)
+        itemFavoriteStatus = chainLookupReturn(favoriteItemStatuses, item.LookupCI("id"), FavoriteStatus.UNKNOWN)
+        tmp.favoriteStatus = itemFavoriteStatus
+        tmp.favorite = isStringEqual(itemFavoriteStatus, FavoriteStatus.FAVORITE)
         results.push(tmp)
     end for
 

--- a/source/enums/FavoriteStatus.bs
+++ b/source/enums/FavoriteStatus.bs
@@ -1,0 +1,5 @@
+enum FavoriteStatus
+    FAVORITE = "favorite"
+    NOT_FAVORITE = "notFavorite"
+    UNKNOWN = "unknown"
+end enum

--- a/source/static/whatsNew/3.2.4.json
+++ b/source/static/whatsNew/3.2.4.json
@@ -18,5 +18,9 @@
   {
     "description": "Fix crash when pressing * on user select screen when no users are shown",
     "author": "1hitsong"
+  },
+  {
+    "description": "Add favorite indicators to album track lists",
+    "author": "VX-101"
   }
 ]


### PR DESCRIPTION
## Summary

Follow-up to PR #1001. Adds persistent favorite indicators to album track lists.

## Changes

- Show a persistent red heart beside favorite tracks while keeping track titles aligned.
- Show a red `?` when favorite status cannot be loaded, retaining a previously known state when available.
- Load ID-scoped favorite state in bounded batches of up to 50 tracks without limiting or truncating the visible track list, and continue processing later batches if one fails.
- Add `Add To Favorites` or `Remove From Favorites` to the existing track `*` menu while retaining `Add To Playlist`.

<img width="359" height="187" alt="pr1061-album-track-favorite-status-design-3-small" src="https://github.com/user-attachments/assets/8b04954e-12cc-412e-89ad-625d9c4cec69" />

## Follow-up

- Evaluate an alternate way to open track actions when Roku consumes the `*` button during music playback.

## Testing

- Ran `npm run build` successfully.
- Sideloaded local build `3.2.4.1061.0300`.
- Verified heart states persist after reopening the album, and focus returns to the same track after leaving the MiniPlayer.
- Verified Enter/OK playback and the track `*` menu, including `Add To Playlist`; Roku consumes `*` during playback.
- In combined build `3.2.4.9999.0298` with [PR #1001](https://github.com/jellyfin/jellyfin-roku/pull/1001), tested a possible follow-up for synchronizing MiniPlayer favorite changes with album-row hearts; it is not included here.
