### PR TITLE
fix(playback): correct audio codec profiles and string serialization

### DIFF
--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -91,7 +91,7 @@ function GetDirectPlayProfiles() as object
     }
     ' all possible codecs (besides those restricted by user settings)
     videoCodecs = ["h264", "mpeg4 avc", "vp8", "vp9", "h263", "mpeg1"]
-    audioCodecs = ["mp3", "mp2", "pcm", "lpcm", "wav", "ac3", "ac4", "aiff", "wma", "flac", "alac", "aac", "dts", "wmapro", "vorbis", "eac3", "mpg123"]
+    audioCodecs = ["mp3", "mp2", "pcm", "lpcm", "wav", "ac3", "ac4", "aiff", "wma", "flac", "alac", "aac", "opus", "dts", "wmapro", "vorbis", "eac3", "mpg123"]
 
     ' check if hevc is disabled
     if globalUserSettings["playback.compatibility.disablehevc"] = false
@@ -146,10 +146,6 @@ function GetDirectPlayProfiles() as object
                 Codec: audioCodec,
                 Container: container
             }).Result
-
-            if isStringEqual(container, "ts") and not inArray(["aac", "ac3", "eac3", "mp3"], audioCodec)
-                canDecode = false
-            end if
 
             if canDecode or (isSurround and isStringEqual(audioCodec, "ac3") and not isStringEqual(container, "mp4"))
                 supportedCodecs[container]["audio"].push(audioCodec)
@@ -348,20 +344,13 @@ function getTranscodingProfiles(videoCodec = string.EMPTY as string) as object
     end for
 
     ' AUDIO CODECS
-    validTsAudio = ["aac", "ac3", "eac3", "mp3"]
-    validMp4Audio = ["aac", "ac3", "eac3", "mp3", "alac", "flac"]
-
     for each container in transcodingContainers
         for each codec in audioCodecs
             if di.CanDecodeAudio({ Codec: codec, Container: container }).result
-                if container = "mp4" and inArray(validMp4Audio, codec)
-                    if mp4AudioCodecs.Instr(0, codec) = -1
-                        mp4AudioCodecs = mp4AudioCodecs + "," + codec
-                    end if
-                else if container = "ts" and inArray(validTsAudio, codec)
-                    if tsAudioCodecs.Instr(0, codec) = -1
-                        tsAudioCodecs = tsAudioCodecs + "," + codec
-                    end if
+                if container = "mp4"
+                    mp4AudioCodecs = mp4AudioCodecs + "," + codec
+                else if container = "ts"
+                    tsAudioCodecs = tsAudioCodecs + "," + codec
                 end if
             end if
         end for

--- a/source/utils/deviceCapabilities.bs
+++ b/source/utils/deviceCapabilities.bs
@@ -91,7 +91,7 @@ function GetDirectPlayProfiles() as object
     }
     ' all possible codecs (besides those restricted by user settings)
     videoCodecs = ["h264", "mpeg4 avc", "vp8", "vp9", "h263", "mpeg1"]
-    audioCodecs = ["mp3", "mp2", "pcm", "lpcm", "wav", "ac3", "ac4", "aiff", "wma", "flac", "alac", "aac", "opus", "dts", "wmapro", "vorbis", "eac3", "mpg123"]
+    audioCodecs = ["mp3", "mp2", "pcm", "lpcm", "wav", "ac3", "ac4", "aiff", "wma", "flac", "alac", "aac", "dts", "wmapro", "vorbis", "eac3", "mpg123"]
 
     ' check if hevc is disabled
     if globalUserSettings["playback.compatibility.disablehevc"] = false
@@ -146,6 +146,10 @@ function GetDirectPlayProfiles() as object
                 Codec: audioCodec,
                 Container: container
             }).Result
+
+            if isStringEqual(container, "ts") and not inArray(["aac", "ac3", "eac3", "mp3"], audioCodec)
+                canDecode = false
+            end if
 
             if canDecode or (isSurround and isStringEqual(audioCodec, "ac3") and not isStringEqual(container, "mp4"))
                 supportedCodecs[container]["audio"].push(audioCodec)
@@ -209,7 +213,7 @@ function getTranscodingProfiles(videoCodec = string.EMPTY as string) as object
     ' does the users setup support surround sound?
     maxAudioChannels = "2" ' jellyfin expects this as a string
     ' in order of preference from left to right
-    audioCodecs = ["eac3", "ac3", "dts", "mp3", "vorbis", "opus", "flac", "alac", "ac4", "pcm", "wma", "wmapro"]
+    audioCodecs = ["aac", "eac3", "ac3", "dts", "mp3", "vorbis", "flac", "alac", "ac4", "pcm", "wma", "wmapro"]
 
     if di.GetAudioOutputChannel() = "5.1 surround"
         maxAudioChannels = "6"
@@ -344,13 +348,20 @@ function getTranscodingProfiles(videoCodec = string.EMPTY as string) as object
     end for
 
     ' AUDIO CODECS
+    validTsAudio = ["aac", "ac3", "eac3", "mp3"]
+    validMp4Audio = ["aac", "ac3", "eac3", "mp3", "alac", "flac"]
+
     for each container in transcodingContainers
         for each codec in audioCodecs
             if di.CanDecodeAudio({ Codec: codec, Container: container }).result
-                if container = "mp4"
-                    mp4AudioCodecs = mp4AudioCodecs + "," + codec
-                else if container = "ts"
-                    tsAudioCodecs = tsAudioCodecs + "," + codec
+                if container = "mp4" and inArray(validMp4Audio, codec)
+                    if mp4AudioCodecs.Instr(0, codec) = -1
+                        mp4AudioCodecs = mp4AudioCodecs + "," + codec
+                    end if
+                else if container = "ts" and inArray(validTsAudio, codec)
+                    if tsAudioCodecs.Instr(0, codec) = -1
+                        tsAudioCodecs = tsAudioCodecs + "," + codec
+                    end if
                 end if
             end if
         end for
@@ -490,7 +501,7 @@ function getCodecProfiles(videoCodec = string.EMPTY as string) as object
                                 {
                                     "Condition": "LessThanEqual",
                                     "Property": "AudioChannels",
-                                    "Value": audioChannel,
+                                    "Value": audioChannel.toStr(),
                                     "IsRequired": true
                                 },
                                 {
@@ -509,7 +520,7 @@ function getCodecProfiles(videoCodec = string.EMPTY as string) as object
                                 {
                                     "Condition": "LessThanEqual",
                                     "Property": "AudioChannels",
-                                    "Value": audioChannel,
+                                    "Value": audioChannel.toStr(),
                                     "IsRequired": true
                                 }
                             ]
@@ -1065,7 +1076,7 @@ function getMaxHeightArray() as object
     return {
         "Condition": "LessThanEqual",
         "Property": "Height",
-        "Value": maxVideoHeight,
+        "Value": maxVideoHeight.toStr(),
         "IsRequired": true
     }
 end function
@@ -1097,7 +1108,7 @@ function getMaxWidthArray() as object
     return {
         "Condition": "LessThanEqual",
         "Property": "Width",
-        "Value": maxVideoWidth,
+        "Value": maxVideoWidth.toStr(),
         "IsRequired": true
     }
 end function


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
# Fix profile condition value string serialization and audio codec playback profiles

## Changes
This PR aligns client device profile conditions with the Jellyfin OpenAPI specification and resolves silent audio playback for Opus-encoded video streams on Roku devices:
* Converts `ProfileCondition.Value` for `AudioChannels`, `Height`, and `Width` to string values (`.toStr()`) in `source/utils/deviceCapabilities.bs` to strictly comply with the OpenAPI schema.
* Removes `opus` from video container `DirectPlayProfiles` so the server remuxes video (`VideoCodec=copy`) and transcodes Opus audio to stereo AAC (`AudioCodec=aac`), resolving silent playback on Roku SceneGraph `Video` nodes.
* Enforces container-specific audio codec validation for MPEG-TS and MP4 containers in `GetDirectPlayProfiles()` and `getTranscodingProfiles()`.

## Issues
* Fixes #986

---

### Additional Details
1. **OpenAPI Schema Compliance**: `ProfileCondition.Value` is defined as a string in the Jellyfin OpenAPI schema. Emitting integer values for `AudioChannels`, `Height`, and `Width` caused schema validation errors and HTTP 422 responses on strictly-typed backends.
2. **Opus Audio Decoding on Roku**: Roku SceneGraph `Video` nodes do not decode Opus audio tracks muxed inside video containers (resulting in silent playback or severe buzzing artifacts). Removing `opus` from video direct play profiles ensures the server direct-streams (remuxes) the video while transcoding audio to AAC.
3. **MPEG-TS Audio Codec Restrictions**: Restricts direct play and transcoding profiles for `ts` containers to codecs supported natively by Roku hardware (`aac`, `ac3`, `eac3`, `mp3`).

### Testing
* Verified on Roku hardware:
  * Profile conditions correctly serialize as strings in `DeviceProfile` payloads.
  * MKV video files with Opus audio remux cleanly with AAC audio transcode.
  * Direct play of AAC/AC3 content continues to function normally.
* Code passes `npm run build` with 0 compilation errors.
