### PR TITLE
Create warning popup for Rokus running OS versions older than 15.1

### DIFF
--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2647,5 +2647,9 @@
             <source>Starts With</source>
             <translation>Starts With</translation>
         </message>
+        <message>
+            <source>This Roku will stop receiving Jellyfin for Roku updates on October 1 due to Roku's new OS 15.1 minimum requirement. You can continue using the installed app, but it will never update unless you update your Roku OS. All releases will be blocked unless we make this change. We're forced to do this, so if you're affected, contact Roku. Don't yell at us. You can hide this popup by disabling the 'User Interface / General / Show Roku OS Version Popup' setting.</source>
+            <translation>This Roku will stop receiving Jellyfin for Roku updates on October 1 due to Roku's new OS 15.1 minimum requirement. You can continue using the installed app, but it will never update unless you update your Roku OS. All releases will be blocked unless we make this change. We're forced to do this, so if you're affected, contact Roku. Don't yell at us. You can hide this popup by disabling the 'User Interface / General / Show Roku OS Version Popup' setting.</translation>
+        </message>
     </context>
 </TS>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2648,8 +2648,20 @@
             <translation>Starts With</translation>
         </message>
         <message>
-            <source>This Roku will stop receiving Jellyfin for Roku updates on October 1 due to Roku's new OS 15.1 minimum requirement. You can continue using the installed app, but it will never update unless you update your Roku OS. All releases will be blocked unless we make this change. We're forced to do this, so if you're affected, contact Roku. Don't yell at us. You can hide this popup by disabling the 'User Interface / General / Show Roku OS Version Popup' setting.</source>
-            <translation>This Roku will stop receiving Jellyfin for Roku updates on October 1 due to Roku's new OS 15.1 minimum requirement. You can continue using the installed app, but it will never update unless you update your Roku OS. All releases will be blocked unless we make this change. We're forced to do this, so if you're affected, contact Roku. Don't yell at us. You can hide this popup by disabling the 'User Interface / General / Show Roku OS Version Popup' setting.</translation>
+            <source>This Roku will stop receiving Jellyfin for Roku updates on October 1, 2026 due to Roku's new OS 15.1 minimum requirement. You can continue using the installed app, but it will never update unless you update your Roku OS.</source>
+            <translation>This Roku will stop receiving Jellyfin for Roku updates on October 1, 2026 due to Roku's new OS 15.1 minimum requirement. You can continue using the installed app, but it will never update unless you update your Roku OS.</translation>
+        </message>
+        <message>
+            <source>All releases will be blocked unless we make this change. We're forced to do this, so if you're affected, contact Roku. Don't yell at us.</source>
+            <translation>All releases will be blocked unless we make this change. We're forced to do this, so if you're affected, contact Roku. Don't yell at us.</translation>
+        </message>
+        <message>
+            <source>You can hide this popup by disabling the 'User Interface / General / Show Roku OS Version Popup' setting.</source>
+            <translation>You can hide this popup by disabling the 'User Interface / General / Show Roku OS Version Popup' setting.</translation>
+        </message>
+        <message>
+            <source>Roku OS Version Warning</source>
+            <translation>Roku OS Version Warning</translation>
         </message>
     </context>
 </TS>

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -802,6 +802,13 @@
             "default": "false"
           },
           {
+            "title": "Show Roku OS Version Popup",
+            "description": "Show Roku OS Version popup when app starts.",
+            "settingName": "load.rokuospopup",
+            "type": "bool",
+            "default": "true"
+          },
+          {
             "title": "Show What's New Popup",
             "description": "Show What's New popup when Jellyfin is updated to a new version.",
             "settingName": "load.allowwhatsnew",

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -239,7 +239,13 @@ sub DeviceOSVersionCheck(OS as object)
     m.scene.isLoading = false
     stopLoadingSpinner()
 
-    show_dialog(`${tr("This Roku will stop receiving Jellyfin for Roku updates on October 1 due to Roku's new OS 15.1 minimum requirement. You can continue using the installed app, but it will never update unless you update your Roku OS. All releases will be blocked unless we make this change. We're forced to do this, so if you're affected, contact Roku. Don't yell at us. You can hide this popup by disabling the 'User Interface / General / Show Roku OS Version Popup' setting.")}`, [tr("OK")], 0)
+    warningContent = [
+        "<p>" + tr("This Roku will stop receiving Jellyfin for Roku updates on October 1, 2026 due to Roku's new OS 15.1 minimum requirement. You can continue using the installed app, but it will never update unless you update your Roku OS.") + "</p>",
+        "<p>" + tr("All releases will be blocked unless we make this change. We're forced to do this, so if you're affected, contact Roku. Don't yell at us.") + "</p>",
+        "<p>" + tr("You can hide this popup by disabling the 'User Interface / General / Show Roku OS Version Popup' setting.") + "</p>"
+    ]
+
+    m.global.sceneManager.callFunc("standardDialog", "Roku OS Version Warning", { data: warningContent })
 
     if isValid(overhang)
         overhang.visible = true

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -2,6 +2,7 @@ import "pkg:/source/enums/ImageType.bs"
 import "pkg:/source/utils/misc.bs"
 
 const minimumServerVersion = [10, 9, 0]
+const minimumRokuOSVersion = [15, 1, 0]
 
 function LoginFlow()
     'Collect Jellyfin server and user information
@@ -197,6 +198,11 @@ function LoginFlow()
         goto start_login
     end if
 
+    if isChainValid(m.global, "device.osversion")
+        OS = m.global.device.osversion
+        DeviceOSVersionCheck(OS)
+    end if
+
     LoadUserAbilities()
     m.global.sceneManager.callFunc("clearScenes")
 
@@ -218,6 +224,19 @@ sub ServerVersionCheck(systemVersion as string)
             LoginFlow()
         end if
     end if
+end sub
+
+sub DeviceOSVersionCheck(OS as object)
+    if not chainLookupReturn(m.global.session, "user.settings.`load.rokuospopup`", false) then return
+    if serverVersionMeetsMinimumRequirements(`${OS.major}.${OS.minor}.${OS.revision}`, minimumRokuOSVersion) then return
+
+    m.scene.isLoading = false
+    stopLoadingSpinner()
+
+    show_dialog(`${tr("This Roku will stop receiving Jellyfin for Roku updates on October 1 due to Roku's new OS 15.1 minimum requirement. You can continue using the installed app, but it will never update unless you update your Roku OS. All releases will be blocked unless we make this change. We're forced to do this, so if you're affected, contact Roku. Don't yell at us. You can hide this popup by disabling the 'User Interface / General / Show Roku OS Version Popup' setting.")}`, [tr("OK")], 0)
+
+    m.scene.isLoading = true
+    startLoadingSpinner()
 end sub
 
 sub SaveServerList()

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -230,11 +230,21 @@ sub DeviceOSVersionCheck(OS as object)
     if not chainLookupReturn(m.global.session, "user.settings.`load.rokuospopup`", false) then return
     if serverVersionMeetsMinimumRequirements(`${OS.major}.${OS.minor}.${OS.revision}`, minimumRokuOSVersion) then return
 
+    overhang = m.scene.findNode("overhang")
+    if isValid(overhang)
+        overhang.visible = false
+        overhang.isVisible = false
+    end if
+
     m.scene.isLoading = false
     stopLoadingSpinner()
 
     show_dialog(`${tr("This Roku will stop receiving Jellyfin for Roku updates on October 1 due to Roku's new OS 15.1 minimum requirement. You can continue using the installed app, but it will never update unless you update your Roku OS. All releases will be blocked unless we make this change. We're forced to do this, so if you're affected, contact Roku. Don't yell at us. You can hide this popup by disabling the 'User Interface / General / Show Roku OS Version Popup' setting.")}`, [tr("OK")], 0)
 
+    if isValid(overhang)
+        overhang.visible = true
+        overhang.isVisible = true
+    end if
     m.scene.isLoading = true
     startLoadingSpinner()
 end sub

--- a/source/static/whatsNew/3.2.4.json
+++ b/source/static/whatsNew/3.2.4.json
@@ -22,5 +22,9 @@
   {
     "description": "Add item count and filter chips to library screens",
     "author": "1hitsong"
+  },
+  {
+    "description": "Create warning popup for Rokus running OS versions older than 15.1",
+    "author": "1hitsong"
   }
 ]


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- On app start, checks if Roku OS is older than 15.1.0. If so, displays a warning popup telling the user they will stop receiving updates on October 1.
- Adds a new setting allowing users to disable the Roku OS warning popup if they so choose.

## Screenshot
<img width="1920" height="1080" alt="WIN_20260829_10_06_24_Pro" src="https://github.com/user-attachments/assets/472986c3-8f4c-49c1-b915-44b146904b84" />

