### PR TITLE
Add shared Backdrop component behind Home, TV season and TV series screens

### DIFF
--- a/components/BaseScene.xml
+++ b/components/BaseScene.xml
@@ -2,6 +2,7 @@
 <component name="BaseScene" extends="Scene">
   <children>
     <Poster id="imageBackground" uri="" opacity=".2" width="1920" height="1080" />
+    <Backdrop id="backdrop" visible="false" />
     <Group id="content" />
     <JFOverhang id="overhang" />
     <AudioMiniPlayer id="audioMiniPlayer" translation="[0, 935]" />

--- a/components/data/Backdrop.bs
+++ b/components/data/Backdrop.bs
@@ -1,0 +1,283 @@
+import "pkg:/source/api/Image.bs"
+import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/utils/misc.bs"
+
+const BACKDROP_OPACITY = 0.3
+const DEFAULT_BACKDROP_OPACITY = 1.0
+
+sub init()
+    m.backdropA = m.top.findNode("backdropA")
+    m.backdropB = m.top.findNode("backdropB")
+    m.backdropBlack = m.top.findNode("backdropBlack")
+
+    m.backdropA.observeField("loadStatus", "onBackdropLoaded")
+    m.backdropB.observeField("loadStatus", "onBackdropLoaded")
+
+    m.crossfadeAnimation = m.top.findNode("crossfadeAnimation")
+    m.backdropAFade = m.top.findNode("backdropAFade")
+    m.backdropBFade = m.top.findNode("backdropBFade")
+
+    m.activeBackdrop = m.backdropA
+    m.inactiveBackdrop = m.backdropB
+
+    m.pendingBackdropTarget = invalid
+    m.targetOpacity = DEFAULT_BACKDROP_OPACITY
+    m.defaultBackdropUri = ""
+
+    m.activeBackdrop.opacity = DEFAULT_BACKDROP_OPACITY
+    m.backdropBlack.opacity = 1.0
+end sub
+
+sub setImage(backdropUri as string, targetOpacity = BACKDROP_OPACITY as float)
+    if backdropUri = ""
+        clear()
+        return
+    end if
+
+    ' Already showing this image
+    if backdropUri = m.activeBackdrop.uri and m.activeBackdrop.opacity > 0
+        return
+    end if
+
+    ' Image already loaded in the inactive poster
+    if backdropUri = m.inactiveBackdrop.uri and m.inactiveBackdrop.loadStatus = "ready"
+        startBackdropFade(m.activeBackdrop, m.inactiveBackdrop, targetOpacity)
+        return
+    end if
+
+    ' Load into the inactive poster
+    m.pendingBackdropTarget = m.inactiveBackdrop
+    m.inactiveBackdrop.uri = backdropUri
+    m.targetOpacity = targetOpacity
+end sub
+
+sub clear()
+    m.pendingBackdropTarget = invalid
+
+    if isStringEqual(m.crossfadeAnimation.state, "running")
+        m.crossfadeAnimation.control = "stop"
+    end if
+
+    m.backdropAFade.keyValue = [m.backdropA.opacity, 0.0]
+    m.backdropBFade.keyValue = [m.backdropB.opacity, 0.0]
+
+    m.crossfadeAnimation.control = "start"
+
+    m.backdropBlack.opacity = 0.0
+end sub
+
+sub onBackdropLoaded(event as object)
+    node = event.GetRoSGNode()
+
+    ' Ignore stale load events
+    if not isValid(m.pendingBackdropTarget) then return
+    if not node.isSameNode(m.pendingBackdropTarget) then return
+    if node.loadStatus <> "ready" then return
+
+    targetOpacity = isValid(m.targetOpacity) ? m.targetOpacity : BACKDROP_OPACITY
+    startBackdropFade(m.activeBackdrop, node, targetOpacity)
+end sub
+
+sub startBackdropFade(outgoing as object, incoming as object, targetOpacity = BACKDROP_OPACITY as float)
+    if isStringEqual(m.crossfadeAnimation.state, "running")
+        m.crossfadeAnimation.control = "stop"
+    end if
+
+    ' Freeze both interpolators at their current opacity.
+    m.backdropAFade.keyValue = [m.backdropA.opacity, m.backdropA.opacity]
+    m.backdropBFade.keyValue = [m.backdropB.opacity, m.backdropB.opacity]
+
+    outgoingInterpolator = outgoing.isSameNode(m.backdropA) ? m.backdropAFade : m.backdropBFade
+    incomingInterpolator = incoming.isSameNode(m.backdropA) ? m.backdropAFade : m.backdropBFade
+
+    outgoingInterpolator.keyValue = [outgoing.opacity, 0.0]
+    incomingInterpolator.keyValue = [incoming.opacity, targetOpacity]
+
+    m.backdropBlack.opacity = 1.0
+
+    m.activeBackdrop = incoming
+    m.inactiveBackdrop = outgoing
+
+    m.pendingBackdropTarget = invalid
+    m.targetOpacity = targetOpacity
+
+    m.crossfadeAnimation.control = "start"
+end sub
+
+function getBackdropUri(item as object) as string
+    if not isValid(item.json) then return ""
+
+    isHD = chainLookupReturn(m.global.device, "isHDDevice", false)
+    backdropWidth = isHD ? "1280" : "1920"
+    backdropHeight = isHD ? "720" : "1080"
+
+    if isValidAndNotEmpty(item.json.BackdropImageTags)
+        backdrop = ImageURL(item.id, ImageType.BACKDROP, {
+            maxHeight: backdropHeight,
+            maxWidth: backdropWidth,
+            quality: "90"
+        })
+
+        if backdrop <> "" then return backdrop
+    end if
+
+    if isStringEqual(item.type, "MusicAlbum") or isStringEqual(item.type, "Audio")
+
+        if isValidAndNotEmpty(item.json.AlbumArtists)
+            artistId = item.json.AlbumArtists[0].Id
+
+            if isValidAndNotEmpty(artistId)
+                backdrop = ImageURL(artistId, ImageType.BACKDROP, {
+                    maxHeight: backdropHeight,
+                    maxWidth: backdropWidth,
+                    quality: "90"
+                })
+
+                if backdrop <> "" then return backdrop
+            end if
+        end if
+
+        if isValidAndNotEmpty(item.json.ImageTags)
+            return ImageURL(item.id, ImageType.PRIMARY, {
+                maxHeight: backdropHeight,
+                maxWidth: backdropWidth,
+                quality: "90"
+            })
+        end if
+    end if
+
+    if isStringEqual(item.type, "season")
+        seriesId = item.json.LookupCI("SeriesId")
+
+        if isValidAndNotEmpty(seriesId)
+            return ImageURL(seriesId, ImageType.BACKDROP, {
+                maxHeight: backdropHeight,
+                maxWidth: backdropWidth,
+                quality: "90"
+            })
+        end if
+    end if
+
+    if isStringEqual(item.type, "Episode") and isValidAndNotEmpty(item.json.seriesid)
+        return ImageURL(item.json.seriesid, ImageType.BACKDROP, {
+            maxHeight: backdropHeight,
+            maxWidth: backdropWidth,
+            quality: "90"
+        })
+    end if
+
+    return ""
+end function
+
+sub setItem(item as object)
+    backdropUri = getBackdropUri(item)
+
+    if backdropUri = ""
+        backdropUri = m.defaultBackdropUri
+    end if
+
+    ' Item backdrops are shown as a translucent overlay, while the
+    ' configured default backdrop is shown fully opaque.
+    targetOpacity = BACKDROP_OPACITY
+
+    if backdropUri = m.defaultBackdropUri
+        targetOpacity = DEFAULT_BACKDROP_OPACITY
+    end if
+
+    ' white.png is used as a neutral base when the user has selected
+    ' a background color instead of an image. Apply the color to the
+    ' incoming poster because A and B alternate during crossfades.
+    if backdropUri = "pkg:/images/white.png"
+        userColor = chainLookupReturn(
+            m.global.session,
+            "user.settings.colorBackground",
+            ColorPalette.VIEWBACKGROUND
+        )
+
+        m.inactiveBackdrop.blendColor = userColor
+    else
+        m.inactiveBackdrop.blendColor = "0xFFFFFFFF"
+    end if
+
+    setImage(backdropUri, targetOpacity)
+end sub
+
+sub release()
+    m.pendingBackdropTarget = invalid
+
+    if isStringEqual(m.crossfadeAnimation.state, "running")
+        m.crossfadeAnimation.control = "stop"
+    end if
+
+    m.backdropA.opacity = 0
+    m.backdropB.opacity = 0
+
+    m.backdropA.uri = ""
+    m.backdropB.uri = ""
+
+    m.backdropBlack.opacity = 0
+end sub
+
+' Called right before pushing a playback screen: unloads poster
+' textures to free memory for the video decoder, but keeps the solid
+' black base layer so any frame before the new backdrop fades back in
+' reads as intentional black, not the default image or transparency.
+sub prepareForPlayback()
+    m.pendingBackdropTarget = invalid
+
+    if isStringEqual(m.crossfadeAnimation.state, "running")
+        m.crossfadeAnimation.control = "stop"
+    end if
+
+    m.backdropA.opacity = 0
+    m.backdropB.opacity = 0
+
+    m.backdropA.uri = ""
+    m.backdropB.uri = ""
+
+    m.backdropBlack.opacity = 1.0
+end sub
+
+' Main and Settings resolve the user's background image and pass the
+' final URI here. Keep it as the default so items without their own
+' backdrop can return to the user's selected background.
+sub setDefaultBackdrop(backdropUri as string)
+    if isStringEqual(m.crossfadeAnimation.state, "running")
+        m.crossfadeAnimation.control = "stop"
+    end if
+
+    if isValidAndNotEmpty(backdropUri)
+        m.defaultBackdropUri = backdropUri
+
+        m.activeBackdrop.blendColor = "0xFFFFFFFF"
+        m.activeBackdrop.uri = backdropUri
+        m.activeBackdrop.opacity = DEFAULT_BACKDROP_OPACITY
+
+        ' Reset the inactive poster's tint too, in case it was left
+        ' colored from a previous "no image" state.
+        m.inactiveBackdrop.blendColor = "0xFFFFFFFF"
+    else
+        ' No background image is configured. Use white.png as a neutral
+        ' base and tint both posters so the color remains correct when
+        ' the posters alternate during crossfades.
+        userColor = chainLookupReturn(
+            m.global.session,
+            "user.settings.colorBackground",
+            ColorPalette.VIEWBACKGROUND
+        )
+
+        m.defaultBackdropUri = "pkg:/images/white.png"
+
+        m.backdropA.blendColor = userColor
+        m.backdropB.blendColor = userColor
+
+        m.activeBackdrop.uri = m.defaultBackdropUri
+        m.activeBackdrop.opacity = DEFAULT_BACKDROP_OPACITY
+    end if
+
+    ' Reset the inactive poster so a previous image cannot reappear
+    ' during the next transition.
+    m.inactiveBackdrop.uri = ""
+    m.inactiveBackdrop.opacity = 0.0
+    m.pendingBackdropTarget = invalid
+end sub

--- a/components/data/Backdrop.xml
+++ b/components/data/Backdrop.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component name="Backdrop" extends="Group">
+    <children>
+        <Rectangle
+            id="backdropBlack"
+            width="1920"
+            height="1080"
+            color="0x000000FF"
+            opacity="0" />
+
+        <Poster
+            id="backdropA"
+            loadDisplayMode="scaleToZoom"
+            width="1920"
+            height="1080"
+            opacity="0" />
+
+        <Poster
+            id="backdropB"
+            loadDisplayMode="scaleToZoom"
+            width="1920"
+            height="1080"
+            opacity="0" />
+
+        <Animation
+            id="crossfadeAnimation"
+            duration=".5"
+            repeat="false"
+            easeFunction="linear">
+            <FloatFieldInterpolator
+                id="backdropAFade"
+                key="[0.0, 1.0]"
+                keyValue="[0.00, 0.00]"
+                fieldToInterp="backdropA.opacity" />
+
+            <FloatFieldInterpolator
+                id="backdropBFade"
+                key="[0.0, 1.0]"
+                keyValue="[0.00, 0.00]"
+                fieldToInterp="backdropB.opacity" />
+        </Animation>
+    </children>
+
+    <interface>
+        <function name="setItem" />
+        <function name="setImage" />
+        <function name="clear" />
+        <function name="release" />
+        <function name="setDefaultBackdrop" />
+        <function name="prepareForPlayback" />
+    </interface>
+</component>

--- a/components/data/SceneManager.bs
+++ b/components/data/SceneManager.bs
@@ -14,6 +14,9 @@ end sub
 ' Push a new group onto the stack, replacing the existing group on the screen
 sub pushScene(newGroup)
     currentGroup = m.groups.peek()
+
+    updateBackdropVisibility(newGroup)
+
     if isValid(newGroup)
         if isValid(currentGroup)
             'Search through group and store off last focused item
@@ -95,6 +98,8 @@ sub popScene()
     end if
 
     group = m.groups.peek()
+
+    updateBackdropVisibility(group)
 
     if isValid(group)
         registerOverhangData(group)
@@ -597,4 +602,57 @@ end sub
 ' Returns bool indicating if dialog is currently displayed
 function isDialogOpen() as boolean
     return isValid(m.scene.dialog)
+end function
+
+sub updateBackdropVisibility(group as object)
+    if not isValid(group) then return
+
+    scene = m.top.getScene()
+    if not isValid(scene) then return
+
+    backdrop = scene.findNode("backdrop")
+    if not isValid(backdrop) then return
+
+    shouldShow = false
+    for each screenType in getBackdropScreens()
+        if group.isSubType(screenType)
+            shouldShow = true
+            exit for
+        end if
+    end for
+
+    for each screenType in getMemoryReleaseScreens()
+        if group.isSubType(screenType)
+            backdrop.callFunc("prepareForPlayback")
+            exit for
+        end if
+    end for
+
+    backdrop.visible = shouldShow
+end sub
+
+' Screens that show the shared BaseScene-level Backdrop.
+' To enable the backdrop on a new screen: add its component name here,
+' and grab the node in that screen's init() via:
+'   scene = m.top.getScene()
+'   if isValid(scene) then m.backdrop = scene.findNode("backdrop")
+' MovieDetails intentionally excluded: it still manages its own
+' background poster (see setBackdropImage in MovieDetails.bs) and
+' hasn't been migrated to the shared Backdrop yet.
+function getBackdropScreens() as object
+    return [
+        "Home",
+        "TVSeasonDetails",
+        "TVSeriesDetails"
+    ]
+end function
+
+' Screens that should trigger releasing the backdrop poster textures
+' before they take over the screen (frees memory for the video decoder).
+' The backdrop reloads on its own next time setItem() is called, since
+' prepareForPlayback() clears activeBackdrop.uri.
+function getMemoryReleaseScreens() as object
+    return [
+        "VideoPlayer"
+    ]
 end function

--- a/components/home/Home.bs
+++ b/components/home/Home.bs
@@ -29,6 +29,11 @@ sub init()
     m.homeRows = m.top.findNode("homeRows")
     m.homeRows.focusBitmapBlendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 
+    scene = m.top.getScene()
+    if isValid(scene)
+        m.backdrop = scene.findNode("backdrop")
+    end if
+
     m.buttons = m.top.findNode("buttons")
     m.toggleButtonsAnimation = m.top.findNode("toggleButtonsAnimation")
     m.buttonsFade = m.top.findNode("buttonsFade")
@@ -380,4 +385,16 @@ sub onMetaDataLoaded()
 
     m.loadItemsTask1.itemId = focusedItem.LookupCI("id")
     m.loadItemsTask1.control = TaskControl.RUN
+end sub
+
+sub onHomeItemFocusedChange()
+    if not isValid(m.homeRows.rowItemFocused) then return
+
+    row = m.homeRows.rowItemFocused[0]
+    col = m.homeRows.rowItemFocused[1]
+
+    focusedItem = m.homeRows.content.getChild(row).getChild(col)
+    if not isValid(focusedItem) then return
+
+    m.backdrop.callFunc("setItem", focusedItem)
 end sub

--- a/components/home/Home.xml
+++ b/components/home/Home.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="Home" extends="JFScreen">
   <children>
-    <Poster id="backdrop" loadDisplayMode="scaleToZoom" width="1920" height="1200" />
-
     <LayoutGroup id="buttons" translation="[100, 100]" layoutDirection="horiz" horizAlignment="left" itemSpacings="[25]">
       <TextButton
         id="searchButton"
@@ -46,6 +44,7 @@
     <field id="playlistData" type="array" />
     <field id="selectedItem" alias="homeRows.selectedItem" />
     <field id="rowFocused" alias="homeRows.itemFocused" onchange="onRowFocusedChange" />
+    <field id="homeItemFocused" alias="homeRows.rowItemFocused" onchange="onHomeItemFocusedChange" />
     <field id="quickPlayNode" alias="homeRows.quickPlayNode" />
     <function name="refresh" />
     <function name="loadLibraries" />

--- a/components/settings/settings.bs
+++ b/components/settings/settings.bs
@@ -411,6 +411,12 @@ sub radioSettingChanged()
         end if
 
         scene.callFunc("setBackgroundImage", selectedBackgroundImage)
+
+        ' Update Backdrop immediately so the new background is used as the default.
+        backdrop = scene.findNode("backdrop")
+        if isValid(backdrop)
+            backdrop.callFunc("setDefaultBackdrop", selectedBackgroundImage)
+        end if
     end if
 
     if isStringEqual(selectedSetting.settingName, "playback.media.forceTranscode")

--- a/components/tvshows/TVSeasonDetails.bs
+++ b/components/tvshows/TVSeasonDetails.bs
@@ -72,6 +72,11 @@ sub init()
 
     m.isFirstRun = true
 
+    scene = m.top.getScene()
+    if isValid(scene)
+        m.backdrop = scene.findNode("backdrop")
+    end if
+
     setFontSizes()
 end sub
 
@@ -176,6 +181,8 @@ sub updateSeason()
         played: chainLookupReturn(m.top.seasonData.json, "UserData.Played", false),
         unplayedCount: chainLookupReturn(m.top.seasonData.json, "UserData.UnplayedItemCount", 0)
     }
+
+    m.backdrop.callFunc("setItem", m.top.seasonData)
 
     m.tvExtrasTask.seasonID = m.top.seasonData.json.Id
     m.tvExtrasTask.control = TaskControl.RUN
@@ -722,3 +729,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     return false
 end function
+
+sub OnScreenHidden()
+    m.backdrop.callFunc("release")
+end sub

--- a/components/tvshows/TVSeriesDetails.bs
+++ b/components/tvshows/TVSeriesDetails.bs
@@ -59,6 +59,11 @@ sub init()
     m.top.observeField("selectedButtonIndex", "onButtonSelectedChange")
     m.top.selectedButtonIndex = 0
 
+    scene = m.top.getScene()
+    if isValid(scene)
+        m.backdrop = scene.findNode("backdrop")
+    end if
+
     setFontSizes()
 end sub
 
@@ -177,6 +182,8 @@ sub itemContentChanged()
     ' Updates video metadata
     item = m.top.itemContent
     itemData = item.json
+
+    m.backdrop.callFunc("setItem", item)
 
     ' Post image may change. We need to again watch load status
     m.tvshowPoster.observeFieldscoped("loadStatus", "onPosterLoadStatusChanged")
@@ -586,4 +593,8 @@ end function
 
 sub checkGridItemCount()
     m.buttonGrp.blockDown = m.seasons.content.getChildCount() = 0
+end sub
+
+sub OnScreenHidden()
+    m.backdrop.callFunc("release")
 end sub

--- a/source/Main.bs
+++ b/source/Main.bs
@@ -360,6 +360,11 @@ sub setBackgroundImage()
     end if
 
     m.scene.callFunc("setBackgroundImage", selectedBackgroundImage)
+    ' Keep Backdrop in sync with the resolved background URI used by BaseScene.
+    backdrop = m.scene.findNode("backdrop")
+    if isValid(backdrop)
+        backdrop.callFunc("setDefaultBackdrop", selectedBackgroundImage)
+    end if
 end sub
 
 sub setOverhangColors()


### PR DESCRIPTION
## Changes
This adds a single, persistent `Backdrop` component living at the `BaseScene` level, shown behind Home, TV Season Details, and TV Series Details. Instead of each screen owning its own background poster, `SceneManager` toggles the shared instance's visibility on push/pop and each screen calls `setItem()` on focus/content change. The backdrop also supports the user's configured background image or color as a default, crossfading between it and the focused item's backdrop.

The goal is to bring the client closer to how the official apps behave on other platforms (web, Android TV), where a backdrop persists behind navigation instead of being tied to a single screen.

I want to flag something I noticed while working on this: there's an unused `<Poster id="backdrop">` node in `Home.xml` (removed in this PR) that was never wired up to anything. I don't know the history there, but its presence makes me wonder if something like this was tried before and didn't pan out for a reason I'm not aware of. I'm sharing this approach in that spirit — as something that seemed reasonable to me, not as a finished, definitive design. Happy to adjust, simplify, or drop it entirely based on feedback from people who know this codebase better.

This currently covers Home, TVSeasonDetails, and TVSeriesDetails. MovieDetails was intentionally left out for now since it already has its own background logic (`setBackdropImage` in `MovieDetails.bs`) — migrating it felt like a separate, riskier change I'd rather do in a follow-up if this approach is welcome.

## Issues
N/A