### PR TITLE
Fix/Custom Captions visible on pause

### DIFF
--- a/components/captionTask.bs
+++ b/components/captionTask.bs
@@ -388,6 +388,9 @@ sub updateCaption()
         return
     end if
 
+    ' Keep last captions visible while paused instead of clearing them.
+    if isStringEqual(m.top.playerState, "pausedon") then return
+
     m.top.currentCaption = []
 
     if not isStringEqual(m.top.playerState, "playingon") then return

--- a/source/static/whatsNew/3.2.4.json
+++ b/source/static/whatsNew/3.2.4.json
@@ -18,5 +18,9 @@
   {
     "description": "Fix crash when pressing * on user select screen when no users are shown",
     "author": "1hitsong"
+  },
+  {
+    "description": "fix(Custom Captions): keep captions visible while paused",
+    "author": "ferezvi"
   }
 ]

--- a/source/static/whatsNew/3.2.4.json
+++ b/source/static/whatsNew/3.2.4.json
@@ -20,7 +20,7 @@
     "author": "1hitsong"
   },
   {
-    "description": "fix(Custom Captions): keep captions visible while paused",
+    "description": "Keep custom caption text visible while video is paused",
     "author": "ferezvi"
   }
 ]


### PR DESCRIPTION
## What

`captionTask.updateCaption()` only rendered captions when `playerState` was exactly `"playingon"`, clearing `currentCaption` for any other state - including `"pausedon"`. This made subtitles disappear the moment you paused and only reappear after resuming playback.

## Fix

Skip the clear while paused, so the last rendered captions stay on screen. No resync is needed since the position clock isn't advancing during pause anyway - it picks back up correctly once playback resumes.

## Testing

Manually verified on device: play a video with subtitles on, pause with a caption visible on screen, confirm it stays visible while paused, and confirm captions continue advancing normally on resume.