### PR TITLE
Fix ScrollingText width warning in HomeItem

### DIFF
--- a/components/home/HomeItem.bs
+++ b/components/home/HomeItem.bs
@@ -431,7 +431,7 @@ sub displayProgramInfo(itemData as object)
         realWidth = itemData.FHDItemWidth
         m.itemPoster.width = realWidth
         m.itemText.maxWidth = realWidth - 8
-        m.itemTextExtra.width = realWidth - 8
+        m.itemTextExtra.maxWidth = realWidth - 8
         m.backdrop.width = realWidth
     end if
 


### PR DESCRIPTION
## Changes
`itemTextExtra` in `HomeItem.xml` is a `ScrollingText` node, which doesn't have a `width` field — only `maxWidth`. In `displayProgramInfo()`, `HomeItem.bs` was setting `m.itemTextExtra.width` instead of `m.itemTextExtra.maxWidth`, which throws a "Tried to set nonexistent field" warning at runtime for Live TV program rows on Home. This one-line fix matches the pattern already used for `itemText` right above it.

## Issues
N/A
