### PR TITLE
Route Home Favorites View All tiles to their corresponding library views

### DIFF
--- a/components/Buttons/JFButtons.bs
+++ b/components/Buttons/JFButtons.bs
@@ -40,6 +40,7 @@ end sub
 ' When options are fully displayed, set focus and selected option
 sub renderChanged()
     if m.top.renderTracking = "full"
+        if m.buttonCount = 0 then return
         highlightSelected(m.selectedFocusedIndex, false)
         m.top.setfocus(true)
         group = m.global.sceneManager.callFunc("getActiveScene")
@@ -80,6 +81,7 @@ end sub
 sub highlightSelected(index as integer, animate = true)
 
     val = m.buttonGroup.getChild(index)
+    if not isValid(val) then return
     rect = val.ancestorBoundingRect(m.top)
 
     if animate = true

--- a/components/ItemGrid/ItemGridOptions.bs
+++ b/components/ItemGrid/ItemGridOptions.bs
@@ -16,14 +16,15 @@ sub init()
     background.blendColor = ColorPalette.LIGHTGREY
 
     m.buttons = m.top.findNode("buttons")
-    m.buttons.buttons = [tr("TAB_VIEW"), tr("TAB_SORT"), tr("TAB_FILTER")]
-    m.buttons.selectedIndex = MenuType.SORT
+    m.buttons.visible = false
 
     m.favoriteMenu = m.top.findNode("favoriteMenu")
     m.selectedFavoriteItem = m.top.findNode("selectedFavoriteItem")
 
     m.selectedSortIndex = 0
     m.selectedItem = MenuType.SORT
+    m.availableMenus = []
+    m.menuButtonsConfigured = false
 
     viewMenu = m.top.findNode("viewMenu")
     viewMenu.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
@@ -68,6 +69,50 @@ sub init()
 
     m.buttons.observeField("focusedIndex", "buttonFocusChanged")
     m.favoriteMenu.observeField("buttonSelected", "toggleFavorite")
+end sub
+
+function menuHasItems(menuIndex as integer) as boolean
+    menu = m.menus[menuIndex]
+    if not isChainValid(menu, "content") then return false
+    return menu.content.getChildCount() > 0
+end function
+
+sub configureMenuButtons()
+    if m.menuButtonsConfigured then return
+
+    ' Show tabs only for menus with choices.
+    buttonLabels = []
+    availableMenus = []
+
+    if menuHasItems(MenuType.VIEW)
+        buttonLabels.push(tr("TAB_VIEW"))
+        availableMenus.push(MenuType.VIEW)
+    end if
+    if menuHasItems(MenuType.SORT)
+        buttonLabels.push(tr("TAB_SORT"))
+        availableMenus.push(MenuType.SORT)
+    end if
+    if menuHasItems(MenuType.FILTER)
+        buttonLabels.push(tr("TAB_FILTER"))
+        availableMenus.push(MenuType.FILTER)
+    end if
+
+    if availableMenus.Count() = 0 then return
+
+    selectedButtonIndex = 0
+    for i = 0 to availableMenus.Count() - 1
+        if availableMenus[i] = MenuType.SORT
+            selectedButtonIndex = i
+            exit for
+        end if
+    end for
+
+    m.availableMenus = availableMenus
+    m.selectedItem = availableMenus[selectedButtonIndex]
+    m.buttons.selectedIndex = selectedButtonIndex
+    m.buttons.buttons = buttonLabels
+    m.buttons.visible = true
+    m.menuButtonsConfigured = true
 end sub
 
 sub showChecklist()
@@ -207,11 +252,17 @@ sub optionsSet()
         m.menus[2].content = filterContent
         m.menus[2].checkedItem = 0
     end if
+
+    configureMenuButtons()
 end sub
 
 ' Switch menu shown when button focus changes
 sub buttonFocusChanged()
-    if m.buttons.focusedIndex = m.selectedItem
+    focusedButtonIndex = m.buttons.focusedIndex
+    if focusedButtonIndex < 0 or focusedButtonIndex >= m.availableMenus.Count() then return
+
+    focusedMenu = m.availableMenus[focusedButtonIndex]
+    if focusedMenu = m.selectedItem
         if m.buttons.hasFocus()
             m.buttons.setFocus(false)
             m.menus[m.selectedItem].setFocus(false)
@@ -222,9 +273,9 @@ sub buttonFocusChanged()
         end if
     end if
     m.fadeOutAnimOpacity.fieldToInterp = m.menus[m.selectedItem].id + ".opacity"
-    m.fadeInAnimOpacity.fieldToInterp = m.menus[m.buttons.focusedIndex].id + ".opacity"
+    m.fadeInAnimOpacity.fieldToInterp = m.menus[focusedMenu].id + ".opacity"
     m.fadeAnim.control = AnimationControl.START
-    m.selectedItem = m.buttons.focusedIndex
+    m.selectedItem = focusedMenu
 end sub
 
 sub toggleFavorite()

--- a/components/ItemGrid/LoadItemsTask2.bs
+++ b/components/ItemGrid/LoadItemsTask2.bs
@@ -22,28 +22,30 @@ function loadFavoriteViewAllItems(params as object) as dynamic
     isArtistQuery = isStringEqual(queryType, ItemType.MUSICARTIST)
     useLocalAlphaFilter = isLocalHashFilter or (isValidAndNotEmpty(nameStartsWith) and not isArtistQuery)
     useLocalPaging = isPeopleQuery or useLocalAlphaFilter
+    isBoundedPeopleQuery = isPeopleQuery and not useLocalAlphaFilter
 
     if useLocalPaging
         params.Delete("NameStartsWith")
         params.Delete("NameLessThan")
         params.Delete("NameStartsWithOrGreater")
         params.Delete("StartIndex")
-        params.Delete("limit")
+        if isBoundedPeopleQuery
+            ' People lacks start-index paging. Fetch only the prefix needed for this page.
+            params.limit = requestedStartIndex + requestedLimit
+        else
+            params.Delete("limit")
+        end if
     end if
 
     params.Delete("parentid")
     params.Delete("IncludeItemTypes")
     params.UserId = m.global.session.user.id
     params.recursive = true
-    params.Filters = "IsFavorite"
-    params.IsFavorite = true
-
     if not useLocalPaging
         return fetchFavoriteViewAllItems(params, queryType, includeItemTypes)
     end if
 
-    ' People do not support a server start index, and local alpha filtering needs the whole
-    ' favorites list. Cache that list so follow-up pages can be sliced locally.
+    ' Cache locally paged results so follow-up pages can reuse a complete list or prefix.
     cacheKey = FormatJson({
         queryType: queryType,
         includeItemTypes: includeItemTypes,
@@ -51,10 +53,21 @@ function loadFavoriteViewAllItems(params as object) as dynamic
         nameLessThan: nameLessThan,
         sortBy: chainLookupReturn(params, "SortBy", string.EMPTY),
         sortOrder: chainLookupReturn(params, "SortOrder", string.EMPTY),
-        searchTerm: chainLookupReturn(params, "searchTerm", string.EMPTY)
+        searchTerm: chainLookupReturn(params, "searchTerm", string.EMPTY),
+        filters: chainLookupReturn(params, "Filters", string.EMPTY)
     })
 
-    if requestedStartIndex > 0 and isChainValid(m.favoriteViewAllAlphaCache, "data") and isStringEqual(chainLookupReturn(m.favoriteViewAllAlphaCache, "key", string.EMPTY), cacheKey)
+    useCachedData = requestedStartIndex > 0 and isChainValid(m.favoriteViewAllAlphaCache, "data") and isStringEqual(chainLookupReturn(m.favoriteViewAllAlphaCache, "key", string.EMPTY), cacheKey)
+    if useCachedData and isBoundedPeopleQuery
+        cachedCount = chainLookupReturn(m.favoriteViewAllAlphaCache, "data.Items", []).Count()
+        cachedTotal = chainLookupReturn(m.favoriteViewAllAlphaCache, "data.TotalRecordCount", invalid)
+        requestedCount = requestedStartIndex + requestedLimit
+        cacheIsComplete = false
+        if isValid(cachedTotal) then cacheIsComplete = cachedCount >= cachedTotal
+        useCachedData = cachedCount >= requestedCount or cacheIsComplete
+    end if
+
+    if useCachedData
         data = m.favoriteViewAllAlphaCache.data
     else
         data = fetchFavoriteViewAllItems(params, queryType, includeItemTypes)
@@ -281,21 +294,21 @@ sub loadItems()
     else if isStringEqual(m.top.view, "Genres")
         url = "Genres"
         params.append({ UserId: m.global.session.user.id, includeItemTypes: m.top.itemType })
-    else if m.top.ItemType = "MusicArtist"
+    else if isStringEqual(m.top.ItemType, ItemType.MUSICARTIST)
         url = "Artists"
         params.append({
             UserId: m.global.session.user.id,
             Fields: "Genres"
         })
         params.IncludeItemTypes = "MusicAlbum,Audio"
-    else if m.top.ItemType = "AlbumArtists"
+    else if isStringEqual(m.top.ItemType, "AlbumArtists")
         url = "Artists/AlbumArtists"
         params.append({
             UserId: m.global.session.user.id,
             Fields: "Genres"
         })
         params.IncludeItemTypes = "MusicAlbum,Audio"
-    else if m.top.ItemType = "MusicAlbum"
+    else if isStringEqual(m.top.ItemType, ItemType.MUSICALBUM)
         url = "Items"
         params.append({ ImageTypeLimit: 1, UserId: m.global.session.user.id })
         ' Request Primary artwork (album cover) and Backdrop as fallback
@@ -511,20 +524,33 @@ sub loadItems()
 
                 else if item.Type = "Studio"
                     tmp = CreateObject("roSGNode", "FolderData")
-                else if item.Type = "MusicAlbum"
+                else if isStringEqual(item.Type, ItemType.MUSICALBUM)
                     tmp = CreateObject("roSGNode", "MusicAlbumData")
                     tmp.type = "MusicAlbum"
                     if isChainValid(item, "ImageTags.Primary")
                         tmp.posterURL = ImageURL(item.id, "Primary")
                     end if
-                else if item.Type = "MusicArtist"
+                else if isStringEqual(item.Type, ItemType.MUSICARTIST)
                     tmp = CreateObject("roSGNode", "MusicArtistData")
                 else if isStringEqual(item.Type, ItemType.PERSON)
                     tmp = CreateObject("roSGNode", "PersonData")
-                else if item.Type = "Audio"
+                else if isStringEqual(item.Type, ItemType.AUDIO)
                     tmp = CreateObject("roSGNode", "MusicSongData")
                     tmp.type = "Audio"
-                    tmp.image = api.items.GetImageURL(item.id, "primary", 0, { "maxHeight": 280, "maxWidth": 280, "quality": "90" })
+                    albumId = chainLookupReturn(item, "AlbumId", chainLookupReturn(item, "ParentId", string.EMPTY))
+                    albumPrimaryImageTag = chainLookupReturn(item, "AlbumPrimaryImageTag", string.EMPTY)
+                    itemPrimaryImageTag = chainLookupReturn(item, "ImageTags.Primary", string.EMPTY)
+                    imageParams = { "maxHeight": 280, "maxWidth": 280, "quality": "90" }
+
+                    if isValidAndNotEmpty(albumId) and isValidAndNotEmpty(albumPrimaryImageTag)
+                        imageParams.tag = albumPrimaryImageTag
+                        tmp.posterURL = api.items.GetImageURL(albumId, ImageType.PRIMARY, 0, imageParams)
+                    else if isValidAndNotEmpty(itemPrimaryImageTag)
+                        imageParams.tag = itemPrimaryImageTag
+                        tmp.posterURL = api.items.GetImageURL(item.id, ImageType.PRIMARY, 0, imageParams)
+                    else
+                        tmp.posterURL = "pkg:/images/icons/album.png"
+                    end if
                 else if item.Type = "MusicGenre"
                     tmp = CreateObject("roSGNode", "FolderData")
                     tmp.title = item.name

--- a/components/Libraries/LiveTVLibraryView.bs
+++ b/components/Libraries/LiveTVLibraryView.bs
@@ -16,6 +16,7 @@ const ASPECT_RATIO_LANDSCAPE_WITH_TITLE = .925
 sub init()
     m.top.imageDisplayMode = "scaleToZoom"
     m.top.showItemTitles = "showonhover"
+    m.favoriteViewAllInitialized = false
 
     overhang = m.top.getScene().findNode("overhang")
     overhang.isVisible = false
@@ -105,23 +106,47 @@ sub loadInitialItems()
         m.top.HomeLibraryItem = m.top.parentItem.Id
     end if
 
+    ' Keep shortcut state separate from Live TV settings.
+    m.settingID = isFavoriteViewAll() ? m.top.parentItem.Id : "livetv"
+    settingPrefix = `display.${m.settingID}`
+    favoriteViewAll = isFavoriteViewAll()
+
     ' Read view/sort/filter settings
     ' Translate between app and server nomenclature
-    viewSetting = m.global.session.user.settings["display.livetv.landing"]
-    if viewSetting = "guide"
-        m.view = "tvGuide"
-    else
-        m.view = "livetv"
-        if isValid(m.tvGuide)
-            m.tvGuide.opacity = 0
+    if not favoriteViewAll
+        userSettings = chainLookupReturn(m.global.session, "user.settings", {})
+        viewSetting = userSettings[settingPrefix + ".landing"]
+        if isStringEqual(viewSetting, "guide")
+            m.view = "tvGuide"
+        else
+            m.view = "livetv"
+            if isValid(m.tvGuide)
+                m.tvGuide.opacity = 0
+            end if
+            m.alpha.visible = true
+            m.itemGrid.opacity = 1
         end if
-        m.alpha.visible = true
-        m.itemGrid.opacity = 1
+        m.sortField = userSettings[settingPrefix + ".sortField"]
+        m.sortAscending = userSettings[settingPrefix + ".sortAscending"]
+        m.filter = userSettings[settingPrefix + ".filter"]
     end if
-    m.sortField = chainLookupReturn(m.global.session, "user.settings.`display.livetv.sortField`", "SortName")
-    m.sortAscending = chainLookupReturn(m.global.session, "user.settings.`display.livetv.sortAscending`", true)
-    m.filter = m.global.session.user.settings["display.livetv.filter"]
 
+    ' Seed once; preserve later All/Favorites changes.
+    if favoriteViewAll and not m.favoriteViewAllInitialized
+        m.view = "livetv"
+        m.sortField = chainLookupReturn(m.top.parentItem, "json.SortBy", "SortName")
+        m.sortAscending = isStringEqual(chainLookupReturn(m.top.parentItem, "json.SortOrder", "Ascending"), "Ascending")
+        m.filter = "Favorites"
+        m.favoriteViewAllInitialized = true
+    end if
+
+    if not isValidAndNotEmpty(m.sortField) then m.sortField = "SortName"
+    if not isValid(m.sortAscending) then m.sortAscending = true
+    if isStringEqual(type(m.sortAscending), "roString")
+        m.sortAscending = isStringEqual(m.sortAscending, "true")
+    else if not isStringEqual(type(m.sortAscending), "roBoolean")
+        m.sortAscending = true
+    end if
     if not isValidAndNotEmpty(m.filter) then m.filter = "All"
 
     m.loadItemsTask.itemId = m.top.parentItem.Id
@@ -141,13 +166,13 @@ sub loadInitialItems()
     m.loadItemsTask.filter = m.filter
     m.loadItemsTask.startIndex = 0
 
-    ' Load Item Types
+    ' Blank parent queries all channels; filter applies Favorites or All.
     m.loadItemsTask.itemType = "TvChannel"
     m.loadItemsTask.itemId = " "
     ' For LiveTV, we want to "Fit" the item images, not zoom
     m.top.imageDisplayMode = "scaleToFit"
 
-    if m.global.session.user.settings["display.livetv.landing"] = "guide" and m.options.view <> "livetv"
+    if isStringEqual(m.view, "tvGuide") and m.options.view <> "livetv"
         showTvGuide()
     end if
 
@@ -191,10 +216,11 @@ end sub
 
 ' Set Live TV view, sort, and filter options
 sub setLiveTvOptions(options)
-    options.views = [
-        { "Title": tr("Channels"), "Name": "livetv" },
-        { "Title": tr("TV Guide"), "Name": "tvGuide" }
-    ]
+    options.views = [{ "Title": tr("Channels"), "Name": "livetv" }]
+    ' TV Guide cannot preserve the shortcut filter.
+    if not isFavoriteViewAll()
+        options.views.push({ "Title": tr("TV Guide"), "Name": "tvGuide" })
+    end if
     options.sort = [
         { "Title": tr("TITLE"), "Name": "SortName" },
         { "Title": tr("RECENTLY_WATCHED"), "Name": "DatePlayed" }
@@ -217,6 +243,15 @@ function getCollectionType() as string
     end if
 end function
 
+function isFavoriteViewAll() as boolean
+    return chainLookupReturn(m.top.parentItem, "json.FavoriteViewAll", false)
+end function
+
+sub setLibraryUserSetting(settingName as string, value)
+    if isFavoriteViewAll() then return
+    set_user_setting(`display.${m.settingID}.${settingName}`, value)
+end sub
+
 ' Search string array for search value. Return if it's found
 function inStringArray(array, searchValue) as boolean
     for each item in array
@@ -232,6 +267,10 @@ sub SetUpOptions()
     options.favorite = []
 
     setLiveTvOptions(options)
+
+    if isFavoriteViewAll() and isChainValid(options, "sort")
+        m.sortField = getMatchingSortField(m.sortField, options.sort)
+    end if
 
     ' Set selected view option
     for each o in options.views
@@ -281,7 +320,7 @@ sub ItemDataLoaded(msg)
         group = m.global.sceneManager.callFunc("getActiveScene")
         group.lastFocus = m.alphaMenu
     else
-        if not isStringEqual(m.global.session.user.settings["display.livetv.landing"], "guide") or isStringEqual(m.options.view, "livetv")
+        if not isStringEqual(m.view, "tvGuide") or isStringEqual(m.options.view, "livetv")
             m.itemGrid.setFocus(true)
             group = m.global.sceneManager.callFunc("getActiveScene")
             group.lastFocus = m.itemGrid
@@ -305,7 +344,7 @@ sub ItemDataLoaded(msg)
         m.emptyText.visible = true
     end if
 
-    if not isStringEqual(m.global.session.user.settings["display.livetv.landing"], "guide") or isStringEqual(m.options.view, "livetv")
+    if not isStringEqual(m.view, "tvGuide") or isStringEqual(m.options.view, "livetv")
         stopLoadingSpinner()
     end if
 end sub
@@ -403,12 +442,12 @@ sub optionsClosed()
     if not isStringEqual(m.options.view, m.view)
         if isStringEqual(m.options.view, "tvGuide")
             m.view = "tvGuide"
-            set_user_setting("display.livetv.landing", "guide")
+            setLibraryUserSetting("landing", "guide")
             showTVGuide()
             return
         else
             m.view = "livetv"
-            set_user_setting("display.livetv.landing", "channels")
+            setLibraryUserSetting("landing", "channels")
             m.alpha.visible = true
             m.itemGrid.opacity = 1
 
@@ -424,8 +463,8 @@ sub optionsClosed()
         m.sortAscending = m.options.sortAscending
         reload = true
 
-        set_user_setting("display.livetv.sortField", m.sortField)
-        set_user_setting("display.livetv.sortAscending", m.sortAscending.tostr())
+        setLibraryUserSetting("sortField", m.sortField)
+        setLibraryUserSetting("sortAscending", m.sortAscending.toStr())
     end if
 
     ' Check if filter option changed
@@ -433,7 +472,7 @@ sub optionsClosed()
         m.filter = m.options.filter
         reload = true
         'Store filter setting
-        set_user_setting("display.livetv.filter", m.options.filter)
+        setLibraryUserSetting("filter", m.options.filter)
     end if
 
     if reload

--- a/components/Libraries/MusicLibraryView.bs
+++ b/components/Libraries/MusicLibraryView.bs
@@ -16,6 +16,7 @@ import "pkg:/source/utils/deviceCapabilities.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub setupNodes()
+    m.favoriteViewAllInitialized = false
     m.toggleDropdownOptionsAnimation = m.top.findNode("toggleDropdownOptionsAnimation")
     m.dropdownOptionsMove = m.top.findNode("dropdownOptionsMove")
     m.itemGridMove = m.top.findNode("itemGridMove")
@@ -163,7 +164,7 @@ sub onSortChange(sortChoice)
     m.dropdownOptionGroup@.setSortAscending(true)
     m.sortAscending = true
 
-    set_user_setting("display." + m.settingID + ".sortField", m.sortField)
+    setLibraryUserSetting("sortField", m.sortField)
 
     m.loadedRows = 0
     m.loadedItems = 0
@@ -183,7 +184,7 @@ sub onViewChange(viewChoice)
     m.view = viewChoice.LookupCI("name")
     m.dropdownOptionGroup@.setText("viewButton", tr(viewChoice.LookupCI("title")))
 
-    set_user_setting("display." + m.settingID + ".landing", m.view)
+    setLibraryUserSetting("landing", m.view)
 
     ' Reset any filtering or search terms
     m.bypassSearchEvent = true
@@ -191,16 +192,16 @@ sub onViewChange(viewChoice)
     m.top.alphaSelected = string.EMPTY
     m.loadItemsTask.NameStartsWith = " "
     m.loadItemsTask.searchTerm = string.EMPTY
-    m.filter = "All"
+    if not isFavoriteViewAll() then m.filter = "All"
     m.filterOptions = {}
     m.sortField = "SortName"
     m.sortAscending = true
 
     ' Reset view to defaults
-    set_user_setting("display." + m.settingID + ".sortField", m.sortField)
-    set_user_setting("display." + m.settingID + ".sortAscending", "true")
-    set_user_setting("display." + m.settingID + ".filter", m.filter)
-    set_user_setting("display." + m.settingID + ".filterOptions", FormatJson(m.filterOptions))
+    setLibraryUserSetting("sortField", m.sortField)
+    setLibraryUserSetting("sortAscending", "true")
+    setLibraryUserSetting("filter", m.filter)
+    setLibraryUserSetting("filterOptions", FormatJson(m.filterOptions))
 
     m.getFiltersTask.control = "RUN"
 
@@ -223,7 +224,7 @@ sub onSortOrderChange(sortOrderChoice)
     m.dropdownOptionGroup@.setSortAscending(m.sortAscending)
     m.dropdownOptionGroup@.setText("sortOrderButton", tr(sortOrderChoice.LookupCI("title")))
 
-    set_user_setting("display." + m.settingID + ".sortAscending", m.sortAscending.toStr())
+    setLibraryUserSetting("sortAscending", m.sortAscending.toStr())
 
     m.loadedRows = 0
     m.loadedItems = 0
@@ -274,11 +275,22 @@ sub loadInitialItems()
         m.settingID = m.top.parentItem.Id
     end if
 
-    m.sortField = m.global.session.user.settings["display." + m.settingID + ".sortField"]
-    m.sortAscending = m.global.session.user.settings["display." + m.settingID + ".sortAscending"]
-    m.filter = m.global.session.user.settings["display." + m.settingID + ".filter"]
-    m.filterOptions = m.global.session.user.settings["display." + m.settingID + ".filterOptions"]
-    m.view = m.global.session.user.settings["display." + m.settingID + ".landing"]
+    if not isFavoriteViewAll()
+        m.sortField = m.global.session.user.settings["display." + m.settingID + ".sortField"]
+        m.sortAscending = m.global.session.user.settings["display." + m.settingID + ".sortAscending"]
+        m.filter = m.global.session.user.settings["display." + m.settingID + ".filter"]
+        m.filterOptions = m.global.session.user.settings["display." + m.settingID + ".filterOptions"]
+        m.view = m.global.session.user.settings["display." + m.settingID + ".landing"]
+    end if
+
+    if isFavoriteViewAll() and not m.favoriteViewAllInitialized
+        m.sortField = chainLookupReturn(m.top.parentItem, "json.SortBy", "SortName")
+        m.sortAscending = isStringEqual(chainLookupReturn(m.top.parentItem, "json.SortOrder", "Ascending"), "Ascending")
+        m.filter = "Favorites"
+        m.filterOptions = "{}"
+        m.view = chainLookupReturn(m.top.parentItem, "json.LibraryViewInitialView", "ArtistsPresentation")
+        m.favoriteViewAllInitialized = true
+    end if
 
     if not isValidAndNotEmpty(m.sortField) then m.sortField = "SortName"
     if not isValidAndNotEmpty(m.filter) then m.filter = "All"
@@ -294,7 +306,9 @@ sub loadInitialItems()
         if not isStringEqual(m.view, "albums") then m.view = "albums"
     end if
 
-    m.filterOptions = ParseJson(m.filterOptions)
+    if inArray(["roString", "String"], type(m.filterOptions))
+        m.filterOptions = ParseJson(m.filterOptions)
+    end if
 
     m.top.showItemTitles = m.global.session.user.settings["itemgrid.gridTitles"]
 
@@ -339,6 +353,12 @@ sub loadInitialItems()
     if isStringEqual(m.view, "albums")
         m.loadItemsTask.itemType = "MusicAlbum"
         m.top.imageDisplayMode = "scaleToFit"
+    else if isStringEqual(m.view, "songs")
+        m.loadItemsTask.itemType = ItemType.AUDIO
+        m.top.imageDisplayMode = "scaleToFit"
+    else if isStringEqual(m.view, "playlists")
+        m.loadItemsTask.itemType = ItemType.PLAYLIST
+        m.top.imageDisplayMode = "scaleToFit"
     else if isStringEqual(m.view, "albumartistsgrid")
         m.loadItemsTask.itemType = "AlbumArtists"
     else if isStringEqual(m.view, "albumartistspresentation")
@@ -354,7 +374,10 @@ sub loadInitialItems()
         end if
         m.dropdownOptionsMove.keyValue = "[[100, 540], [100, 480]]"
         m.itemGridMove.keyValue = "[[100, 670], [100, 520]]"
+    else if isStringEqual(m.view, "artistsgrid")
+        m.loadItemsTask.itemType = ItemType.MUSICARTIST
     else if isStringEqual(m.view, "ArtistsPresentation")
+        m.loadItemsTask.itemType = ItemType.MUSICARTIST
         m.emptyText.translation = "[0, 750]"
         m.itemGrid.translation = "[100, 670]"
         m.itemGrid.numRows = "2"
@@ -374,6 +397,17 @@ sub loadInitialItems()
         m.selectedArtistName.visible = false
     end if
 
+    if isFavoriteViewAll()
+        m.loadItemsTask.itemId = string.EMPTY
+        m.loadItemsTask.recursive = true
+        m.loadItemsTask.genreIds = string.EMPTY
+        m.loadItemsTask.metadata = {
+            favoriteViewAll: true,
+            includeItemTypes: m.loadItemsTask.itemType,
+            queryType: m.loadItemsTask.itemType
+        }
+    end if
+
     setColumnSizes()
 
     m.loadItemsTask.control = TaskControl.RUN
@@ -381,7 +415,7 @@ sub loadInitialItems()
     m.getFiltersTask.observeField("filters", "FilterDataLoaded")
     m.getFiltersTask.params = {
         userid: m.global.session.user.id,
-        parentid: m.top.parentItem.Id
+        parentid: getLibraryQueryParentId()
     }
     m.getFiltersTask.control = TaskControl.RUN
 end sub
@@ -425,7 +459,7 @@ sub onOptionsVisibleChange()
     if m.options.filter <> m.filter
         m.filter = m.options.filter
         reload = true
-        set_user_setting("display." + m.settingID + ".filter", m.options.filter)
+        setLibraryUserSetting("filter", m.options.filter)
     end if
 
     if not isValid(m.options.filterOptions)
@@ -435,7 +469,7 @@ sub onOptionsVisibleChange()
     if not AssocArrayEqual(m.options.filterOptions, m.filterOptions)
         m.filterOptions = m.options.filterOptions
         reload = true
-        set_user_setting("display." + m.settingID + ".filterOptions", FormatJson(m.options.filterOptions))
+        setLibraryUserSetting("filterOptions", FormatJson(m.options.filterOptions))
     end if
 
     if reload
@@ -466,13 +500,13 @@ sub FilterDataLoaded(msg)
     if not isValid(data) then return
 
     ' Add Music filters from the API data
-    if inArray(["musicartist", "albumartists"], LCase(m.loadItemsTask.itemType))
+    if not isFavoriteViewAll() and inArray(["musicartist", "albumartists"], LCase(m.loadItemsTask.itemType))
         if isValid(data.genres)
             options.filter.push({ "Title": tr("Genres"), "Name": "Genres", "Options": data.genres, "Delimiter": "|", "CheckedState": [] })
         end if
     end if
 
-    if LCase(m.loadItemsTask.itemType) = "musicalbum"
+    if not isFavoriteViewAll() and isStringEqual(m.loadItemsTask.itemType, ItemType.MUSICALBUM)
         if isValid(data.genres)
             options.filter.push({ "Title": tr("Genres"), "Name": "Genres", "Options": data.genres, "Delimiter": "|", "CheckedState": [] })
         end if
@@ -488,6 +522,10 @@ end sub
 
 ' Data to display when options button selected
 sub setSelectedOptions(options)
+
+    if isFavoriteViewAll() and isChainValid(options, "sort")
+        m.sortField = getMatchingSortField(m.sortField, options.sort)
+    end if
 
     ' Set selected view option
     for each o in options.views
@@ -549,14 +587,34 @@ function setMusicOptions() as object
         filter: []
     }
 
-    options.views = [
-        { "Title": tr("Artists (Presentation)"), "Name": "ArtistsPresentation", "Track": { "description": tr("Artists (Presentation)") } },
-        { "Title": tr("Artists (Grid)"), "Name": "ArtistsGrid", "Track": { "description": tr("Artists (Grid)") } },
-        { "Title": tr("Album Artists (Presentation)"), "Name": "AlbumArtistsPresentation", "Track": { "description": tr("Album Artists (Presentation)") } },
-        { "Title": tr("Album Artists (Grid)"), "Name": "AlbumArtistsGrid", "Track": { "description": tr("Album Artists (Grid)") } },
-        { "Title": tr("Albums"), "Name": "Albums", "Track": { "description": tr("Albums") } },
-        { "Title": tr("Genres"), "Name": "Genres", "Track": { "description": tr("Genres") } }
-    ]
+    if isFavoriteViewAll()
+        favoriteItemType = chainLookupReturn(m.top.parentItem, "json.QueryType", string.EMPTY)
+        if not isValidAndNotEmpty(favoriteItemType)
+            favoriteItemType = chainLookupReturn(m.top.parentItem, "json.IncludeItemTypes", string.EMPTY)
+        end if
+
+        if isStringEqual(favoriteItemType, ItemType.MUSICARTIST)
+            options.views = [
+                { "Title": tr("Artists (Presentation)"), "Name": "ArtistsPresentation", "Track": { "description": tr("Artists (Presentation)") } },
+                { "Title": tr("Artists (Grid)"), "Name": "ArtistsGrid", "Track": { "description": tr("Artists (Grid)") } }
+            ]
+        else if isStringEqual(favoriteItemType, ItemType.MUSICALBUM)
+            options.views = [{ "Title": tr("Albums"), "Name": "Albums", "Track": { "description": tr("Albums") } }]
+        else if isStringEqual(favoriteItemType, ItemType.AUDIO)
+            options.views = [{ "Title": tr("Songs"), "Name": "Songs", "Track": { "description": tr("Songs") } }]
+        else if isStringEqual(favoriteItemType, ItemType.PLAYLIST)
+            options.views = [{ "Title": tr("Playlists"), "Name": "Playlists", "Track": { "description": tr("Playlists") } }]
+        end if
+    else
+        options.views = [
+            { "Title": tr("Artists (Presentation)"), "Name": "ArtistsPresentation", "Track": { "description": tr("Artists (Presentation)") } },
+            { "Title": tr("Artists (Grid)"), "Name": "ArtistsGrid", "Track": { "description": tr("Artists (Grid)") } },
+            { "Title": tr("Album Artists (Presentation)"), "Name": "AlbumArtistsPresentation", "Track": { "description": tr("Album Artists (Presentation)") } },
+            { "Title": tr("Album Artists (Grid)"), "Name": "AlbumArtistsGrid", "Track": { "description": tr("Album Artists (Grid)") } },
+            { "Title": tr("Albums"), "Name": "Albums", "Track": { "description": tr("Albums") } },
+            { "Title": tr("Genres"), "Name": "Genres", "Track": { "description": tr("Genres") } }
+        ]
+    end if
 
     options.sort = [
         { "Title": tr("TITLE"), "Name": "SortName", "Track": { "description": tr("TITLE") } },
@@ -615,6 +673,20 @@ function getCollectionType() as string
     else
         return LCase(m.top.parentItem.CollectionType)
     end if
+end function
+
+function isFavoriteViewAll() as boolean
+    return chainLookupReturn(m.top.parentItem, "json.FavoriteViewAll", false)
+end function
+
+sub setLibraryUserSetting(settingName as string, value)
+    if isFavoriteViewAll() then return
+    set_user_setting(`display.${m.settingID}.${settingName}`, value)
+end sub
+
+function getLibraryQueryParentId() as string
+    if isFavoriteViewAll() then return string.EMPTY
+    return m.top.parentItem.Id
 end function
 
 '
@@ -780,7 +852,7 @@ sub onItemFocused()
 
     m.selectedFavoriteItem = getItemFocused()
 
-    if isStringEqual(m.view, "albums") or isStringEqual(m.top.parentItem.json.type, "musicgenre")
+    if inArray(["albums", "songs", "playlists"], LCase(m.view)) or isStringEqual(m.top.parentItem.json.type, "musicgenre")
         return
     end if
 
@@ -947,7 +1019,7 @@ sub setDropdownDisabledState(disabledState = false as boolean)
 end sub
 
 sub resetDropdownsToDefaultState()
-    m.filter = "All"
+    if not isFavoriteViewAll() then m.filter = "All"
     m.filterOptions = {}
     if isStringEqual(getCollectionType(), ItemType.BOXSET)
         m.sortField = "PremiereDate,SortName"
@@ -959,12 +1031,12 @@ sub resetDropdownsToDefaultState()
     m.sortAscending = true
 
     ' Reset view to defaults
-    set_user_setting("display." + m.settingID + ".sortField", m.sortField)
-    set_user_setting("display." + m.settingID + ".sortAscending", "true")
-    set_user_setting("display." + m.settingID + ".filter", m.filter)
-    set_user_setting("display." + m.settingID + ".filterOptions", FormatJson(m.filterOptions))
+    setLibraryUserSetting("sortField", m.sortField)
+    setLibraryUserSetting("sortAscending", "true")
+    setLibraryUserSetting("filter", m.filter)
+    setLibraryUserSetting("filterOptions", FormatJson(m.filterOptions))
 
-    if not isStringEqual(m.view, "Genres")
+    if not isFavoriteViewAll() and not isStringEqual(m.view, "Genres")
         set_user_setting(`display.${m.top.mediaType}library.defaultview`, m.view)
     end if
 
@@ -1083,7 +1155,8 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     if isStringEqual(key, KeyCode.OPTIONS)
         focusedItem = getItemFocused()
-        if not isValid(focusedItem) then return false
+        ' Consume Options until the grid has a focused item.
+        if not isValid(focusedItem) then return true
 
         popupTitle = focusedItem.LookupCI("title")
 

--- a/components/Libraries/OtherLibrary.bs
+++ b/components/Libraries/OtherLibrary.bs
@@ -21,6 +21,7 @@ const ASPECT_RATIO_LANDSCAPE_WITH_TITLE = .66307
 sub init()
     m.top.imageDisplayMode = "scaleToZoom"
     m.top.showItemTitles = chainLookupReturn(m.global.session, "user.settings.`itemgrid.gridTitles`", "showonhover")
+    m.favoriteViewAllInitialized = false
 
     m.loadItemsTask1 = createObject("roSGNode", "LoadItemsTask")
 
@@ -77,13 +78,7 @@ sub init()
     m.getFiltersTask = createObject("roSGNode", "GetFiltersTask")
     m.getPlaylistDataTask = createObject("roSGNode", "GetPlaylistDataTask")
 
-    posterOrientation = chainLookupReturn(m.global, "session.user.settings.libraryPosterOrientation", ImageLayout.DEFAULT)
-
-    if isStringEqual(posterOrientation, ImageLayout.DEFAULT)
-        setColumnSizes(ImageLayout.PORTRAIT)
-    else
-        setColumnSizes(posterOrientation)
-    end if
+    setConfiguredColumnSizes()
 
     'set inital counts for overhang before content is loaded.
     m.loadItemsTask.observeField("content", "ItemDataLoaded")
@@ -116,6 +111,16 @@ sub createItemGrid()
     m.itemGrid.observeField("itemSelected", "onItemSelected")
     m.itemGrid.content = m.data
     m.itemGrid.setFocus(true)
+end sub
+
+sub setConfiguredColumnSizes()
+    posterOrientation = chainLookupReturn(m.global, "session.user.settings.libraryPosterOrientation", ImageLayout.DEFAULT)
+
+    if isStringEqual(posterOrientation, ImageLayout.DEFAULT)
+        posterOrientation = ImageLayout.PORTRAIT
+    end if
+
+    setColumnSizes(posterOrientation)
 end sub
 
 sub setColumnSizes(layout = ImageLayout.PORTRAIT as string)
@@ -160,10 +165,6 @@ sub loadInitialItems()
     startLoadingSpinner()
     favoriteViewAll = isFavoriteViewAll()
 
-    if favoriteViewAll
-        m.top.optionsAvailable = false
-    end if
-
     if isStringEqual(m.top.parentItem.json.Type, "CollectionFolder")
         m.top.HomeLibraryItem = m.top.parentItem.Id
     end if
@@ -173,23 +174,30 @@ sub loadInitialItems()
     end if
 
     ' Read view/sort/filter settings
-    if favoriteViewAll
+    if not favoriteViewAll or not m.favoriteViewAllInitialized
+        if isStringEqual(m.top.parentItem.collectionType, "music")
+            m.view = m.global.session.user.settings["display.music.view"]
+            m.sortField = m.global.session.user.settings["display." + m.top.parentItem.Id + ".sortField"]
+            sortAscendingStr = m.global.session.user.settings["display." + m.top.parentItem.Id + ".sortAscending"]
+            m.filter = m.global.session.user.settings["display." + m.top.parentItem.Id + ".filter"]
+        else
+            m.sortField = m.global.session.user.settings["display." + m.top.parentItem.Id + ".sortField"]
+            sortAscendingStr = m.global.session.user.settings["display." + m.top.parentItem.Id + ".sortAscending"]
+            m.filter = m.global.session.user.settings["display." + m.top.parentItem.Id + ".filter"]
+            m.filterOptions = m.global.session.user.settings["display." + m.top.parentItem.Id + ".filterOptions"]
+            m.view = m.global.session.user.settings["display." + m.top.parentItem.Id + ".landing"]
+        end if
+    else
+        sortAscendingStr = m.sortAscending
+    end if
+
+    if favoriteViewAll and not m.favoriteViewAllInitialized
         m.sortField = chainLookupReturn(m.top.parentItem, "json.SortBy", "SortName")
         sortAscendingStr = isStringEqual(chainLookupReturn(m.top.parentItem, "json.SortOrder", "Ascending"), "Ascending")
         m.filter = "Favorites"
         m.filterOptions = "{}"
-        m.view = string.EMPTY
-    else if isStringEqual(m.top.parentItem.collectionType, "music")
-        m.view = m.global.session.user.settings["display.music.view"]
-        m.sortField = m.global.session.user.settings["display." + m.top.parentItem.Id + ".sortField"]
-        sortAscendingStr = m.global.session.user.settings["display." + m.top.parentItem.Id + ".sortAscending"]
-        m.filter = m.global.session.user.settings["display." + m.top.parentItem.Id + ".filter"]
-    else
-        m.sortField = m.global.session.user.settings["display." + m.top.parentItem.Id + ".sortField"]
-        sortAscendingStr = m.global.session.user.settings["display." + m.top.parentItem.Id + ".sortAscending"]
-        m.filter = m.global.session.user.settings["display." + m.top.parentItem.Id + ".filter"]
-        m.filterOptions = m.global.session.user.settings["display." + m.top.parentItem.Id + ".filterOptions"]
-        m.view = m.global.session.user.settings["display." + m.top.parentItem.Id + ".landing"]
+        m.view = "default"
+        m.favoriteViewAllInitialized = true
     end if
 
     if isStringEqual(getCollectionType(), "tvshows")
@@ -208,7 +216,9 @@ sub loadInitialItems()
         end if
     end if
 
-    m.filterOptions = ParseJson(m.filterOptions)
+    if inArray(["roString", "String"], type(m.filterOptions))
+        m.filterOptions = ParseJson(m.filterOptions)
+    end if
 
     if not isValid(sortAscendingStr) or sortAscendingStr = true
         m.sortAscending = true
@@ -218,7 +228,7 @@ sub loadInitialItems()
 
     if favoriteViewAll
         m.loadItemsTask.itemId = string.EMPTY
-        m.loadItemsTask.itemType = string.EMPTY
+        m.loadItemsTask.itemType = chainLookupReturn(m.top.parentItem, "json.IncludeItemTypes", chainLookupReturn(m.top.parentItem, "json.QueryType", string.EMPTY))
         m.loadItemsTask.recursive = true
         m.loadItemsTask.studioIds = string.EMPTY
         m.loadItemsTask.genreIds = string.EMPTY
@@ -418,6 +428,10 @@ end sub
 ' Data to display when options button selected
 sub setSelectedOptions(options)
 
+    if isFavoriteViewAll() and isChainValid(options, "sort")
+        m.sortField = getMatchingSortField(m.sortField, options.sort)
+    end if
+
     ' Set selected view option
     for each o in options.views
         if o.Name = m.view
@@ -611,6 +625,16 @@ function isFavoriteViewAll() as boolean
     return chainLookupReturn(m.top.parentItem, "json.FavoriteViewAll", false)
 end function
 
+function isFavoritePeopleViewAll() as boolean
+    queryType = chainLookupReturn(m.top.parentItem, "json.QueryType", string.EMPTY)
+    return isFavoriteViewAll() and isStringEqual(queryType, ItemType.PERSON)
+end function
+
+sub setLibraryUserSetting(settingName as string, value)
+    if isFavoriteViewAll() then return
+    set_user_setting(`display.${m.top.parentItem.Id}.${settingName}`, value)
+end sub
+
 ' Search string array for search value. Return if it's found
 function inStringArray(array, searchValue) as boolean
     for each item in array
@@ -626,13 +650,17 @@ sub SetUpOptions()
     options.favorite = []
 
     if isFavoriteViewAll()
-        options.views = []
-        options.sort = []
-        m.options.options = options
-        return
-    end if
-
-    if isStringEqual(getCollectionType(), "movies")
+        setDefaultOptions(options)
+        if isFavoritePeopleViewAll()
+            ' /Persons ignores view and sort options.
+            options.views = []
+            options.sort = []
+        end if
+        options.filter = [
+            { "Title": tr("All"), "Name": "All" },
+            { "Title": tr("Favorites"), "Name": "Favorites" }
+        ]
+    else if isStringEqual(getCollectionType(), "movies")
         setMoviesOptions(options)
     else if inStringArray(["boxsets", "Boxset"], getCollectionType())
         return
@@ -644,6 +672,10 @@ sub SetUpOptions()
         setMusicOptions(options)
     else
         setDefaultOptions(options)
+    end if
+
+    if isFavoriteViewAll() and isChainValid(options, "sort")
+        m.sortField = getMatchingSortField(m.sortField, options.sort)
     end if
 
     ' Set selected view option
@@ -671,6 +703,13 @@ sub SetUpOptions()
             m.options.filter = o.Name
         end if
     end for
+
+    if isFavoritePeopleViewAll()
+        ' Keep hidden options unchanged when the dialog closes.
+        m.options.view = m.view
+        m.options.sortField = m.sortField
+        m.options.sortAscending = m.sortAscending
+    end if
 
     m.options.options = options
 end sub
@@ -870,7 +909,7 @@ end sub
 
 'Check if options updated and any reloading required
 sub optionsClosed()
-    if isStringEqual(m.top.parentItem.Type, "CollectionFolder") or isStringEqual(m.top.parentItem.Type, "Folder") or isStringEqual(m.top.parentItem.CollectionType, "CollectionFolder")
+    if not isFavoriteViewAll() and (isStringEqual(m.top.parentItem.Type, "CollectionFolder") or isStringEqual(m.top.parentItem.Type, "Folder") or isStringEqual(m.top.parentItem.CollectionType, "CollectionFolder"))
         ' Did the user just request "Random" on a PhotoAlbum?
         if m.options.view = "singlephoto"
             set_user_setting("photos.slideshow", "false")
@@ -889,24 +928,26 @@ sub optionsClosed()
     if isStringEqual(m.top.parentItem.collectionType, "music")
         if not isStringEqual(m.options.view, m.view)
             m.view = m.options.view
-            set_user_setting("display.music.view", m.view)
+            if not isFavoriteViewAll() then set_user_setting("display.music.view", m.view)
             reload = true
         end if
     else
-        m.view = m.global.session.user.settings["display." + m.top.parentItem.Id + ".landing"]
+        if not isFavoriteViewAll()
+            m.view = m.global.session.user.settings["display." + m.top.parentItem.Id + ".landing"]
+        end if
         if not isStringEqual(m.options.view, m.view)
             'reload and store new view setting
             m.view = m.options.view
             m.filter = "All"
             m.filterOptions = {}
-            set_user_setting("display." + m.top.parentItem.Id + ".filter", m.filter)
-            set_user_setting("display." + m.top.parentItem.Id + ".filterOptions", FormatJson(m.filterOptions))
-            set_user_setting("display." + m.top.parentItem.Id + ".landing", m.view)
+            setLibraryUserSetting("filter", m.filter)
+            setLibraryUserSetting("filterOptions", FormatJson(m.filterOptions))
+            setLibraryUserSetting("landing", m.view)
             reload = true
         end if
     end if
 
-    if not isStringEqual(m.options.sortField, m.sortField) or not isStringEqual(m.options.sortAscending, m.sortAscending)
+    if not isStringEqual(m.options.sortField, m.sortField) or not (m.options.sortAscending = m.sortAscending)
         m.sortField = m.options.sortField
         m.sortAscending = m.options.sortAscending
         reload = true
@@ -918,15 +959,15 @@ sub optionsClosed()
             sortAscendingStr = "false"
         end if
 
-        set_user_setting("display." + m.top.parentItem.Id + ".sortField", m.sortField)
-        set_user_setting("display." + m.top.parentItem.Id + ".sortAscending", sortAscendingStr)
+        setLibraryUserSetting("sortField", m.sortField)
+        setLibraryUserSetting("sortAscending", sortAscendingStr)
     end if
 
     if not isStringEqual(m.options.filter, m.filter)
         m.filter = m.options.filter
         reload = true
         'Store filter setting
-        set_user_setting("display." + m.top.parentItem.Id + ".filter", m.options.filter)
+        setLibraryUserSetting("filter", m.options.filter)
     end if
 
     if not isValid(m.options.filterOptions)
@@ -936,7 +977,7 @@ sub optionsClosed()
     if not AssocArrayEqual(m.options.filterOptions, m.filterOptions)
         m.filterOptions = m.options.filterOptions
         reload = true
-        set_user_setting("display." + m.top.parentItem.Id + ".filterOptions", FormatJson(m.options.filterOptions))
+        setLibraryUserSetting("filterOptions", FormatJson(m.options.filterOptions))
     end if
 
     if reload
@@ -944,6 +985,7 @@ sub optionsClosed()
         m.loadedItems = 0
         m.top.removeChild(m.itemGrid)
         createItemGrid()
+        setConfiguredColumnSizes()
         m.data = CreateObject("roSGNode", "ContentNode")
         m.itemGrid.content = m.data
         loadInitialItems()
@@ -983,7 +1025,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
         group.lastFocus = topGrp
     end if
 
-    if isStringEqual(key, KeyCode.OPTIONS) and not isStringEqual(getCollectionType(), "nextup") and not isFavoriteViewAll()
+    if isStringEqual(key, KeyCode.OPTIONS) and not isStringEqual(getCollectionType(), "nextup")
         if isStringEqual(getCollectionType(), "playlists")
             itemToPlay = getItemFocused()
             if not isValid(itemToPlay) then return true

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -24,6 +24,7 @@ const ASPECT_RATIO_LANDSCAPE_WITH_TITLE = .66307
 sub setupNodes()
     m.top.imageDisplayMode = "scaleToZoom"
     m.top.showItemTitles = "showonhover"
+    m.favoriteViewAllInitialized = false
 
     m.librarySettings = m.top.findNode("librarySettings")
     m.librarySettings.observeFieldScoped("selected", "onLibrarySettingsSelected")
@@ -78,11 +79,15 @@ sub onExit()
             m.alphaMenu.setFocus(true)
             group = m.global.sceneManager.callFunc("getActiveScene")
             group.lastFocus = m.alphaMenu
-        else
+        else if not isFavoriteViewAll()
             m.librarySettings.setFocus(true)
             m.librarySettings.highlighted = true
             group = m.global.sceneManager.callFunc("getActiveScene")
             group.lastFocus = m.librarySettings
+        else
+            m.itemGrid.setFocus(true)
+            group = m.global.sceneManager.callFunc("getActiveScene")
+            group.lastFocus = m.itemGrid
         end if
 
         return
@@ -285,11 +290,24 @@ sub loadInitialItems()
         toggleDropdownOptions(true)
     end if
 
-    m.sortField = m.global.session.user.settings["display." + m.top.parentItem.Id + ".sortField"]
-    m.filter = m.global.session.user.settings["display." + m.top.parentItem.Id + ".filter"]
-    m.filterOptions = m.global.session.user.settings["display." + m.top.parentItem.Id + ".filterOptions"]
-    m.view = m.global.session.user.settings["display." + m.top.parentItem.Id + ".landing"]
-    m.sortAscending = m.global.session.user.settings["display." + m.top.parentItem.Id + ".sortAscending"]
+    if not isFavoriteViewAll()
+        m.sortField = m.global.session.user.settings["display." + m.top.parentItem.Id + ".sortField"]
+        m.filter = m.global.session.user.settings["display." + m.top.parentItem.Id + ".filter"]
+        m.filterOptions = m.global.session.user.settings["display." + m.top.parentItem.Id + ".filterOptions"]
+        m.view = m.global.session.user.settings["display." + m.top.parentItem.Id + ".landing"]
+        m.sortAscending = m.global.session.user.settings["display." + m.top.parentItem.Id + ".sortAscending"]
+    end if
+
+    if isFavoriteViewAll() and not m.favoriteViewAllInitialized
+        m.sortField = chainLookupReturn(m.top.parentItem, "json.SortBy", "SortName")
+        m.filter = "Favorites"
+        m.filterOptions = "{}"
+        m.view = chainLookupReturn(m.top.parentItem, "json.LibraryViewInitialView", "presentation")
+        m.sortAscending = isStringEqual(chainLookupReturn(m.top.parentItem, "json.SortOrder", "Ascending"), "Ascending")
+        m.favoriteViewAllInitialized = true
+    end if
+
+    m.librarySettings.visible = not isFavoriteViewAll()
 
     ' If user has not set a preferred view for this folder, check if they've set a default view
     if not isValid(m.view)
@@ -328,7 +346,9 @@ sub loadInitialItems()
         if not inArray(["presentation", "grid"], m.view) then m.view = "presentation"
     end if
 
-    m.filterOptions = ParseJson(m.filterOptions)
+    if inArray(["roString", "String"], type(m.filterOptions))
+        m.filterOptions = ParseJson(m.filterOptions)
+    end if
 
     m.loadItemsTask.searchTerm = m.top.searchTerm
     m.loadItemsTask.sortField = m.sortField
@@ -415,6 +435,17 @@ sub loadInitialItems()
             m.loadItemsTask.genreIds = m.top.parentItem.id
             m.loadItemsTask.itemType = ItemType.MUSICVIDEO
             m.loadItemsTask.recursive = true
+        end if
+    end if
+
+    if isFavoriteViewAll()
+        m.loadItemsTask.itemId = string.EMPTY
+        m.loadItemsTask.recursive = true
+        m.loadItemsTask.studioIds = string.EMPTY
+        m.loadItemsTask.genreIds = string.EMPTY
+
+        if inArray([ItemType.BOXSET, ItemType.MUSICVIDEO], m.top.mediaType)
+            m.loadItemsTask.itemType = chainLookupReturn(m.top.parentItem, "json.IncludeItemTypes", m.top.mediaType)
         end if
     end if
 
@@ -580,7 +611,7 @@ sub loadInitialItems()
     m.getFiltersTask.observeField("filters", "FilterDataLoaded")
     m.getFiltersTask.params = {
         userid: m.global.session.user.id,
-        parentid: m.top.parentItem.Id,
+        parentid: getLibraryQueryParentId(),
         includeitemtypes: m.loadItemsTask.itemType
     }
     m.getFiltersTask.control = "RUN"
@@ -657,7 +688,7 @@ function setMovieOptions() as object
         { "Title": tr("Grid"), "Name": "grid", "Track": { "description": tr("Grid") } }
     ]
 
-    if not isStringEqual(m.top.mediaType, ItemType.MYLIST)
+    if not isFavoriteViewAll() and not isStringEqual(m.top.mediaType, ItemType.MYLIST)
         options.views.push({ "Title": tr("Genres"), "Name": "Genres", "Track": { "description": tr("Genres") } })
     end if
 
@@ -706,6 +737,13 @@ function setMovieOptions() as object
         ]
     end if
 
+    if isFavoriteViewAll()
+        options.filter = [
+            { "Title": tr("All"), "Name": "All" },
+            { "Title": tr("Favorites"), "Name": "Favorites" }
+        ]
+    end if
+
     return options
 end function
 
@@ -716,9 +754,12 @@ function setMusicVideoOptions() as object
 
     options.views = [
         { "Title": tr("Presentation"), "Name": "presentation", "Track": { "description": tr("Presentation") } },
-        { "Title": tr("Grid"), "Name": "grid", "Track": { "description": tr("Grid") } },
-        { "Title": tr("Genres"), "Name": "Genres", "Track": { "description": tr("Genres") } }
+        { "Title": tr("Grid"), "Name": "grid", "Track": { "description": tr("Grid") } }
     ]
+
+    if not isFavoriteViewAll()
+        options.views.push({ "Title": tr("Genres"), "Name": "Genres", "Track": { "description": tr("Genres") } })
+    end if
 
     options.sort = [
         { "Title": tr("TITLE"), "Name": "SortName", "Track": { "description": tr("TITLE") } },
@@ -752,6 +793,13 @@ function setMusicVideoOptions() as object
         options.views = [
             { "Title": tr("Presentation"), "Name": "presentation", "Track": { "description": tr("Presentation") } },
             { "Title": tr("Grid"), "Name": "grid", "Track": { "description": tr("Grid") } }
+        ]
+    end if
+
+    if isFavoriteViewAll()
+        options.filter = [
+            { "Title": tr("All"), "Name": "All" },
+            { "Title": tr("Favorites"), "Name": "Favorites" }
         ]
     end if
 
@@ -789,12 +837,21 @@ function setSeriesOptions() as object
         filter: []
     }
 
-    options.views = [
-        { "Title": tr("Presentation"), "Name": "presentation", "Track": { "description": tr("Presentation") } },
-        { "Title": tr("Grid"), "Name": "grid", "Track": { "description": tr("Grid") } },
-        { "Title": tr("Genres"), "Name": "Genres", "Track": { "description": tr("Genres") } },
-        { "Title": tr("Episodes"), "Name": "Episodes", "Track": { "description": tr("Episodes") } }
-    ]
+    if isFavoriteViewAll() and isStringEqual(chainLookupReturn(m.top.parentItem, "json.IncludeItemTypes", string.EMPTY), ItemType.EPISODE)
+        options.views = [{ "Title": tr("Episodes"), "Name": "Episodes", "Track": { "description": tr("Episodes") } }]
+    else if isFavoriteViewAll()
+        options.views = [
+            { "Title": tr("Presentation"), "Name": "presentation", "Track": { "description": tr("Presentation") } },
+            { "Title": tr("Grid"), "Name": "grid", "Track": { "description": tr("Grid") } }
+        ]
+    else
+        options.views = [
+            { "Title": tr("Presentation"), "Name": "presentation", "Track": { "description": tr("Presentation") } },
+            { "Title": tr("Grid"), "Name": "grid", "Track": { "description": tr("Grid") } },
+            { "Title": tr("Genres"), "Name": "Genres", "Track": { "description": tr("Genres") } },
+            { "Title": tr("Episodes"), "Name": "Episodes", "Track": { "description": tr("Episodes") } }
+        ]
+    end if
 
     options.sort = [
         { "Title": tr("TITLE"), "Name": "SortName", "Track": { "description": tr("TITLE") } },
@@ -827,16 +884,42 @@ function setSeriesOptions() as object
         ]
     end if
 
+    if isFavoriteViewAll()
+        options.filter = [
+            { "Title": tr("All"), "Name": "All" },
+            { "Title": tr("Favorites"), "Name": "Favorites" }
+        ]
+    end if
+
     return options
 end function
 
 ' Return parent collection type
 function getCollectionType() as string
+    if isFavoriteViewAll() then return m.top.mediaType
     return m.top.parentItem.collectionType ?? m.top.parentItem.Type
+end function
+
+function isFavoriteViewAll() as boolean
+    return chainLookupReturn(m.top.parentItem, "json.FavoriteViewAll", false)
+end function
+
+sub setLibraryUserSetting(settingName as string, value)
+    if isFavoriteViewAll() then return
+    set_user_setting(`display.${m.top.parentItem.Id}.${settingName}`, value)
+end sub
+
+function getLibraryQueryParentId() as string
+    if isFavoriteViewAll() then return string.EMPTY
+    return m.top.parentItem.Id
 end function
 
 ' Data to display when options button selected
 sub setSelectedOptions(options)
+
+    if isFavoriteViewAll() and isChainValid(options, "sort")
+        m.sortField = getMatchingSortField(m.sortField, options.sort)
+    end if
 
     ' Set selected view option
     for each o in options.views
@@ -904,7 +987,7 @@ sub FilterDataLoaded(msg)
     if not isValid(data) then return
 
     ' Add filters from the API data
-    if inArray(["presentation", "grid"], m.view)
+    if inArray(["presentation", "grid"], m.view) and not isFavoriteViewAll()
         options.filter.push({ "Title": tr("Features"), "Name": "Features", "Options": ["Subtitles", "Special Features", "Theme Song", "Theme Video"], "Delimiter": "|", "CheckedState": [] })
 
         if isValidAndNotEmpty(data.genres)
@@ -1346,7 +1429,7 @@ sub setDropdownDisabledState(disabledState = false as boolean)
 end sub
 
 sub resetDropdownsToDefaultState()
-    m.filter = "All"
+    if not isFavoriteViewAll() then m.filter = "All"
     m.filterOptions = {}
     if isStringEqual(getCollectionType(), ItemType.BOXSET)
         m.sortField = "PremiereDate,SortName"
@@ -1368,17 +1451,17 @@ sub resetDropdownsToDefaultState()
     m.dropdownOptionGroup@.setSortAscending(true)
 
     ' Reset view to defaults
-    set_user_setting("display." + m.top.parentItem.Id + ".sortField", m.sortField)
-    set_user_setting("display." + m.top.parentItem.Id + ".sortAscending", "true")
-    set_user_setting("display." + m.top.parentItem.Id + ".filter", m.filter)
-    set_user_setting("display." + m.top.parentItem.Id + ".filterOptions", FormatJson(m.filterOptions))
+    setLibraryUserSetting("sortField", m.sortField)
+    setLibraryUserSetting("sortAscending", "true")
+    setLibraryUserSetting("filter", m.filter)
+    setLibraryUserSetting("filterOptions", FormatJson(m.filterOptions))
 
-    if not isStringEqual(m.view, "Genres")
+    if not isFavoriteViewAll() and not isStringEqual(m.view, "Genres")
         set_user_setting(`display.${m.top.mediaType}library.defaultview`, m.view)
     end if
 
     m.dropdownOptionGroup@.setText("sortOrderButton", tr("Ascending"))
-    m.dropdownOptionGroup@.setText("filterButton", tr("All"))
+    m.dropdownOptionGroup@.setText("filterButton", tr(m.filter))
 
     m.getFiltersTask.control = "RUN"
 end sub
@@ -1485,7 +1568,7 @@ sub onOptionsVisibleChange()
     if m.options.filter <> m.filter
         m.filter = m.options.filter
         reload = true
-        set_user_setting("display." + m.top.parentItem.Id + ".filter", m.options.filter)
+        setLibraryUserSetting("filter", m.options.filter)
     end if
 
     if not isValid(m.options.filterOptions)
@@ -1495,7 +1578,7 @@ sub onOptionsVisibleChange()
     if not AssocArrayEqual(m.options.filterOptions, m.filterOptions)
         m.filterOptions = m.options.filterOptions
         reload = true
-        set_user_setting("display." + m.top.parentItem.Id + ".filterOptions", FormatJson(m.options.filterOptions))
+        setLibraryUserSetting("filterOptions", FormatJson(m.options.filterOptions))
     end if
 
     if reload
@@ -1529,7 +1612,7 @@ sub onSortChange(sortChoice)
     m.dropdownOptionGroup@.setSortAscending(true)
     m.sortAscending = true
 
-    set_user_setting("display." + m.top.parentItem.Id + ".sortField", m.sortField)
+    setLibraryUserSetting("sortField", m.sortField)
 
     m.loadedRows = 0
     m.loadedItems = 0
@@ -1555,7 +1638,7 @@ sub onViewChange(viewChoice)
     m.view = viewChoice.LookupCI("name")
     m.dropdownOptionGroup@.setText("viewButton", tr(viewChoice.LookupCI("title")))
 
-    set_user_setting("display." + m.top.parentItem.Id + ".landing", m.view)
+    setLibraryUserSetting("landing", m.view)
 
     ' Reset any filtering or search terms
     m.bypassSearchEvent = true
@@ -1563,7 +1646,7 @@ sub onViewChange(viewChoice)
     m.top.alphaSelected = string.EMPTY
     m.loadItemsTask.NameStartsWith = " "
     m.loadItemsTask.searchTerm = string.EMPTY
-    m.filter = "All"
+    if not isFavoriteViewAll() then m.filter = "All"
     m.filterOptions = {}
     if isStringEqual(getCollectionType(), ItemType.BOXSET)
         m.sortField = "PremiereDate,SortName"
@@ -1576,12 +1659,12 @@ sub onViewChange(viewChoice)
     m.dropdownOptionGroup@.setSortAscending(true)
 
     ' Reset view to defaults
-    set_user_setting("display." + m.top.parentItem.Id + ".sortField", m.sortField)
-    set_user_setting("display." + m.top.parentItem.Id + ".sortAscending", "true")
-    set_user_setting("display." + m.top.parentItem.Id + ".filter", m.filter)
-    set_user_setting("display." + m.top.parentItem.Id + ".filterOptions", FormatJson(m.filterOptions))
+    setLibraryUserSetting("sortField", m.sortField)
+    setLibraryUserSetting("sortAscending", "true")
+    setLibraryUserSetting("filter", m.filter)
+    setLibraryUserSetting("filterOptions", FormatJson(m.filterOptions))
 
-    if not isStringEqual(m.view, "Genres")
+    if not isFavoriteViewAll() and not isStringEqual(m.view, "Genres")
         set_user_setting(`display.${m.top.mediaType}library.defaultview`, m.view)
     end if
 
@@ -1630,7 +1713,7 @@ sub onSortOrderChange(sortOrderChoice)
     m.dropdownOptionGroup@.setSortAscending(m.sortAscending)
     m.dropdownOptionGroup@.setText("sortOrderButton", tr(sortOrderChoice.LookupCI("title")))
 
-    set_user_setting("display." + m.top.parentItem.Id + ".sortAscending", m.sortAscending.toStr())
+    setLibraryUserSetting("sortAscending", m.sortAscending.toStr())
 
     m.loadedRows = 0
     m.loadedItems = 0
@@ -1640,6 +1723,7 @@ sub onSortOrderChange(sortOrderChoice)
 end sub
 
 sub onLibrarySettingsSelected()
+    if isFavoriteViewAll() then return
     m.global.sceneManager.callFunc("librarySettingDialog", tr("Library Settings"))
 end sub
 
@@ -1648,7 +1732,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     if isStringEqual(key, KeyCode.DOWN)
         if m.alphaMenu.isinFocusChain()
-            if m.alphaMenu.itemFocused = m.alphaMenu.numRows - 1
+            if m.alphaMenu.itemFocused = m.alphaMenu.numRows - 1 and not isFavoriteViewAll()
                 m.librarySettings.setFocus(true)
                 m.librarySettings.highlighted = true
                 return true
@@ -1668,7 +1752,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     if isStringEqual(key, KeyCode.UP)
         if m.alphaMenu.isinFocusChain()
-            if m.alphaMenu.itemFocused = 0
+            if m.alphaMenu.itemFocused = 0 and not isFavoriteViewAll()
                 m.librarySettings.setFocus(true)
                 m.librarySettings.highlighted = true
                 return true
@@ -1748,6 +1832,8 @@ function onKeyEvent(key as string, press as boolean) as boolean
     if isStringEqual(key, KeyCode.LEFT)
         alphaDisplayed = m.alpha.callFunc("getDisplay")
         if not alphaDisplayed
+            if isFavoriteViewAll() then return false
+
             if not m.librarySettings.highlighted
                 m.librarySettings.setFocus(true)
                 m.librarySettings.highlighted = true

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -3,6 +3,7 @@ import "pkg:/source/api/Image.bs"
 import "pkg:/source/api/Items.bs"
 import "pkg:/source/api/sdk.bs"
 import "pkg:/source/constants/HomeRowItemSizes.bs"
+import "pkg:/source/enums/FavoriteViewAllRoute.bs"
 import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/enums/String.bs"
 import "pkg:/source/utils/config.bs"
@@ -500,17 +501,17 @@ end function
 '
 function getFavoriteRowDefinitions() as object
     return [
-        { rowKey: "movies", title: `${tr("Favorite")} ${tr("Movies")}`, includeItemTypes: ItemType.MOVIE, rowType: "poster" },
-        { rowKey: "shows", title: `${tr("Favorite")} ${tr("Shows")}`, includeItemTypes: ItemType.SERIES, rowType: "poster" },
-        { rowKey: "episodes", title: `${tr("Favorite")} ${tr("Episodes")}`, includeItemTypes: ItemType.EPISODE, rowType: "wide" },
-        { rowKey: "videos", title: `${tr("Favorite")} ${tr("Videos")}`, includeItemTypes: `${ItemType.VIDEO},${ItemType.MUSICVIDEO}`, rowType: "wide" },
-        { rowKey: "collections", title: `${tr("Favorite")} ${tr("Collections")}`, includeItemTypes: ItemType.BOXSET, rowType: "poster" },
-        { rowKey: "playlists", title: `${tr("Favorite")} ${tr("Playlists")}`, includeItemTypes: ItemType.PLAYLIST, rowType: "album" },
-        { rowKey: "people", title: `${tr("Favorite")} ${tr("Cast & Crew")}`, queryType: ItemType.PERSON, rowType: "poster" },
-        { rowKey: "artists", title: `${tr("Favorite")} ${tr("Artists")}`, queryType: ItemType.MUSICARTIST, rowType: "album" },
-        { rowKey: "albums", title: `${tr("Favorite")} ${tr("Albums")}`, includeItemTypes: ItemType.MUSICALBUM, rowType: "album" },
-        { rowKey: "songs", title: `${tr("Favorite")} ${tr("Songs")}`, includeItemTypes: ItemType.AUDIO, rowType: "album" },
-        { rowKey: "channels", title: `${tr("Favorite")} ${tr("Channels")}`, includeItemTypes: ItemType.TVCHANNEL, rowType: "wide" }
+        { rowKey: "movies", title: `${tr("Favorite")} ${tr("Movies")}`, includeItemTypes: ItemType.MOVIE, rowType: "poster", route: FavoriteViewAllRoute.VISUAL, mediaType: ItemType.MOVIE, view: "presentation" },
+        { rowKey: "shows", title: `${tr("Favorite")} ${tr("Shows")}`, includeItemTypes: ItemType.SERIES, rowType: "poster", route: FavoriteViewAllRoute.VISUAL, mediaType: ItemType.SERIES, view: "presentation" },
+        { rowKey: "episodes", title: `${tr("Favorite")} ${tr("Episodes")}`, includeItemTypes: ItemType.EPISODE, rowType: "wide", route: FavoriteViewAllRoute.VISUAL, mediaType: ItemType.SERIES, view: "Episodes" },
+        { rowKey: "videos", title: `${tr("Favorite")} ${tr("Videos")}`, includeItemTypes: `${ItemType.VIDEO},${ItemType.MUSICVIDEO}`, rowType: "wide", route: FavoriteViewAllRoute.VISUAL, mediaType: ItemType.MUSICVIDEO, view: "grid" },
+        { rowKey: "collections", title: `${tr("Favorite")} ${tr("Collections")}`, includeItemTypes: ItemType.BOXSET, rowType: "poster", route: FavoriteViewAllRoute.VISUAL, mediaType: ItemType.BOXSET, view: "presentation" },
+        { rowKey: "playlists", title: `${tr("Favorite")} ${tr("Playlists")}`, includeItemTypes: ItemType.PLAYLIST, rowType: "album", route: FavoriteViewAllRoute.MUSIC, view: "Playlists" },
+        { rowKey: "people", title: `${tr("Favorite")} ${tr("Cast & Crew")}`, queryType: ItemType.PERSON, rowType: "poster", route: FavoriteViewAllRoute.OTHER },
+        { rowKey: "artists", title: `${tr("Favorite")} ${tr("Artists")}`, queryType: ItemType.MUSICARTIST, rowType: "album", route: FavoriteViewAllRoute.MUSIC, view: "ArtistsPresentation" },
+        { rowKey: "albums", title: `${tr("Favorite")} ${tr("Albums")}`, includeItemTypes: ItemType.MUSICALBUM, rowType: "album", route: FavoriteViewAllRoute.MUSIC, view: "Albums" },
+        { rowKey: "songs", title: `${tr("Favorite")} ${tr("Songs")}`, includeItemTypes: ItemType.AUDIO, rowType: "album", route: FavoriteViewAllRoute.MUSIC, view: "Songs" },
+        { rowKey: "channels", title: `${tr("Favorite")} ${tr("Channels")}`, includeItemTypes: ItemType.TVCHANNEL, rowType: "wide", route: FavoriteViewAllRoute.LIVETV }
     ]
 end function
 
@@ -598,6 +599,9 @@ function createFavoriteViewAllHomeData(favoriteRow as object, sortField as strin
         FavoriteViewAll: true,
         IncludeItemTypes: favoriteRow.LookupCI("includeItemTypes") ?? string.EMPTY,
         QueryType: favoriteRow.LookupCI("queryType") ?? string.EMPTY,
+        LibraryViewRoute: favoriteRow.LookupCI("route") ?? FavoriteViewAllRoute.OTHER,
+        LibraryViewMediaType: favoriteRow.LookupCI("mediaType") ?? string.EMPTY,
+        LibraryViewInitialView: favoriteRow.LookupCI("view") ?? string.EMPTY,
         SortBy: sortField,
         SortOrder: sortOrder
     }

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -1,5 +1,6 @@
 import "pkg:/components/manager/ViewCreator.bs"
 import "pkg:/source/enums/CollectionType.bs"
+import "pkg:/source/enums/FavoriteViewAllRoute.bs"
 import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/enums/KeyCode.bs"
 import "pkg:/source/enums/MediaPlaybackState.bs"
@@ -745,6 +746,28 @@ sub onRefreshMovieDetailsDataEvent()
     stopLoadingSpinner()
 end sub
 
+function openFavoriteViewAll(selectedItem as object) as boolean
+    if not chainLookupReturn(selectedItem, "json.FavoriteViewAll", false) then return false
+
+    route = chainLookupReturn(selectedItem, "json.LibraryViewRoute", FavoriteViewAllRoute.OTHER)
+
+    if isStringEqual(route, FavoriteViewAllRoute.VISUAL)
+        mediaType = chainLookupReturn(selectedItem, "json.LibraryViewMediaType", string.EMPTY)
+        group = CreateVisualLibraryScene(selectedItem, mediaType)
+    else if isStringEqual(route, FavoriteViewAllRoute.MUSIC)
+        group = CreateMusicLibraryView(selectedItem)
+    else if isStringEqual(route, FavoriteViewAllRoute.LIVETV)
+        group = CreateLiveTVLibraryView(selectedItem)
+    else
+        group = CreateOtherLibrary(selectedItem)
+    end if
+
+    if not isValid(group) then return false
+
+    m.global.sceneManager.callFunc("pushScene", group)
+    return true
+end function
+
 sub onSelectedItemEvent(msg)
     ' If you select a library from ANYWHERE, follow this flow
     selectedItem = msg.getData()
@@ -756,6 +779,8 @@ sub onSelectedItemEvent(msg)
             ' If button selected is a string, lcase it
             if isStringEqual(type(selectedItemType), "rostring") then selectedItemType = LCase(selectedItemType)
         end if
+
+        if openFavoriteViewAll(selectedItem) then return
 
         if isStringEqual(selectedItemType, "collectionfolder")
             onLibrarySelection(selectedItem)

--- a/source/enums/FavoriteViewAllRoute.bs
+++ b/source/enums/FavoriteViewAllRoute.bs
@@ -1,0 +1,6 @@
+enum FavoriteViewAllRoute
+    LIVETV = "livetv"
+    MUSIC = "music"
+    OTHER = "other"
+    VISUAL = "visual"
+end enum

--- a/source/static/whatsNew/3.2.4.json
+++ b/source/static/whatsNew/3.2.4.json
@@ -18,5 +18,9 @@
   {
     "description": "Fix crash when pressing * on user select screen when no users are shown",
     "author": "1hitsong"
+  },
+  {
+    "description": "Route Home Favorites View All tiles to their corresponding library views",
+    "author": "VX-101"
   }
 ]

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -331,6 +331,29 @@ function isStringEqual(input1, input2) as boolean
     return LCase(input1) = LCase(input2)
 end function
 
+function getMatchingSortField(sortField as string, sortOptions as object, fallbackSortField = "SortName" as string) as string
+    if not isValidAndNotEmpty(sortOptions) then return sortField
+
+    fallback = string.EMPTY
+    for each option in sortOptions
+        optionName = chainLookupReturn(option, "Name", string.EMPTY)
+        sortParts = optionName.Split(",")
+        primarySortField = string.EMPTY
+        if sortParts.Count() > 0 then primarySortField = sortParts[0]
+
+        if isStringEqual(optionName, sortField) or isStringEqual(primarySortField, sortField)
+            return optionName
+        end if
+
+        if isStringEqual(optionName, fallbackSortField) or isStringEqual(primarySortField, fallbackSortField)
+            fallback = optionName
+        end if
+    end for
+
+    if isValidAndNotEmpty(fallback) then return fallback
+    return chainLookupReturn(sortOptions[0], "Name", sortField)
+end function
+
 ' Returns whether or not all items in passed array are valid
 function isAllValid(input as object) as boolean
     for each item in input


### PR DESCRIPTION
## Summary

Follow-up to PR #994. Routes Home Favorites `View All` tiles to their corresponding library views.

## Changes

- Route movies, shows, episodes, videos, and collections to the visual library scene.
- Route artists, albums, songs, and playlists to the music library view.
- Route Cast & Crew to the generic library grid and channels to the Live TV library view.
- Keep only view choices that preserve the original item type.
- Keep shortcut settings separate from regular library defaults.

## Notes

- Only type-preserving views and filters are available; played-state filters, `Genres`, `Album Artists`, and `TV Guide` are excluded. Supported routes can select `Favorites` or `All`.
- Cast & Crew uses the generic person grid. `View` is unavailable; `Sort` is hidden because `/Persons` ignores `SortBy` and `SortOrder`.
- Channels excludes `TV Guide` because it cannot preserve the filter. Testing used synthetic M3U channels, not a real tuner or guide.
- Songs without primary artwork use the album fallback icon.

####  Existing behavior 

- `Favorite Collections` resets `Sort By` to `Release Date` after starting a search or switching between `Presentation` and `Grid`.
- Home Favorites groups by item type, placing `Concerts` under `Favorite Movies`.
- Favorites shortcuts inherit `/Items/Filters` requests from the visual and music views and per-playlist image lookups.

## Follow-up

- Add a dedicated Cast & Crew view with working sorting.
- Preserve the selected Collections sort through search and view changes.
- Remove unused `/Items/Filters` requests and per-playlist image lookups.
- Make Home Favorites grouping library-aware so Concerts do not appear under `Favorite Movies`.

## Testing

- Ran `npm run build` successfully.
- Sideloaded local build `3.2.4.1062.0295`.
- Smoke tested all routes, view/filter limits, `All` switching, Songs artwork, Artist layouts, and back navigation.
- Confirmed Cast & Crew exposes only `Filter` and stays populated after closing `Options`.
- Confirmed Favorite Songs remains responsive when `Options` is pressed before and after the grid loads.
- Manually tested Shows, Channels, Collections, and Playlists `View All` routes.
