### PR TITLE
Add Premiere Date to OSD Item Details

### DIFF
--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -106,9 +106,9 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
         date.FromISO8601String(premiere)
         if not date.AsSeconds() = 0 and not isStringEqual(premiere, "1970-01-01T00:00:00.000000Z")
             if isStringEqual(chainLookupReturn(meta.json, "Type", ItemType.SERIES), ItemType.MOVIE)
-                dateDescriptor = "Released"
+                dateDescriptor = tr("Released")
             else
-                dateDescriptor = "Aired"
+                dateDescriptor = tr("Aired")
             end if
             video.premiere = tr(dateDescriptor) + ": " + date.AsDateString("short-month-no-weekday")
         end if

--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -98,6 +98,21 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
 
     video.overview = meta.json.overview
     video.people = meta.json.people
+    premiere = meta.json.premieredate
+    if isValid(premiere)
+        date = CreateObject("roDateTime")
+        date.FromSeconds(0)
+        ' Parse failures silently do not update the date so set to a known value and check if it changed
+        date.FromISO8601String(premiere)
+        if not date.AsSeconds() = 0 and not isStringEqual(premiere, "1970-01-01T00:00:00.000000Z")
+            if isStringEqual(chainLookupReturn(meta.json, "Type", ItemType.SERIES), ItemType.MOVIE)
+                dateDescriptor = "Released"
+            else
+                dateDescriptor = "Aired"
+            end if
+            video.premiere = tr(dateDescriptor) + ": " + date.AsDateString("short-month-no-weekday")
+        end if
+    end if
     if not isValid(video.overview) and isValid(meta.json.CurrentProgram)
         ' Live TV is under CurrentProgram.Overview
         video.overview = meta.json.CurrentProgram.overview

--- a/components/ItemGrid/LoadVideoContentTask.bs
+++ b/components/ItemGrid/LoadVideoContentTask.bs
@@ -99,7 +99,7 @@ sub LoadItems_AddVideoContent(video as object, mediaSourceId as dynamic, audio_s
     video.overview = meta.json.overview
     video.people = meta.json.people
     premiere = meta.json.premieredate
-    if isValid(premiere)
+    if isValidAndNotEmpty(premiere)
         date = CreateObject("roDateTime")
         date.FromSeconds(0)
         ' Parse failures silently do not update the date so set to a known value and check if it changed

--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -454,7 +454,15 @@ sub handleShowVideoOverviewPopupAction()
         end if
     end if
 
-    m.global.sceneManager.callFunc("standardDialog", overviewPopupTitle, { data: ["<p>" + m.overview + "</p>"] })
+    info = []
+    if isValid(m.premiere)
+        info.push("<header>" + m.premiere + "</header>")
+    end if
+    if isValid(m.overview)
+        info.push("<p>" + m.overview + "</p>")
+    end if
+
+    m.global.sceneManager.callFunc("standardDialog", overviewPopupTitle, { data: info })
 end sub
 
 sub handleShowCastCrewPopupAction()
@@ -766,6 +774,7 @@ sub onVideoContentLoaded()
     m.top.transcodeParams = videoContent[0].transcodeparams
     m.chapters = videoContent[0].chapters
     m.overview = videoContent[0].overview
+    m.premiere = videoContent[0].premiere
     m.castPeople = videoContent[0].people
     m.trickplay = videoContent[0].trickplay
     m.top.showID = videoContent[0].showID

--- a/source/static/whatsNew/3.2.4.json
+++ b/source/static/whatsNew/3.2.4.json
@@ -38,5 +38,9 @@
   {
     "description": "Add favorite toggle to audio mini player",
     "author": "VX-101"
+  },
+  {
+    "description": "Add premiere date to OSD item details",
+    "author": "michaelcresswell"
   }
 ]


### PR DESCRIPTION
## Changes
Displays the media premiere date, when available, in the details pop-up.