### PR TITLE
Scroll guide to current time after watching Live TV

### DIFF
--- a/components/Libraries/LiveTVLibraryView.bs
+++ b/components/Libraries/LiveTVLibraryView.bs
@@ -68,6 +68,8 @@ sub init()
     m.alphaMenu = m.alpha.findNode("alphaMenu")
 
     m.top.gridTitles = m.global.session.user.settings["itemgrid.gridTitles"]
+
+    m.top.observeField("visible", "onVisibleChange")
 end sub
 
 sub setColumnSizes(layout = ImageLayout.PORTRAIT as string)
@@ -618,3 +620,9 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     return false
 end function
+
+sub onVisibleChange()
+    if m.top.visible and isValid(m.tvGuide)
+        m.tvGuide.callFunc("updateTime")
+    end if
+end sub

--- a/components/liveTv/schedule.bs
+++ b/components/liveTv/schedule.bs
@@ -617,3 +617,10 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     return false
 end function
+
+sub updateTime()
+    if isValid(m.scheduleGrid)
+        now = CreateObject("roDateTime").ToISOString()
+        m.scheduleGrid.jumpToTime = now
+    end if
+end sub

--- a/components/liveTv/schedule.xml
+++ b/components/liveTv/schedule.xml
@@ -28,5 +28,6 @@
     <field id="filter" type="string" value="" onChange="onFilterSet" />
     <field id="searchTerm" type="string" value="" onChange="onSearchTermSet" />
     <function name="loadChannelList" />
+    <function name="updateTime" />
   </interface>
 </component>

--- a/source/static/whatsNew/3.2.4.json
+++ b/source/static/whatsNew/3.2.4.json
@@ -18,5 +18,9 @@
   {
     "description": "Fix crash when pressing * on user select screen when no users are shown",
     "author": "1hitsong"
+  },
+  {
+    "description": "Scroll guide to current time after watching Live TV",
+    "author": "FractalBoy"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
<!-- Describe your changes here in 1-5 sentences. -->
Currently, if you are watching live TV for a while (especially multiple hours), when you return to the TV guide, it is still at the time it was when you started watching.

Now, when the Live TV library becomes visible again, it will trigger updateTime on the TV guide schedule, which uses jumpToTime to set the time of the schedule to the current time. This should trigger an update to leftEdgeTargetTime and trigger loading more data if needed.

I have not yet tested it watching multiple hours of TV but I was able to test it by going to the right edge of a TV guide entry, watching the channel, and then immediately going back. The TV guide was reset to the current time.

## Issues
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
None