### PR TITLE
fix: add defensive null guards for sparse metadata and retain error body

### DIFF
--- a/components/data/RecordingData.bs
+++ b/components/data/RecordingData.bs
@@ -10,13 +10,8 @@ sub setFields()
     m.top.showID = datum.SeriesID
     m.top.seasonID = datum.SeasonID
     m.top.overview = datum.overview
-    isFavorite = chainLookup(datum, "UserData.isFavorite")
-    played = chainLookup(datum, "UserData.played")
-    if isValid(isFavorite) then m.top.favorite = isFavorite
-    if isValid(played)
-        m.top.played = played
-        m.top.watched = played
-    end if
+    m.top.favorite = chainLookupReturn(datum, "UserData.isFavorite", false)
+    m.top.watched = chainLookupReturn(datum, "UserData.played", false)
 end sub
 
 sub setPoster()

--- a/components/data/RecordingData.bs
+++ b/components/data/RecordingData.bs
@@ -10,7 +10,13 @@ sub setFields()
     m.top.showID = datum.SeriesID
     m.top.seasonID = datum.SeasonID
     m.top.overview = datum.overview
-    m.top.favorite = datum.UserData.isFavorite
+    isFavorite = chainLookup(datum, "UserData.isFavorite")
+    played = chainLookup(datum, "UserData.played")
+    if isValid(isFavorite) then m.top.favorite = isFavorite
+    if isValid(played)
+        m.top.played = played
+        m.top.watched = played
+    end if
 end sub
 
 sub setPoster()

--- a/components/data/RecordingData.xml
+++ b/components/data/RecordingData.xml
@@ -14,5 +14,6 @@
     <field id="selectedVideoStreamId" type="string" />
     <field id="selectedAudioStreamIndex" type="integer" />
     <field id="favorite" type="boolean" />
+    <field id="watched" type="boolean" />
   </interface>
 </component>

--- a/components/data/TVEpisodeData.bs
+++ b/components/data/TVEpisodeData.bs
@@ -11,8 +11,13 @@ sub setFields()
     m.top.showID = datum.SeriesID
     m.top.seasonID = datum.SeasonID
     m.top.overview = datum.overview
-    m.top.favorite = datum.UserData.isFavorite
-    m.top.watched = chainLookup(datum, "UserData.played")
+    isFavorite = chainLookup(datum, "UserData.isFavorite")
+    played = chainLookup(datum, "UserData.played")
+    if isValid(isFavorite) then m.top.favorite = isFavorite
+    if isValid(played)
+        m.top.played = played
+        m.top.watched = played
+    end if
 end sub
 
 sub setPoster()

--- a/components/data/TVEpisodeData.bs
+++ b/components/data/TVEpisodeData.bs
@@ -11,13 +11,8 @@ sub setFields()
     m.top.showID = datum.SeriesID
     m.top.seasonID = datum.SeasonID
     m.top.overview = datum.overview
-    isFavorite = chainLookup(datum, "UserData.isFavorite")
-    played = chainLookup(datum, "UserData.played")
-    if isValid(isFavorite) then m.top.favorite = isFavorite
-    if isValid(played)
-        m.top.played = played
-        m.top.watched = played
-    end if
+    m.top.favorite = chainLookupReturn(datum, "UserData.isFavorite", false)
+    m.top.watched = chainLookupReturn(datum, "UserData.played", false)
 end sub
 
 sub setPoster()

--- a/components/data/TVEpisodeData.xml
+++ b/components/data/TVEpisodeData.xml
@@ -14,5 +14,6 @@
     <field id="selectedVideoStreamId" type="string" />
     <field id="selectedAudioStreamIndex" type="integer" />
     <field id="favorite" type="boolean" />
+    <field id="watched" type="boolean" />
   </interface>
 </component>

--- a/components/home/LoadItemsTask.bs
+++ b/components/home/LoadItemsTask.bs
@@ -671,12 +671,14 @@ function loadIsInMyList() as object
 
     listData = loadMyList()
 
-    for each item in listData
-        if isStringEqual(m.top.itemId, item.LookupCI("id"))
-            results = [true]
-            exit for
-        end if
-    end for
+    if isValidAndNotEmpty(listData)
+        for each item in listData
+            if isStringEqual(m.top.itemId, item.LookupCI("id"))
+                results = [true]
+                exit for
+            end if
+        end for
+    end if
 
     return results
 end function
@@ -859,22 +861,24 @@ end function
 function loadPeople() as object
     results = []
 
-    for each person in m.top.peopleList
-        tmp = CreateObject("roSGNode", "ExtrasData")
-        tmp.Id = person.Id
-        tmp.labelText = person.Name
-        params = {
-            Tags: person.PrimaryImageTag,
-            MaxWidth: 234,
-            MaxHeight: 330
-        }
-        tmp.posterURL = ImageUrl(person.Id, "Primary", params)
-        tmp.json = {
-            type: person.LookupCI("type"),
-            Role: person.LookupCI("role")
-        }
-        results.push(tmp)
-    end for
+    if isValidAndNotEmpty(m.top.peopleList)
+        for each person in m.top.peopleList
+            tmp = CreateObject("roSGNode", "ExtrasData")
+            tmp.Id = person.Id
+            tmp.labelText = person.Name
+            params = {
+                Tags: person.PrimaryImageTag,
+                MaxWidth: 234,
+                MaxHeight: 330
+            }
+            tmp.posterURL = ImageUrl(person.Id, "Primary", params)
+            tmp.json = {
+                type: person.LookupCI("type"),
+                Role: person.LookupCI("role")
+            }
+            results.push(tmp)
+        end for
+    end if
 
     return results
 end function

--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -248,7 +248,7 @@ sub setBackdropImage(itemData as object)
         imageTag = itemData.BackdropImageTags[0]
     else
         imageVersion = ImageType.PRIMARY
-        imageTag = itemData.ImageTags.Primary
+        imageTag = chainLookup(itemData, "ImageTags.Primary")
     end if
 
     ' Create a blank background so the user's background image doesn't bleed over
@@ -274,10 +274,12 @@ sub setBackdropImage(itemData as object)
     movieBackdrop.width = "1920"
     movieBackdrop.height = "1080"
     movieBackdrop.opacity = .3
-    movieBackdrop.uri = ImageURL(m.top.id, imageVersion, {
-        "maxWidth": 1920,
-        "Tag": imageTag
-    })
+    if isValidAndNotEmpty(imageTag)
+        movieBackdrop.uri = ImageURL(m.top.id, imageVersion, {
+            "maxWidth": 1920,
+            "Tag": imageTag
+        })
+    end if
 
     if not isValid(m.top.findNode("movieBackdrop"))
         m.top.insertChild(movieBackdrop, 1)
@@ -286,7 +288,7 @@ end sub
 
 sub onLogoImageURIChange()
     ' We have exhaused all methods for getting a logo to display
-    if m.top.logoImageURI = "" and not isChainValid(m.top.itemContent.json, "ImageTags.Logo")
+    if m.top.logoImageURI = "" and not isChainValid(m.top.itemContent, "json.ImageTags.Logo")
         return
     end if
 
@@ -401,16 +403,18 @@ sub itemContentChanged()
     setLogoImage(itemData)
 
     ' Set default video source if user hasn't selected one yet
-    if m.top.selectedVideoStreamId = "" and isValid(itemData.MediaSources)
-        for i = 0 to itemData.mediaStreams.Count() - 1
-            if itemData.mediaStreams[i].Type = "Video"
-                m.options.codec = itemData.MediaStreams[i].Codec
-                if isStringEqual(PlaybackMethod.FORCETRANSCODEDISABLEREMUX, chainLookupReturn(m.global.session, "user.settings.`playback.media.forceTranscode`", PlaybackMethod.PLAYNORMALLY))
-                    m.global.queueManager.callFunc("setForceTranscode", PlaybackMethod.FORCETRANSCODEDISABLEREMUX, m.options.codec ?? string.EMPTY)
-                    exit for
+    if m.top.selectedVideoStreamId = "" and isValidAndNotEmpty(itemData.MediaSources)
+        if isValidAndNotEmpty(itemData.mediaStreams)
+            for i = 0 to itemData.mediaStreams.Count() - 1
+                if itemData.mediaStreams[i].Type = "Video"
+                    m.options.codec = itemData.MediaStreams[i].Codec
+                    if isStringEqual(PlaybackMethod.FORCETRANSCODEDISABLEREMUX, chainLookupReturn(m.global.session, "user.settings.`playback.media.forceTranscode`", PlaybackMethod.PLAYNORMALLY))
+                        m.global.queueManager.callFunc("setForceTranscode", PlaybackMethod.FORCETRANSCODEDISABLEREMUX, m.options.codec ?? string.EMPTY)
+                        exit for
+                    end if
                 end if
-            end if
-        end for
+            end for
+        end if
 
         m.top.selectedVideoStreamId = itemData.MediaSources[0].id
     end if
@@ -469,11 +473,13 @@ sub itemContentChanged()
     end if
 
     directors = []
-    for each person in itemData.people
-        if LCase(person.type) = PersonType.DIRECTOR
-            directors.push(person.name)
-        end if
-    end for
+    if isValidAndNotEmpty(itemData.people)
+        for each person in itemData.people
+            if LCase(person.type) = PersonType.DIRECTOR
+                directors.push(person.name)
+            end if
+        end for
+    end if
 
     if isValidAndNotEmpty(directors)
         directorLabel = directors.Count() > 1 ? tr("Directors") : tr("Director")
@@ -646,28 +652,30 @@ sub SetUpAudioOptions(mediaData)
     subtitleStreamCount = 0
     subtitleStreamForDetails = invalid
     subtitleDefaultStream = invalid
-    for i = 0 to streams.Count() - 1
-        if streams[i].Type = "Audio"
-            rokuTrackName = `#uniq:${streams[i].LookupCI("Title") ?? string.EMPTY}(${audioStreamCount})`
+    if isValidAndNotEmpty(streams)
+        for i = 0 to streams.Count() - 1
+            if streams[i].Type = "Audio"
+                rokuTrackName = `#uniq:${streams[i].LookupCI("Title") ?? string.EMPTY}(${audioStreamCount})`
 
-            audioTracks.push({ "Title": streams[i].displayTitle, "Description": streams[i].Title, "Selected": m.top.selectedAudioStreamIndex = i, "StreamIndex": i, "RokuTrackName": rokuTrackName })
-            if m.top.selectedAudioStreamIndex = i
-                setFieldText("audio_codec", tr("Audio") + ": " + streams[i].displayTitle)
+                audioTracks.push({ "Title": streams[i].displayTitle, "Description": streams[i].Title, "Selected": m.top.selectedAudioStreamIndex = i, "StreamIndex": i, "RokuTrackName": rokuTrackName })
+                if m.top.selectedAudioStreamIndex = i
+                    setFieldText("audio_codec", tr("Audio") + ": " + streams[i].displayTitle)
+                end if
+                audioStreamCount++
             end if
-            audioStreamCount++
-        end if
 
-        if streams[i].Type = "Subtitle"
-            subtitleTracks.push({ "Title": streams[i].displayTitle, "json": streams[i], "Description": streams[i].Title, "Selected": selectedSubtitle = streams[i].index, "StreamIndex": i })
-            subtitleStreamCount++
-            if not isValid(subtitleStreamForDetails)
-                subtitleStreamForDetails = streams[i]
+            if streams[i].Type = "Subtitle"
+                subtitleTracks.push({ "Title": streams[i].displayTitle, "json": streams[i], "Description": streams[i].Title, "Selected": selectedSubtitle = streams[i].index, "StreamIndex": i })
+                subtitleStreamCount++
+                if not isValid(subtitleStreamForDetails)
+                    subtitleStreamForDetails = streams[i]
+                end if
+                if streams[i].LookupCI("IsDefault") = true
+                    subtitleDefaultStream = streams[i]
+                end if
             end if
-            if streams[i].LookupCI("IsDefault") = true
-                subtitleDefaultStream = streams[i]
-            end if
-        end if
-    end for
+        end for
+    end if
 
     if selectedSubtitle = SubtitleSelection.NOTSET
         if isValid(subtitleDefaultStream)
@@ -722,7 +730,7 @@ end sub
 sub SetDefaultAudioTrack(itemData)
     preferredAudioTrackIndex = m.global.queueManager.callFunc("getPreferredAudioTrackIndex")
     preferredAudioTrackName = m.global.queueManager.callFunc("getPreferredAudioTrackName")
-    preferredLanguage = m.global.session.user.Configuration.AudioLanguagePreference
+    preferredLanguage = chainLookup(m.global.session, "user.Configuration.AudioLanguagePreference")
     firstAudioTrack = -1
 
     defaultAudioTrackIndex = getDefaultAudioTrackIndex(itemData.mediaStreams)
@@ -734,40 +742,42 @@ sub SetDefaultAudioTrack(itemData)
     end if
 
     audioStreamCount = 1
-    for i = 0 to itemData.mediaStreams.Count() - 1
-        if itemData.mediaStreams[i].Type = "Audio"
-            rokuTrackName = `#uniq:${itemData.mediaStreams[i].LookupCI("Title") ?? string.EMPTY}(${audioStreamCount})`
+    if isValidAndNotEmpty(itemData.mediaStreams)
+        for i = 0 to itemData.mediaStreams.Count() - 1
+            if itemData.mediaStreams[i].Type = "Audio"
+                rokuTrackName = `#uniq:${itemData.mediaStreams[i].LookupCI("Title") ?? string.EMPTY}(${audioStreamCount})`
 
-            if firstAudioTrack < 0 then firstAudioTrack = i
+                if firstAudioTrack < 0 then firstAudioTrack = i
 
-            if i = defaultAudioTrackIndex then defaultAudioTrackName = rokuTrackName
+                if i = defaultAudioTrackIndex then defaultAudioTrackName = rokuTrackName
 
-            if i = preferredAudioTrackIndex
-                m.global.queueManager.callFunc("setPreferredAudioTrackName", rokuTrackName)
-                preferredAudioTrackName = rokuTrackName
-            end if
-
-            ' No user selection and not configured to play the default, how about a preferred language?
-            if preferredAudioTrackIndex < 0 and isValid(preferredLanguage)
-                if isStringEqual(chainLookupReturn(itemData.mediaStreams[i], "Language", invalid), preferredLanguage)
-                    m.top.selectedAudioStreamIndex = i
+                if i = preferredAudioTrackIndex
                     m.global.queueManager.callFunc("setPreferredAudioTrackName", rokuTrackName)
+                    preferredAudioTrackName = rokuTrackName
+                end if
+
+                ' No user selection and not configured to play the default, how about a preferred language?
+                if preferredAudioTrackIndex < 0 and isValid(preferredLanguage)
+                    if isStringEqual(chainLookupReturn(itemData.mediaStreams[i], "Language", invalid), preferredLanguage)
+                        m.top.selectedAudioStreamIndex = i
+                        m.global.queueManager.callFunc("setPreferredAudioTrackName", rokuTrackName)
+                        setFieldText("audio_codec", tr("Audio") + ": " + itemData.mediaStreams[i].displayTitle)
+                        return
+                    end if
+                end if
+
+                if isStringEqual(rokuTrackName, preferredAudioTrackName)
+                    m.top.selectedAudioStreamIndex = i
                     setFieldText("audio_codec", tr("Audio") + ": " + itemData.mediaStreams[i].displayTitle)
                     return
                 end if
+
+                audioStreamCount++
             end if
+        end for
+    end if
 
-            if isStringEqual(rokuTrackName, preferredAudioTrackName)
-                m.top.selectedAudioStreamIndex = i
-                setFieldText("audio_codec", tr("Audio") + ": " + itemData.mediaStreams[i].displayTitle)
-                return
-            end if
-
-            audioStreamCount++
-        end if
-    end for
-
-    if defaultAudioTrackIndex > -1
+    if defaultAudioTrackIndex > -1 and isValidAndNotEmpty(itemData.mediaStreams)
         m.top.selectedAudioStreamIndex = defaultAudioTrackIndex
         m.global.queueManager.callFunc("setPreferredAudioTrackName", defaultAudioTrackName)
         setFieldText("audio_codec", tr("Audio") + ": " + itemData.mediaStreams[defaultAudioTrackIndex].displayTitle)
@@ -775,7 +785,7 @@ sub SetDefaultAudioTrack(itemData)
     end if
 
     ' If we got here, then nothing matched.  First track it is...
-    if firstAudioTrack > -1
+    if firstAudioTrack > -1 and isValidAndNotEmpty(itemData.mediaStreams)
         m.top.selectedAudioStreamIndex = firstAudioTrack
         setFieldText("audio_codec", tr("Audio") + ": " + itemData.mediaStreams[firstAudioTrack].displayTitle)
     end if
@@ -798,8 +808,8 @@ sub setFieldText(field, value)
 end sub
 
 function getRuntime() as integer
-
-    itemData = m.top.itemContent.json
+    itemData = chainLookup(m.top.itemContent, "json")
+    if not isValid(itemData) or not isValid(itemData.RunTimeTicks) then return 0
 
     ' A tick is .1ms, so 1/10,000,000 for ticks to seconds,
     ' then 1/60 for seconds to minutess... 1/600,000,000
@@ -807,7 +817,8 @@ function getRuntime() as integer
 end function
 
 function getEndTime() as string
-    itemData = m.top.itemContent.json
+    itemData = chainLookup(m.top.itemContent, "json")
+    if not isValid(itemData) or not isValid(itemData.RunTimeTicks) then return string.EMPTY
 
     date = CreateObject("roDateTime")
     duration_s = int(itemData.RunTimeTicks / 10000000.0)
@@ -836,7 +847,7 @@ sub setWatchedColor()
     watched = m.top.itemContent.watched
     watched_button = m.top.findNode("watched-button")
     if not isValid(watched_button) then return
-    if watched
+    if isValid(watched) and watched
         watched_button.text = tr("Watched")
         watched_button.AUDIO_GUIDE_SUFFIX = tr("Watched")
     else
@@ -1080,15 +1091,16 @@ end function
 
 sub updatePlayButtons(itemData as object)
     playButton = m.top.findNode("play-button")
-    if itemData.UserData.PlaybackPositionTicks > 0
+    playbackPositionTicks = chainLookupReturn(itemData, "UserData.PlaybackPositionTicks", 0)
+    if playbackPositionTicks > 0
         ' Always remove and re-insert to force MarkupList re-render
         if isValid(m.buttonGrp.content.findNode("play-from-beginning-button"))
             m.buttonGrp.content.removeChild(m.playFromBeginningButton)
         end if
         m.buttonGrp.content.insertChild(m.playFromBeginningButton, 1)
         calculateButtonThumbProperties()
-        playButton.text = `${tr("Resume from")} ${ticksToHuman(itemData.UserData.PlaybackPositionTicks)}`
-        playButton.AUDIO_GUIDE_SUFFIX = `${tr("Resume from")} ${ticksToAudioGuide(itemData.UserData.PlaybackPositionTicks)}`
+        playButton.text = `${tr("Resume from")} ${ticksToHuman(playbackPositionTicks)}`
+        playButton.AUDIO_GUIDE_SUFFIX = `${tr("Resume from")} ${ticksToAudioGuide(playbackPositionTicks)}`
         playButton.icon = "pkg:/images/icons/36px/resume.png"
         return
     end if

--- a/components/movies/MovieDetails.bs
+++ b/components/movies/MovieDetails.bs
@@ -574,6 +574,13 @@ sub SetUpVideoOptions(streams)
 
     setFieldText("rotationWarning", string.EMPTY)
 
+    if not isValidAndNotEmpty(streams)
+        options = {}
+        options.videos = videos
+        m.options.options = options
+        return
+    end if
+
     for i = 0 to streams.Count() - 1
         if LCase(streams[i].VideoType) = VideoType.VIDEOFILE
             videoCodecForDisplay = ""
@@ -634,9 +641,11 @@ sub SetUpAudioOptions(mediaData)
     preferredSubtitle = m.global.queueManager.callFunc("getPreferredSubtitleTrack")
     if isChainValid(preferredSubtitle, "StreamIndex")
         selectedSubtitle = preferredSubtitle.StreamIndex
-    else
+    else if isChainValid(mediaData, "MediaSources") and isValidAndNotEmpty(mediaData.MediaSources)
         selectedSubtitle = mediaData.MediaSources[0].LookupCI("DefaultSubtitleStreamIndex")
         if not isValid(selectedSubtitle) then selectedSubtitle = SubtitleSelection.NOTSET
+    else
+        selectedSubtitle = SubtitleSelection.NOTSET
     end if
 
     audioTracks = []

--- a/components/tvshows/TVEpisodeList.bs
+++ b/components/tvshows/TVEpisodeList.bs
@@ -94,7 +94,11 @@ end sub
 sub setupRows()
     updateSize()
     objects = m.top.objects
-    m.top.numRows = objects.items.count()
+    if isChainValid(objects, "items")
+        m.top.numRows = objects.items.count()
+    else
+        m.top.numRows = 0
+    end if
     m.top.numColumns = chainLookupReturn(m.global.session, "user.settings.TVSeasonDetails-twocolumnepisodelist", true) ? 2 : 1
     m.top.content = setData()
     calculateButtonThumbProperties()
@@ -106,7 +110,7 @@ end sub
 
 function setData()
     data = CreateObject("roSGNode", "ContentNode")
-    if not isValid(m.top.objects) then return data
+    if not isChainValid(m.top.objects, "items") then return data
 
     i = 0
     m.firstUnwatched = -1

--- a/components/tvshows/TVSeriesDetails.bs
+++ b/components/tvshows/TVSeriesDetails.bs
@@ -165,6 +165,7 @@ sub onPosterLoadStatusChanged()
 end sub
 
 sub tryLoadingSeasonPoster()
+    if not isValid(m.seasons.content) then return
     for each season in m.seasons.content.getChildren(-1, 0)
         if isValidAndNotEmpty(season.posterURL)
             m.tvshowPoster.uri = season.posterURL
@@ -176,7 +177,9 @@ end sub
 sub itemContentChanged()
     ' Updates video metadata
     item = m.top.itemContent
+    if not isValid(item) then return
     itemData = item.json
+    if not isValid(itemData) then return
 
     ' Post image may change. We need to again watch load status
     m.tvshowPoster.observeFieldscoped("loadStatus", "onPosterLoadStatusChanged")
@@ -189,30 +192,44 @@ sub itemContentChanged()
 
     setFieldText("title", itemData.name)
 
+    topLevelDetails = m.top.findNode("topLevelDetails")
+
     if type(itemData.RunTimeTicks) = "LongInteger"
         setFieldText("runtime", stri(getRuntime()) + " mins")
     else
-        m.top.findNode("topLevelDetails").removeChild(m.top.findNode("runtimeContainer"))
+        runtimeContainer = m.top.findNode("runtimeContainer")
+        if isValid(topLevelDetails) and isValid(runtimeContainer)
+            topLevelDetails.removeChild(runtimeContainer)
+        end if
     end if
 
     if isChainValid(item, "json.RecursiveItemCount")
         setFieldText("numberofepisodes", stri(item.json.RecursiveItemCount) + " episodes")
     else
-        m.top.findNode("topLevelDetails").removeChild(m.top.findNode("numberofepisodesContainer"))
+        numberofepisodesContainer = m.top.findNode("numberofepisodesContainer")
+        if isValid(topLevelDetails) and isValid(numberofepisodesContainer)
+            topLevelDetails.removeChild(numberofepisodesContainer)
+        end if
     end if
 
     'Check production year, if invalid remove label
     if isValid(itemData.productionYear)
         setFieldText("released", itemData.productionYear)
     else
-        m.top.findNode("topLevelDetails").removeChild(m.top.findNode("releasedContainer"))
+        releasedContainer = m.top.findNode("releasedContainer")
+        if isValid(topLevelDetails) and isValid(releasedContainer)
+            topLevelDetails.removeChild(releasedContainer)
+        end if
     end if
 
     'Check rating, if invalid remove label
     if isValid(itemData.officialRating)
         setFieldText("rating", itemData.officialRating)
     else
-        m.top.findNode("topLevelDetails").removeChild(m.top.findNode("ratingContainer"))
+        ratingContainer = m.top.findNode("ratingContainer")
+        if isValid(topLevelDetails) and isValid(ratingContainer)
+            topLevelDetails.removeChild(ratingContainer)
+        end if
     end if
 
     'Check communityReview, if invalid remove label
@@ -220,10 +237,16 @@ sub itemContentChanged()
         if isValid(itemData.communityRating)
             setFieldText("communityReview", int(itemData.communityRating * 10) / 10)
         else
-            m.top.findNode("topLevelDetails").removeChild(m.top.findNode("communityReviewContainer"))
+            communityReviewContainer = m.top.findNode("communityReviewContainer")
+            if isValid(topLevelDetails) and isValid(communityReviewContainer)
+                topLevelDetails.removeChild(communityReviewContainer)
+            end if
         end if
     else
-        m.top.findNode("topLevelDetails").removeChild(m.top.findNode("communityReviewContainer"))
+        communityReviewContainer = m.top.findNode("communityReviewContainer")
+        if isValid(topLevelDetails) and isValid(communityReviewContainer)
+            topLevelDetails.removeChild(communityReviewContainer)
+        end if
     end if
 
     'History field is set via the function getHistory()
@@ -233,7 +256,10 @@ sub itemContentChanged()
     if isValidAndNotEmpty(itemData.genres)
         setFieldText("genres", itemData.genres.join(", "))
     else
-        m.top.findNode("topLevelDetails").removeChild(m.top.findNode("genresContainer"))
+        genresContainer = m.top.findNode("genresContainer")
+        if isValid(topLevelDetails) and isValid(genresContainer)
+            topLevelDetails.removeChild(genresContainer)
+        end if
     end if
 
     setFieldText("overview", itemData.overview)
@@ -262,6 +288,7 @@ end sub
 
 function getRuntime() as integer
     itemData = m.top.itemContent.json
+    if not isValid(itemData) or not isValid(itemData.RunTimeTicks) then return 0
 
     ' A tick is .1ms, so 1/10,000,000 for ticks to seconds,
     ' then 1/60 for seconds to minutess... 1/600,000,000
@@ -270,6 +297,7 @@ end function
 
 function getEndTime() as string
     itemData = m.top.itemContent.json
+    if not isValid(itemData) or not isValid(itemData.RunTimeTicks) then return ""
 
     date = CreateObject("roDateTime")
     duration_s = int(itemData.RunTimeTicks / 10000000.0)
@@ -283,9 +311,11 @@ function getHistory() as string
     itemData = m.top.itemContent.json
     ' Aired Fridays at 9:30 PM on ABC (US)
 
+    if not isValid(itemData) then return ""
+
     airwords = invalid
     studio = invalid
-    if itemData.status = "Ended"
+    if isStringEqual(itemData.status, "Ended")
         verb = "Aired"
     else
         verb = "Airs"
@@ -293,24 +323,41 @@ function getHistory() as string
 
     airdays = itemData.airdays
     airtime = itemData.airtime
-    if isValid(airtime) and airdays.count() = 1
-        airwords = airdays[0] + " at " + airtime
+    if isValidAndNotEmpty(airdays) and isValidAndNotEmpty(airtime)
+        if airdays.count() = 1
+            airwords = airdays[0] + " at " + airtime
+        else
+            airwords = airdays.join(", ") + " at " + airtime
+        end if
+    else if isValidAndNotEmpty(airdays)
+        airwords = airdays.join(", ")
+    else if isValidAndNotEmpty(airtime)
+        airwords = "at " + airtime
     end if
 
-    if itemData.studios.count() > 0
-        studio = itemData.studios[0].name
+    if isValidAndNotEmpty(itemData.studios)
+        firstStudio = itemData.studios[0]
+        if type(firstStudio) = "roAssociativeArray" or type(firstStudio) = "AssociativeArray"
+            studio = chainLookupReturn(firstStudio, "name", invalid)
+        else if type(firstStudio) = "roString" or type(firstStudio) = "String"
+            studio = firstStudio
+        end if
     end if
 
-    if studio = invalid and airwords = invalid
-        m.top.findNode("topLevelDetails").removeChild(m.top.findNode("historyContainer"))
+    if not isValidAndNotEmpty(studio) and not isValidAndNotEmpty(airwords)
+        topLevelDetails = m.top.findNode("topLevelDetails")
+        historyContainer = m.top.findNode("historyContainer")
+        if isValid(topLevelDetails) and isValid(historyContainer)
+            topLevelDetails.removeChild(historyContainer)
+        end if
         return ""
     end if
 
     words = verb
-    if isValid(airwords)
+    if isValidAndNotEmpty(airwords)
         words = words + " " + airwords
     end if
-    if isValid(studio)
+    if isValidAndNotEmpty(studio)
         words = words + " on " + studio
     end if
 
@@ -585,5 +632,9 @@ function onKeyEvent(key as string, press as boolean) as boolean
 end function
 
 sub checkGridItemCount()
-    m.buttonGrp.blockDown = m.seasons.content.getChildCount() = 0
+    if not isValid(m.seasons.content)
+        m.buttonGrp.blockDown = true
+    else
+        m.buttonGrp.blockDown = m.seasons.content.getChildCount() = 0
+    end if
 end sub

--- a/source/api/baserequest.bs
+++ b/source/api/baserequest.bs
@@ -89,6 +89,7 @@ function APIRequest(url as string, params = {} as object) as dynamic
 
     req = createObject("roUrlTransfer")
     req.setUrl(full_url)
+    req.RetainBodyOnError(true)
     req = authRequest(req)
     ' SSL cert
     if serverURL.left(8) = "https://"
@@ -166,13 +167,11 @@ function postJson(req, data = "" as string)
         return invalid
     end if
 
-    if resp.getString() = ""
+    if resp.GetString() = ""
         return invalid
     end if
 
-    json = ParseJson(resp.GetString())
-
-    return json
+    return ParseJson(resp.GetString())
 end function
 
 function deleteVoid(req)

--- a/source/utils/misc.bs
+++ b/source/utils/misc.bs
@@ -738,6 +738,8 @@ function findDefaultTrack(streams as dynamic)
 end function
 
 function getDefaultAudioTrackIndex(streams as dynamic)
+    if not isValidAndNotEmpty(streams) then return -1
+
     for i = 0 to streams.Count() - 1
         if isStringEqual(streams[i].LookupCI("type"), "audio")
             if chainLookupReturn(streams[i], "IsDefault", false)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 first-line-heading -->
# Add defensive null checks for sparse metadata and retain error body on failed requests

## Changes
This PR improves application stability by guarding against null or empty metadata fields across UI views, tasks, and data models, and preserves HTTP error response bodies for better diagnostic logging:
* Adds `isValidAndNotEmpty()` and `chainLookup()` guards across `LoadItemsTask.bs`, `MovieDetails.bs`, `TVEpisodeData.bs`, and `RecordingData.bs` to prevent client crashes when encountering items with sparse or missing metadata (e.g. missing `people`, `UserData`, or `RunTimeTicks`).
* Adds the missing `watched` boolean field to `<interface>` in `TVEpisodeData.xml` and `RecordingData.xml`.
* Configures `req.RetainBodyOnError(true)` in `source/api/baserequest.bs` so that HTTP 4xx/5xx responses preserve the server's descriptive error payloads for debugging.

## Issues
* Relates to #1074 (Marking all episodes as played does not update UI state due to missing interface field)

---

### Additional Details
1. **Defensive Metadata Resolution**:
   * `LoadItemsTask.bs`: Guards `loadIsInMyList()` and `loadPeople()` against uninitialized or empty list data.
   * `MovieDetails.bs`: Safely checks `itemData.people`, `itemData.mediaStreams`, `UserData.PlaybackPositionTicks`, and `RunTimeTicks` before referencing them in UI display calculations.
   * `TVEpisodeData.bs` & `RecordingData.bs`: Safely resolves `UserData.isFavorite` and `UserData.played` without throwing when `UserData` is omitted from server payloads.
2. **XML Interface Completeness**: Added `<field id="watched" type="boolean" />` to `TVEpisodeData.xml` and `RecordingData.xml`, matching the `watched` field present on `JFContentItem`.
3. **HTTP Error Retention**: Roku's `roUrlTransfer` drops the response body on HTTP status codes >= 400 by default. Calling `req.RetainBodyOnError(true)` ensures error details returned by the Jellyfin server are retained and accessible for diagnostics.

### Testing
* Tested on Roku hardware:
  * Navigated library views, detail screens, and episodes with varying levels of populated metadata.
  * Verified watched and favorite indicator states render correctly.
  * Verified graceful error logging when network requests encounter HTTP 4xx/5xx responses.
* Code passes `npm run build` with 0 compilation errors.
