### PR TITLE
Fix focus indicator position on media posters

### DIFF
--- a/components/ItemGrid/GridItemMedium.bs
+++ b/components/ItemGrid/GridItemMedium.bs
@@ -70,7 +70,7 @@ sub onWidthChanged()
     m.posterText.width = m.top.width
     m.title.maxWidth = m.top.width
     m.itemTextExtra.maxWidth = m.top.width
-    m.playedIndicator.translation = [m.top.width - m.playedIndicator.width, 22]
+    m.playedIndicator.translation = [m.top.width - m.playedIndicator.width, 14]
     m.itemIconBackground.translation = [m.top.width - m.itemIconBackground.width, m.itemIconBackground.translation[1]]
 end sub
 

--- a/components/ItemGrid/GridItemMedium.xml
+++ b/components/ItemGrid/GridItemMedium.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="GridItemMedium" extends="Group">
   <children>
-    <Poster id="backdrop" translation="[0,23]" width="400" height="260" loadDisplayMode="scaleToZoom" uri="pkg:/images/white.9.png" />
-    <Poster id="itemPoster" translation="[0,23]" width="400" height="260" loadDisplayMode="scaleToZoom" />
+    <Poster id="backdrop" translation="[0,15]" width="400" height="260" loadDisplayMode="scaleToZoom" uri="pkg:/images/white.9.png" />
+    <Poster id="itemPoster" translation="[0,15]" width="400" height="260" loadDisplayMode="scaleToZoom" />
 
     <ScrollingText id="title" horizAlign="left" vertAlign="bottom" font="font:SmallBoldSystemFont" height="34" maxWidth="384" translation="[8,290]" repeatCount="0" />
     <ScrollingText id="itemTextExtra" horizAlign="left" vertAlign="center" font="font:SmallBoldSystemFont" height="32" maxWidth="384" translation="[8,325]" color="#777777FF" repeatCount="0" />
@@ -11,7 +11,7 @@
       <Poster id="itemIcon" width="50" height="50" translation="[5,5]" />
     </Rectangle>
     <Text id="posterText" width="400" height="300" translation="[5,5]" horizAlign="center" vertAlign="center" ellipsizeOnBoundary="true" wrap="true" />
-    <PlayedCheckmark id="playedIndicator" translation="[340, 22]" />
+    <PlayedCheckmark id="playedIndicator" translation="[340, 14]" />
   </children>
   <interface>
     <field id="height" type="float" onChange="onHeightChanged" />

--- a/components/ItemGrid/GridItemSmall.bs
+++ b/components/ItemGrid/GridItemSmall.bs
@@ -50,7 +50,7 @@ sub onWidthChanged()
     m.posterText.width = m.top.width
     m.title.maxWidth = m.top.width
     m.itemIcon.translation = [m.top.width, 10]
-    m.playedIndicator.translation = [m.top.width - m.playedIndicator.width, 22]
+    m.playedIndicator.translation = [m.top.width - m.playedIndicator.width, 14]
 end sub
 
 sub itemContentChanged()

--- a/components/ItemGrid/GridItemSmall.xml
+++ b/components/ItemGrid/GridItemSmall.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="GridItemSmall" extends="Group">
   <children>
-    <Poster id="backdrop" translation="[0,23]" loadDisplayMode="scaleToZoom" uri="pkg:/images/white.9.png" />
-    <Poster id="itemPoster" translation="[0,23]" loadDisplayMode="scaleToZoom" />
+    <Poster id="backdrop" translation="[0,15]" loadDisplayMode="scaleToZoom" uri="pkg:/images/white.9.png" />
+    <Poster id="itemPoster" translation="[0,15]" loadDisplayMode="scaleToZoom" />
 
     <ScrollingText id="title" horizAlign="center" font="font:SmallSystemFont" repeatCount="0" />
 


### PR DESCRIPTION
## Changes
The focus highlight was vertically offset above the poster artwork when navigating movie and TV show libraries. This change aligns the focus indicator with the poster image.

## Issues
None.
